### PR TITLE
Permission conditions for search services need to be based on list permission instead of view permission

### DIFF
--- a/src/Model/Search/Modifier/Filter/Workspaces/WorkspaceQuery.php
+++ b/src/Model/Search/Modifier/Filter/Workspaces/WorkspaceQuery.php
@@ -33,7 +33,7 @@ final readonly class WorkspaceQuery implements SearchModifierInterface
 
     public function getPermission(): ?string
     {
-        return $this->permission ?? PermissionTypes::VIEW->value;
+        return $this->permission ?? PermissionTypes::LIST->value;
     }
 
     public function getWorkspaceType(): string

--- a/src/Service/Search/SearchService/AbstractSearchHelper.php
+++ b/src/Service/Search/SearchService/AbstractSearchHelper.php
@@ -50,7 +50,7 @@ abstract class AbstractSearchHelper implements SearchHelperInterface
             $search->addModifier(new WorkspaceQuery(
                 $workspaceType,
                 $user,
-                PermissionTypes::VIEW->value
+                PermissionTypes::LIST->value
             ));
         }
 

--- a/tests/Unit/Model/Modifier/Filter/Workspace/WorkspaceQueryTest.php
+++ b/tests/Unit/Model/Modifier/Filter/Workspace/WorkspaceQueryTest.php
@@ -29,11 +29,11 @@ final class WorkspaceQueryTest extends Unit
         $filter = new WorkspaceQuery(
             DataObjectWorkspace::WORKSPACE_TYPE,
             (new User())->setId(1),
-            PermissionTypes::VIEW->value
+            PermissionTypes::LIST->value
         );
 
         $this->assertSame('object', $filter->getWorkspaceType());
         $this->assertSame(1, $filter->getUser()->getId());
-        $this->assertSame('view', $filter->getPermission());
+        $this->assertSame('list', $filter->getPermission());
     }
 }

--- a/tests/Unit/Service/Workspace/QueryServiceTest.php
+++ b/tests/Unit/Service/Workspace/QueryServiceTest.php
@@ -77,7 +77,7 @@ final class QueryServiceTest extends Unit
         )->getWorkspaceQuery(
             AssetWorkspace::WORKSPACE_TYPE,
             $user,
-            PermissionTypes::VIEW->value
+            PermissionTypes::LIST->value
         );
 
         $this->assertEquals($this->getGenericWorkspaceQuery([$this, 'getExpectedWorkspaceQuery']), $query);
@@ -91,7 +91,7 @@ final class QueryServiceTest extends Unit
         $query = $this->getWorkspaceQueryService()->getWorkspaceQuery(
             AssetWorkspace::WORKSPACE_TYPE,
             $user,
-            PermissionTypes::VIEW->value
+            PermissionTypes::LIST->value
         );
 
         $this->assertEquals(new BoolQuery(), $query);
@@ -102,7 +102,7 @@ final class QueryServiceTest extends Unit
         $query = $this->getWorkspaceQueryService()->getWorkspaceQuery(
             AssetWorkspace::WORKSPACE_TYPE,
             null,
-            PermissionTypes::VIEW->value
+            PermissionTypes::LIST->value
         );
 
         $this->assertEquals($this->getGenericWorkspaceQuery([$this, 'getEmptyWorkspaceQuery']), $query);
@@ -123,7 +123,7 @@ final class QueryServiceTest extends Unit
         )->getWorkspaceQuery(
             AssetWorkspace::WORKSPACE_TYPE,
             null,
-            PermissionTypes::VIEW->value
+            PermissionTypes::LIST->value
         );
 
         $this->assertEquals($this->getGenericWorkspaceQuery([$this, 'getEmptyWorkspaceQuery']), $query);


### PR DESCRIPTION
## Changes in this pull request
Resolves #143 

## Additional info
After merging to 1.x [this](https://github.com/pimcore/generic-data-index-bundle/blob/1.x/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php#L304) needs to be adapted to setList

