### PR TITLE
Fix missing data object enqueuing when inheritance and synchronous pr…

### DIFF
--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -115,6 +115,7 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
                     ->setMaxResults(1)
                     ->setParameter('id', $element->getId());
             }
+
             return null;
         }
 


### PR DESCRIPTION
The data object queue save subscriber works only for classes where inheritance is enabled without a problem. For classes where inheritance is disabled it will fail when the synchronous processing mode is disabled (which is the default).

This PR fixes this problem.