### PR TITLE
Rename .raw subfields to .keyword

### DIFF
--- a/src/Service/SearchIndex/DataObject/FieldDefinitionAdapter/TextKeywordAdapter.php
+++ b/src/Service/SearchIndex/DataObject/FieldDefinitionAdapter/TextKeywordAdapter.php
@@ -29,7 +29,7 @@ final class TextKeywordAdapter extends AbstractAdapter
             'fields' => array_merge(
                 $searchAnalyzerAttributes[AttributeType::TEXT->value]['fields'] ?? [],
                 [
-                    'raw' => [
+                    'keyword' => [
                         'type' => AttributeType::KEYWORD->value,
                     ],
                 ]


### PR DESCRIPTION
As .keyword is the default name for this mechanism in OpenSearch