### PR TITLE
Do not autoconfigure normalizers 

### DIFF
--- a/config/services/normalizer.yaml
+++ b/config/services/normalizer.yaml
@@ -1,7 +1,7 @@
 services:
     _defaults:
         autowire: true
-        autoconfigure: true
+        autoconfigure: false
         public: false
 
     Pimcore\Bundle\GenericDataIndexBundle\Service\Normalizer\DataObjectNormalizer: ~


### PR DESCRIPTION
They should not apply to the default Symfony serializers automatically.
