### PR TITLE
Add services to search for all elements and their dependencies

### DIFF
--- a/.github/ci/files/config/services_test.yaml
+++ b/.github/ci/files/config/services_test.yaml
@@ -7,6 +7,7 @@ services:
   generic-data-index.test.service.asset-search-service: '@Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\AssetSearchServiceInterface'
   generic-data-index.test.service.data-object-search-service: '@Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\DataObjectSearchServiceInterface'
   generic-data-index.test.service.document-search-service: '@Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\DocumentSearchServiceInterface'
+  generic-data-index.test.service.element-search-service: '@Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchServiceInterface'
 
   test.calculatorservice:
     class: Pimcore\Tests\Support\Helper\DataType\Calculator

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This bundle can be extended and customized to fit your specific needs, for examp
 ## Features in a Nutshell
 - Based on OpenSearch
 - Centralized data index for multiple bundles (Portal Engine, Studio API/UI, etc.)
-- Indexing of all asset and data objects
+- Indexing of all documents, assets and data objects
 - Provides search services and models to search, filter and aggregate the data saved in the OpenSearch indices 
 
 ## Documentation Overview

--- a/config/pimcore/config.yaml
+++ b/config/pimcore/config.yaml
@@ -57,6 +57,8 @@ pimcore_generic_data_index:
       general:
         id:
           type: long
+        elementType:
+          type: keyword
         parentId:
           type: long
         creationDate:
@@ -113,6 +115,15 @@ pimcore_generic_data_index:
           type: boolean
         hasWorkflowWithPermissions:
           type: boolean
+        dependencies:
+          type: object
+          properties:
+            asset:
+              type: long
+            document:
+              type: long
+            object:
+              type: long
       document:
         published:
           type: boolean

--- a/config/services/dependency.yaml
+++ b/config/services/dependency.yaml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  Pimcore\Bundle\GenericDataIndexBundle\Service\Dependency\DependencyServiceInterface:
+    class: Pimcore\Bundle\GenericDataIndexBundle\Service\Dependency\DependencyService

--- a/config/services/search-index-adapter/open-search.yaml
+++ b/config/services/search-index-adapter/open-search.yaml
@@ -53,6 +53,9 @@ services:
     Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Workspace\QueryServiceInterface:
         class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Workspace\QueryService
 
+    Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Workspace\ElementWorkspacesQueryServiceInterface:
+        class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Workspace\ElementWorkspacesQueryService
+
     Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\QueryLanguage\PqlAdapterInterface:
         class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\PqlAdapter
 

--- a/config/services/search-index-adapter/open-search.yaml
+++ b/config/services/search-index-adapter/open-search.yaml
@@ -12,6 +12,11 @@ services:
         arguments:
             $openSearchClient: '@generic-data-index.opensearch-client'
 
+    Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface:
+        class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\IndexAliasService
+        arguments:
+            $openSearchClient: '@generic-data-index.opensearch-client'
+
     Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\SearchExecutionServiceInterface:
         class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\SearchExecutionService
         arguments:

--- a/config/services/search-index-adapter/open-search/modifiers/search-modifiers.yaml
+++ b/config/services/search-index-adapter/open-search/modifiers/search-modifiers.yaml
@@ -11,6 +11,7 @@ services:
   Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\Modifier\Filter\BasicFilters: ~
   Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\Modifier\Filter\AssetFilters: ~
   Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\Modifier\Filter\TreeFilters: ~
+  Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\Modifier\Filter\DependencyFilters: ~
 
   Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\Modifier\FullTextSearch\FullTextSearchHandlers: ~
 

--- a/config/services/search/index.yaml
+++ b/config/services/search/index.yaml
@@ -70,3 +70,6 @@ services:
             - [ ]
 
     Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler\DocumentIndexHandler: ~
+
+    Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\GlobalIndexAliasServiceInterface:
+        class: Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\GlobalIndexAliasService

--- a/config/services/search/search-services.yaml
+++ b/config/services/search/search-services.yaml
@@ -11,15 +11,16 @@ services:
       class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\DataObjectSearchService
 
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\DocumentSearchServiceInterface:
-    class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\DocumentSearchService
+      class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\DocumentSearchService
 
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchServiceInterface:
-    class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchService
+      class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchService
 
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\SearchHelper: ~
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\SearchHelper: ~
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\SearchHelper: ~
-  Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\SearchHelper: ~
+  Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchHelperInterface:
+      class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\SearchHelper
 
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface:
       class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProvider

--- a/config/services/search/search-services.yaml
+++ b/config/services/search/search-services.yaml
@@ -13,9 +13,13 @@ services:
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\DocumentSearchServiceInterface:
     class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\DocumentSearchService
 
+  Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchServiceInterface:
+    class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchService
+
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\SearchHelper: ~
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\SearchHelper: ~
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\SearchHelper: ~
+  Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\SearchHelper: ~
 
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface:
       class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProvider

--- a/doc/01_Installation/02_Upgrade.md
+++ b/doc/01_Installation/02_Upgrade.md
@@ -1,0 +1,8 @@
+# Upgrade Information
+
+Following steps are necessary during updating to newer versions.
+
+## Upgrade to 1.1.0
+- Execute the following command to reindex all elements to be able to use all new features:
+
+  ```bin/console generic-data-index:update:index```

--- a/doc/04_Searching_For_Data_In_Index/05_Search_Modifiers/README.md
+++ b/doc/04_Searching_For_Data_In_Index/05_Search_Modifiers/README.md
@@ -21,7 +21,8 @@ $search->addModifier(new ParentIdFilter(1))
 | [PathFilter](https://github.com/pimcore/generic-data-index-bundle/blob/1.x/src/Model/Search/Modifier/Filter/Tree/PathFilter.php)                     | Tree related filters      | Filter by path (depending on use case for all levels or direct children only and with or without the parent item included)                                                                                                                                                                                             |
 | [TagFilter](https://github.com/pimcore/generic-data-index-bundle/blob/1.x/src/Model/Search/Modifier/Filter/Tree/TagFilter.php)                       | Tree related filters      | Filter by tag IDs (it is also possible to include child tags)                                                                                                                                                                                                                                                          |
 | [AssetMetaDataFilter](https://github.com/pimcore/generic-data-index-bundle/blob/1.x/src/Model/Search/Modifier/Filter/Asset/AssetMetaDataFilter.php)  | Asset filters             | Filter by asset meta data attribute. The format of the `$data` which needs to be passed depends on the type of the meta data attribute and is handled by its [field definition adapter](https://github.com/pimcore/generic-data-index-bundle/tree/1.x/src/SearchIndexAdapter/OpenSearch/Asset/FieldDefinitionAdapter). |
-| [WorkspaceFilter](https://github.com/pimcore/generic-data-index-bundle/blob/1.x/src/Model/Search/Modifier/Filter/Workspaces/WorkspaceQuery.php)      | Workspace related filters | Filter based on the user workspaces and permissions (this query is added to the search by default)                                                                                                                                                                                                                     |
+| [WorkspaceQuery](https://github.com/pimcore/generic-data-index-bundle/blob/1.x/src/Model/Search/Modifier/Filter/Workspaces/WorkspaceQuery.php)      | Workspace related filters | Filter based on the user workspaces and permissions for a defined element type (this query is added to the asset/document/data object search by default)                                                                                                                                                               |
+| [ElementWorkspacesQuery](https://github.com/pimcore/generic-data-index-bundle/blob/1.x/src/Model/Search/Modifier/Filter/Workspaces/WorkspaceQuery.php)      | Workspace related filters | Filter based on the user workspaces and permissions respecting all element types (this query is added to the element search by default)                                                                                                                                                                                |
 
 
 
@@ -30,6 +31,14 @@ $search->addModifier(new ParentIdFilter(1))
 | Modifier                                                                                   | Modifier Category | Description                                                                                                                                           |
 |--------------------------------------------------------------------------------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [ElementKeySearch](https://github.com/pimcore/generic-data-index-bundle/blob/1.x/src/Model/Search/Modifier/FullTextSearch/ElementKeySearch.php) | Full text search  | Search by element key like in the studio UI.<br/><br/>* can be used for wildcard searches - for example "Car*" to find all items starting with "Car". |
+
+### Dependencies
+
+| Modifier                                                                                                                                       | Modifier Category | Description                                               |
+|------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|-----------------------------------------------------------|
+| [RequiresFilter](https://github.com/pimcore/generic-data-index-bundle/blob/1.x/src/Model/Search/Modifier/Filter/Dependency/RequiresFilter.php) | Dependencies      | Get all elements which the given element requires.        |
+| [RequiredByFilter](https://github.com/pimcore/generic-data-index-bundle/blob/1.x/src/Model/Search/Modifier/Filter/Dependency/RequiredByFilter.php)    | Dependencies      | Get all elements which are required by the given element. |
+
 
 ### Query Language
 

--- a/doc/04_Searching_For_Data_In_Index/README.md
+++ b/doc/04_Searching_For_Data_In_Index/README.md
@@ -33,10 +33,10 @@ public function searchAction(SearchProviderInterface $searchProvider, AssetSearc
 
 - Example: This example loads all data objects from the root folder (parent ID 1) with a specific class definition and orders them by their full path.
 ```php
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\DataObjectSearchServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\ParentIdFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\DataObjectSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 
 public function searchAction(SearchProviderInterface $searchProvider, DataObjectSearchServiceInterface $dataObjectSearchService)
 {
@@ -56,10 +56,10 @@ public function searchAction(SearchProviderInterface $searchProvider, DataObject
 
 - Example: This example loads all documents from the root folder (parent ID 1) and orders them by their full path.
 ```php
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\DocumentSearchServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\ParentIdFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\DocumentSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 
 public function searchAction(SearchProviderInterface $searchProvider, DocumentSearchServiceInterface $documentSearchService)
 {
@@ -81,10 +81,11 @@ The element search service can be used to search for assets, data objects and do
 
 - Example: This example loads all elements which are required by the asset ID 123 and orders them by their full path.
 ```php
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency\RequiredByFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 
 public function searchAction(SearchProviderInterface $searchProvider, ElementSearchServiceInterface $elementSearchService)
 {

--- a/doc/04_Searching_For_Data_In_Index/README.md
+++ b/doc/04_Searching_For_Data_In_Index/README.md
@@ -71,6 +71,8 @@ public function searchAction(SearchProviderInterface $searchProvider, DocumentSe
 
 The element search service can be used to search for assets, data objects and documents at the same time.
 
+**Hint:** the element search does not support the calculation of the `hasChildren` attributes. This means that the `hasChildren` attribute will always be `false` for all elements.
+
 - Example: This example loads all elements and orders them by their full path.
 ```php
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;

--- a/doc/04_Searching_For_Data_In_Index/README.md
+++ b/doc/04_Searching_For_Data_In_Index/README.md
@@ -14,6 +14,8 @@ The regular way to search for assets, data objects or documents is to use the re
 ```php
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\AssetSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\ParentIdFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
 
 public function searchAction(SearchProviderInterface $searchProvider, AssetSearchServiceInterface $asserSearchService)
 {
@@ -33,6 +35,8 @@ public function searchAction(SearchProviderInterface $searchProvider, AssetSearc
 ```php
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\DataObjectSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\ParentIdFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
 
 public function searchAction(SearchProviderInterface $searchProvider, DataObjectSearchServiceInterface $dataObjectSearchService)
 {
@@ -54,6 +58,8 @@ public function searchAction(SearchProviderInterface $searchProvider, DataObject
 ```php
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\DocumentSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\ParentIdFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
 
 public function searchAction(SearchProviderInterface $searchProvider, DocumentSearchServiceInterface $documentSearchService)
 {
@@ -73,14 +79,17 @@ The element search service can be used to search for assets, data objects and do
 
 **Hint:** the element search does not support the calculation of the `hasChildren` attributes. This means that the `hasChildren` attribute will always be `false` for all elements.
 
-- Example: This example loads all elements and orders them by their full path.
+- Example: This example loads all elements which are required by the asset ID 123 and orders them by their full path.
 ```php
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency\RequiredByFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
 
 public function searchAction(SearchProviderInterface $searchProvider, ElementSearchServiceInterface $elementSearchService)
 {
     $elementSearch = $searchProvider->createElementSearch()
+                ->addModifier(new RequiredByFilter(123, ElementType::ASSET))
                 ->addModifier(new OrderByFullPath())
                 ->setPageSize(50)
                 ->setPage(1);

--- a/doc/04_Searching_For_Data_In_Index/README.md
+++ b/doc/04_Searching_For_Data_In_Index/README.md
@@ -67,6 +67,26 @@ public function searchAction(SearchProviderInterface $searchProvider, DocumentSe
 }
 ```
 
+## Element Search Service
+
+The element search service can be used to search for assets, data objects and documents at the same time.
+
+- Example: This example loads all elements and orders them by their full path.
+```php
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchServiceInterface;
+
+public function searchAction(SearchProviderInterface $searchProvider, ElementSearchServiceInterface $elementSearchService)
+{
+    $elementSearch = $searchProvider->createElementSearch()
+                ->addModifier(new OrderByFullPath())
+                ->setPageSize(50)
+                ->setPage(1);
+
+    $searchResult = $elementSearchService->search($elementSearch);
+}
+```
+
 ## Search Modifiers
 
 To influence the data which gets fetched its possible to use so-called search modifiers.

--- a/doc/05_Extending_Data_Index/06_Extend_Search_Index.md
+++ b/doc/05_Extending_Data_Index/06_Extend_Search_Index.md
@@ -13,8 +13,10 @@ will find code examples below.
 This event can be used to store additional fields in the search index. Depending on if you would like to index additional
 data for assets or data objects use one of the following two events.
 
-* `Pimcore\Bundle\GenericDataIndexBundle\Event\Asset\UpdateIndexDataEvent`
-* `Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\UpdateIndexDataEvent`
+* `Pimcore\Bundle\GenericDataIndexBundle\Event\Asset\UpdateIndexDataEvent` (assets)
+* `Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\UpdateIndexDataEvent` (concrete data object classes)
+* `Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\UpdateFolderIndexDataEvent` (data object folders)
+* `Pimcore\Bundle\GenericDataIndexBundle\Event\Document\UpdateIndexDataEvent` (documents)
 
 If you take a look at the source of an indexed document within search index you will find a structure like this:
 
@@ -53,8 +55,10 @@ they are searchable through the full text search (depending on the mapping of th
 With this event it's possible to define the [mapping](https://opensearch.org/docs/latest/field-types/)
 of the additional custom fields. Again there are separate events for assets and data objects.
 
-* `Pimcore\Bundle\GenericDataIndexBundle\Event\Asset\ExtractMappingEvent`
-* `Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\ExtractMappingEvent`
+* `Pimcore\Bundle\GenericDataIndexBundle\Event\Asset\ExtractMappingEvent` (assets)
+* `Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\ExtractMappingEvent` (concrete data object classes)
+* `Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\ExtractFolderMappingEvent` (data object folders)
+* `Pimcore\Bundle\GenericDataIndexBundle\Event\Document\ExtractMappingEvent` (documents)
 
 
 ### Example 1: Assets

--- a/src/Command/Update/IndexUpdateCommand.php
+++ b/src/Command/Update/IndexUpdateCommand.php
@@ -121,6 +121,7 @@ final class IndexUpdateCommand extends AbstractCommand
 
         if ($input->getOption(self::UPDATE_GLOBAL_ALIASES_ONLY)) {
             $this->updateGlobalIndexAliases();
+
             return self::SUCCESS;
         }
 

--- a/src/Enum/SearchIndex/ElementType.php
+++ b/src/Enum/SearchIndex/ElementType.php
@@ -16,12 +16,25 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex;
 
-/**
- * @internal
- */
 enum ElementType: string
 {
     case ASSET = 'asset';
     case DATA_OBJECT = 'dataObject';
     case DOCUMENT = 'document';
+
+    public function getShortValue(): string
+    {
+        return match ($this) {
+            self::DATA_OBJECT => 'object',
+            default => $this->value,
+        };
+    }
+
+    public static function fromShortValue(string $shortValue): self
+    {
+        return match ($shortValue) {
+            'object' => self::DATA_OBJECT,
+            default => self::from($shortValue),
+        };
+    }
 }

--- a/src/Enum/SearchIndex/FieldCategory/SystemField.php
+++ b/src/Enum/SearchIndex/FieldCategory/SystemField.php
@@ -26,6 +26,7 @@ enum SystemField: string
     use FieldCategory\SystemField\SystemFieldTrait;
 
     case ID = 'id';
+    case ELEMENT_TYPE = 'elementType';
     case PARENT_ID = 'parentId';
     case CREATION_DATE = 'creationDate';
     case MODIFICATION_DATE = 'modificationDate';
@@ -47,6 +48,7 @@ enum SystemField: string
     case IS_LOCKED = 'isLocked';
     case HAS_WORKFLOW_WITH_PERMISSIONS = 'hasWorkflowWithPermissions';
     case FILE_SIZE = 'fileSize';
+    case DEPENDENCIES = 'dependencies';
 
     /**
      * Not persisted in search index but dynamically calculated

--- a/src/Enum/SearchIndex/IndexName.php
+++ b/src/Enum/SearchIndex/IndexName.php
@@ -23,6 +23,7 @@ enum IndexName: string
 {
     case ASSET = 'asset';
     case DATA_OBJECT = 'data-object';
+    case DATA_OBJECT_FOLDER = 'data-object-folder';
     case DOCUMENT = 'document';
     case ELEMENT_SEARCH = 'element-search';
 }

--- a/src/Event/DataObject/ExtractFolderMappingEvent.php
+++ b/src/Event/DataObject/ExtractFolderMappingEvent.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Fires before the mapping will be sent to the search server index.
+ * Can be used to add mappings for customized additional fields.
+ * You will find a description and example on how it works in the docs.
+ */
+final class ExtractFolderMappingEvent extends Event
+{
+
+    public function __construct(private array $customFieldsMapping)
+    {
+    }
+
+    public function getCustomFieldsMapping(): array
+    {
+        return $this->customFieldsMapping;
+    }
+
+    public function setCustomFieldsMapping(array $customFieldsMapping): self
+    {
+        $this->customFieldsMapping = $customFieldsMapping;
+
+        return $this;
+    }
+}

--- a/src/Event/DataObject/ExtractFolderMappingEvent.php
+++ b/src/Event/DataObject/ExtractFolderMappingEvent.php
@@ -25,7 +25,6 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class ExtractFolderMappingEvent extends Event
 {
-
     public function __construct(private array $customFieldsMapping)
     {
     }

--- a/src/Event/DataObject/UpdateFolderIndexDataEvent.php
+++ b/src/Event/DataObject/UpdateFolderIndexDataEvent.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Event\UpdateIndexDataEventInterface;
+use Pimcore\Model\DataObject\Folder;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Fires before the data for data objects gets updated in the search server index.
+ * Can be used to add additional customized attributes in the search index.
+ * You will find a description and example on how it works in the docs.
+ */
+final class UpdateFolderIndexDataEvent extends Event implements UpdateIndexDataEventInterface
+{
+    private Folder $dataObject;
+
+    private array $customFields;
+
+    public function __construct(Folder $dataObject, array $customFields)
+    {
+        $this->dataObject = $dataObject;
+        $this->customFields = $customFields;
+    }
+
+    public function getElement(): Folder
+    {
+        return $this->dataObject;
+    }
+
+    public function getCustomFields(): array
+    {
+        return $this->customFields;
+    }
+
+    public function setCustomFields(array $customFields): self
+    {
+        $this->customFields = $customFields;
+
+        return $this;
+    }
+}

--- a/src/Exception/ElementSearchException.php
+++ b/src/Exception/ElementSearchException.php
@@ -14,15 +14,13 @@ declare(strict_types=1);
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex;
+namespace Pimcore\Bundle\GenericDataIndexBundle\Exception;
+
+use RuntimeException;
 
 /**
  * @internal
  */
-enum IndexName: string
+final class ElementSearchException extends RuntimeException implements GenericDataIndexBundleExceptionInterface
 {
-    case ASSET = 'asset';
-    case DATA_OBJECT = 'data-object';
-    case DOCUMENT = 'document';
-    case ELEMENT_SEARCH = 'element-search';
 }

--- a/src/Model/Search/Asset/SearchResult/AssetSearchResultItem.php
+++ b/src/Model/Search/Asset/SearchResult/AssetSearchResultItem.php
@@ -16,9 +16,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Permission\AssetPermissions;
 
-class AssetSearchResultItem
+class AssetSearchResultItem implements ElementSearchResultItemInterface
 {
     private int $id;
 
@@ -58,6 +60,11 @@ class AssetSearchResultItem
     private array $searchIndexData;
 
     private AssetPermissions $permissions;
+
+    public function getElementType(): ElementType
+    {
+        return ElementType::ASSET;
+    }
 
     public function getId(): int
     {
@@ -172,7 +179,7 @@ class AssetSearchResultItem
         return $this->userModification;
     }
 
-    public function setUserModification(int $userModification): AssetSearchResultItem
+    public function setUserModification(?int $userModification): AssetSearchResultItem
     {
         $this->userModification = $userModification;
 

--- a/src/Model/Search/DataObject/SearchResult/DataObjectSearchResultItem.php
+++ b/src/Model/Search/DataObject/SearchResult/DataObjectSearchResultItem.php
@@ -16,9 +16,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\SearchResult;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Permission\DataObjectPermissions;
 
-class DataObjectSearchResultItem
+class DataObjectSearchResultItem implements ElementSearchResultItemInterface
 {
     private int $id;
 
@@ -55,6 +57,11 @@ class DataObjectSearchResultItem
     private array $searchIndexData;
 
     private DataObjectPermissions $permissions;
+
+    public function getElementType(): ElementType
+    {
+        return ElementType::DATA_OBJECT;
+    }
 
     public function getId(): int
     {

--- a/src/Model/Search/Document/SearchResult/DocumentSearchResultItem.php
+++ b/src/Model/Search/Document/SearchResult/DocumentSearchResultItem.php
@@ -16,9 +16,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Permission\DocumentPermissions;
 
-class DocumentSearchResultItem
+class DocumentSearchResultItem implements ElementSearchResultItemInterface
 {
     private int $id;
 
@@ -55,6 +57,11 @@ class DocumentSearchResultItem
     private array $searchIndexData;
 
     private DocumentPermissions $permissions;
+
+    public function getElementType(): ElementType
+    {
+        return ElementType::DOCUMENT;
+    }
 
     public function getId(): int
     {

--- a/src/Model/Search/Element/ElementSearch.php
+++ b/src/Model/Search/Element/ElementSearch.php
@@ -14,15 +14,10 @@ declare(strict_types=1);
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex;
+namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element;
 
-/**
- * @internal
- */
-enum IndexName: string
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\BaseSearch;
+
+final class ElementSearch extends BaseSearch
 {
-    case ASSET = 'asset';
-    case DATA_OBJECT = 'data-object';
-    case DOCUMENT = 'document';
-    case ELEMENT_SEARCH = 'element-search';
 }

--- a/src/Model/Search/Element/SearchResult/ElementSearchResult.php
+++ b/src/Model/Search/Element/SearchResult/ElementSearchResult.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\SearchResult;
 
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult\DocumentSearchResultItem;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Paging\PaginationInfo;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultAggregation;

--- a/src/Model/Search/Element/SearchResult/ElementSearchResult.php
+++ b/src/Model/Search/Element/SearchResult/ElementSearchResult.php
@@ -61,7 +61,7 @@ final readonly class ElementSearchResult
     public function getIds(): array
     {
         return array_map(
-            static fn (DocumentSearchResultItem $item) => $item->getId(),
+            static fn (ElementSearchResultItemInterface $item) => $item->getId(),
             $this->items
         );
     }

--- a/src/Model/Search/Element/SearchResult/ElementSearchResult.php
+++ b/src/Model/Search/Element/SearchResult/ElementSearchResult.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\SearchResult;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult\DocumentSearchResultItem;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Paging\PaginationInfo;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultAggregation;
+
+final readonly class ElementSearchResult
+{
+    public function __construct(
+        /** @var ElementSearchResultItemInterface[] */
+        private array $items,
+        private PaginationInfo $pagination,
+        /** @var SearchResultAggregation[] */
+        private array $aggregations = [],
+    ) {
+    }
+
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    public function getPagination(): PaginationInfo
+    {
+        return $this->pagination;
+    }
+
+    public function getAggregations(): array
+    {
+        return $this->aggregations;
+    }
+
+    public function getAggregation(string $aggregationName): ?SearchResultAggregation
+    {
+        foreach ($this->aggregations as $aggregation) {
+            if ($aggregation->getName() === $aggregationName) {
+                return $aggregation;
+            }
+        }
+
+        return null;
+    }
+
+    public function getIds(): array
+    {
+        return array_map(
+            static fn (DocumentSearchResultItem $item) => $item->getId(),
+            $this->items
+        );
+    }
+}

--- a/src/Model/Search/Interfaces/ElementSearchResultItemInterface.php
+++ b/src/Model/Search/Interfaces/ElementSearchResultItemInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
@@ -11,45 +24,59 @@ interface ElementSearchResultItemInterface
     public function getElementType(): ElementType;
 
     public function getId(): int;
+
     public function setId(int $id): ElementSearchResultItemInterface;
 
     public function getParentId(): int;
+
     public function setParentId(int $parentId): ElementSearchResultItemInterface;
 
     public function getType(): string;
+
     public function setType(string $type): ElementSearchResultItemInterface;
 
     public function getKey(): string;
+
     public function setKey(string $key): ElementSearchResultItemInterface;
 
     public function getPath(): string;
+
     public function setPath(string $path): ElementSearchResultItemInterface;
 
     public function getFullPath(): string;
+
     public function setFullPath(string $fullPath): ElementSearchResultItemInterface;
 
     public function getUserOwner(): int;
+
     public function setUserOwner(int $userOwner): ElementSearchResultItemInterface;
 
     public function getUserModification(): ?int;
+
     public function setUserModification(?int $userModification): ElementSearchResultItemInterface;
 
     public function getLocked(): ?string;
+
     public function setLocked(?string $locked): ElementSearchResultItemInterface;
 
     public function isLocked(): bool;
+
     public function setIsLocked(bool $isLocked): ElementSearchResultItemInterface;
 
     public function getCreationDate(): ?int;
+
     public function setCreationDate(?int $creationDate): ElementSearchResultItemInterface;
 
     public function getModificationDate(): ?int;
+
     public function setModificationDate(?int $modificationDate): ElementSearchResultItemInterface;
 
     public function isHasChildren(): bool;
+
     public function setHasChildren(bool $hasChildren): ElementSearchResultItemInterface;
 
     public function getSearchIndexData(): array;
+
     public function setSearchIndexData(array $searchIndexData): ElementSearchResultItemInterface;
 
     public function getPermissions(): BasePermissions;

--- a/src/Model/Search/Interfaces/ElementSearchResultItemInterface.php
+++ b/src/Model/Search/Interfaces/ElementSearchResultItemInterface.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
+use Pimcore\Bundle\GenericDataIndexBundle\Permission\BasePermissions;
+
+interface ElementSearchResultItemInterface
+{
+    public function getElementType(): ElementType;
+
+    public function getId(): int;
+    public function setId(int $id): ElementSearchResultItemInterface;
+
+    public function getParentId(): int;
+    public function setParentId(int $parentId): ElementSearchResultItemInterface;
+
+    public function getType(): string;
+    public function setType(string $type): ElementSearchResultItemInterface;
+
+    public function getKey(): string;
+    public function setKey(string $key): ElementSearchResultItemInterface;
+
+    public function getPath(): string;
+    public function setPath(string $path): ElementSearchResultItemInterface;
+
+    public function getFullPath(): string;
+    public function setFullPath(string $fullPath): ElementSearchResultItemInterface;
+
+    public function getUserOwner(): int;
+    public function setUserOwner(int $userOwner): ElementSearchResultItemInterface;
+
+    public function getUserModification(): ?int;
+    public function setUserModification(?int $userModification): ElementSearchResultItemInterface;
+
+    public function getLocked(): ?string;
+    public function setLocked(?string $locked): ElementSearchResultItemInterface;
+
+    public function isLocked(): bool;
+    public function setIsLocked(bool $isLocked): ElementSearchResultItemInterface;
+
+    public function getCreationDate(): ?int;
+    public function setCreationDate(?int $creationDate): ElementSearchResultItemInterface;
+
+    public function getModificationDate(): ?int;
+    public function setModificationDate(?int $modificationDate): ElementSearchResultItemInterface;
+
+    public function isHasChildren(): bool;
+    public function setHasChildren(bool $hasChildren): ElementSearchResultItemInterface;
+
+    public function getSearchIndexData(): array;
+    public function setSearchIndexData(array $searchIndexData): ElementSearchResultItemInterface;
+
+    public function getPermissions(): BasePermissions;
+}

--- a/src/Model/Search/Modifier/Filter/Dependency/RequiredByFilter.php
+++ b/src/Model/Search/Modifier/Filter/Dependency/RequiredByFilter.php
@@ -1,11 +1,23 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierInterface;
 
 final class RequiredByFilter implements SearchModifierInterface
 {
-
 }

--- a/src/Model/Search/Modifier/Filter/Dependency/RequiredByFilter.php
+++ b/src/Model/Search/Modifier/Filter/Dependency/RequiredByFilter.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierInterface;
+
+final class RequiredByFilter implements SearchModifierInterface
+{
+
+}

--- a/src/Model/Search/Modifier/Filter/Dependency/RequiredByFilter.php
+++ b/src/Model/Search/Modifier/Filter/Dependency/RequiredByFilter.php
@@ -16,8 +16,26 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierInterface;
+use Pimcore\ValueObject\Integer\PositiveInteger;
 
-final class RequiredByFilter implements SearchModifierInterface
+final readonly class RequiredByFilter implements SearchModifierInterface
 {
+    private PositiveInteger $id;
+
+    public function __construct(int $id, private ElementType $elementType)
+    {
+        $this->id = new PositiveInteger($id);
+    }
+
+    public function getId(): int
+    {
+        return $this->id->getValue();
+    }
+
+    public function getElementType(): ElementType
+    {
+        return $this->elementType;
+    }
 }

--- a/src/Model/Search/Modifier/Filter/Dependency/RequiresFilter.php
+++ b/src/Model/Search/Modifier/Filter/Dependency/RequiresFilter.php
@@ -1,11 +1,23 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierInterface;
 
 final class RequiresFilter implements SearchModifierInterface
 {
-
 }

--- a/src/Model/Search/Modifier/Filter/Dependency/RequiresFilter.php
+++ b/src/Model/Search/Modifier/Filter/Dependency/RequiresFilter.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierInterface;
+
+final class RequiresFilter implements SearchModifierInterface
+{
+
+}

--- a/src/Model/Search/Modifier/Filter/Dependency/RequiresFilter.php
+++ b/src/Model/Search/Modifier/Filter/Dependency/RequiresFilter.php
@@ -16,8 +16,26 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierInterface;
+use Pimcore\ValueObject\Integer\PositiveInteger;
 
-final class RequiresFilter implements SearchModifierInterface
+final readonly class RequiresFilter implements SearchModifierInterface
 {
+    private PositiveInteger $id;
+
+    public function __construct(int $id, private ElementType $elementType)
+    {
+        $this->id = new PositiveInteger($id);
+    }
+
+    public function getId(): int
+    {
+        return $this->id->getValue();
+    }
+
+    public function getElementType(): ElementType
+    {
+        return $this->elementType;
+    }
 }

--- a/src/Model/Search/Modifier/Filter/Workspaces/ElementWorkspacesQuery.php
+++ b/src/Model/Search/Modifier/Filter/Workspaces/ElementWorkspacesQuery.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Workspaces;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierInterface;
+use Pimcore\Model\User;
+
+final readonly class ElementWorkspacesQuery implements SearchModifierInterface
+{
+    public function __construct(
+        private ?User $user = null,
+        private ?string $permission = null
+    ) {
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function getPermission(): ?string
+    {
+        return $this->permission ?? PermissionTypes::LIST->value;
+    }
+}

--- a/src/SearchIndexAdapter/IndexAliasServiceInterface.php
+++ b/src/SearchIndexAdapter/IndexAliasServiceInterface.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter;
+
+/**
+ * @internal
+ */
+interface IndexAliasServiceInterface
+{
+    public function addAlias(string $aliasName, string $indexName): array;
+
+    public function existsAlias(string $aliasName, string $indexName = null): bool;
+
+    public function deleteAlias(string $indexName, string $aliasName): array;
+
+    public function getAllAliases(): array;
+
+    public function updateAliases(string $alias, array $indexNames, array $existingIndexNames = []): ?array;
+}

--- a/src/SearchIndexAdapter/IndexAliasServiceInterface.php
+++ b/src/SearchIndexAdapter/IndexAliasServiceInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter;
 
 /**

--- a/src/SearchIndexAdapter/OpenSearch/IndexAliasService.php
+++ b/src/SearchIndexAdapter/OpenSearch/IndexAliasService.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch;
+
+use OpenSearch\Client;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+
+/**
+ * @internal
+ */
+final class IndexAliasService implements IndexAliasServiceInterface
+{
+    public function __construct(
+        private readonly Client $openSearchClient,
+        private readonly SearchIndexConfigServiceInterface $searchIndexConfigService,
+    )
+    {
+    }
+
+    public function addAlias(string $aliasName, string $indexName): array
+    {
+        $params['body'] = [
+            'actions' => [
+                [
+                    'add' => [
+                        'index' => $indexName,
+                        'alias' => $aliasName,
+                    ],
+                ],
+            ],
+        ];
+        p_r($params);
+        return $this->openSearchClient->indices()->updateAliases($params);
+    }
+
+    public function existsAlias(string $aliasName, string $indexName = null): bool
+    {
+        return $this->openSearchClient->indices()->existsAlias([
+            'name' => $aliasName,
+            'index' => $indexName,
+            'client' => [
+                'ignore' => [404],
+            ],
+        ]);
+    }
+
+    public function getAllAliases(): array
+    {
+        return $this->openSearchClient->cat()->aliases([
+            'name' => $this->searchIndexConfigService->getIndexPrefix() . '*'
+        ]);
+    }
+
+    public function deleteAlias(string $indexName, string $aliasName): array
+    {
+        return $this->openSearchClient->indices()->deleteAlias([
+            'name' => $aliasName,
+            'index' => $indexName,
+        ]);
+    }
+
+    public function updateAliases(string $alias, array $indexNames, array $existingIndexNames = []): ?array
+    {
+        $toAdd = array_values(array_diff($indexNames, $existingIndexNames));
+        $toRemove = array_values(array_diff($existingIndexNames, $indexNames));
+
+        $actions = [];
+        foreach ($toAdd as $index) {
+            $actions[] = [
+                'add' => [
+                    'index' => $index,
+                    'alias' => $alias
+                ]
+            ];
+        }
+
+        foreach ($toRemove as $index) {
+            $actions[] = [
+                'remove' => [
+                    'index' => $index,
+                    'alias' => $alias
+                ]
+            ];
+        }
+
+        if (!empty($actions)) {
+            return $this->openSearchClient->indices()->updateAliases([
+                'body' => [
+                    'actions' => $actions
+                ]
+            ]);
+        }
+
+        return null;
+    }
+
+}

--- a/src/SearchIndexAdapter/OpenSearch/IndexAliasService.php
+++ b/src/SearchIndexAdapter/OpenSearch/IndexAliasService.php
@@ -43,7 +43,6 @@ final class IndexAliasService implements IndexAliasServiceInterface
                 ],
             ],
         ];
-        p_r($params);
 
         return $this->openSearchClient->indices()->updateAliases($params);
     }

--- a/src/SearchIndexAdapter/OpenSearch/IndexAliasService.php
+++ b/src/SearchIndexAdapter/OpenSearch/IndexAliasService.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch;
 
 use OpenSearch\Client;
@@ -15,8 +28,7 @@ final class IndexAliasService implements IndexAliasServiceInterface
     public function __construct(
         private readonly Client $openSearchClient,
         private readonly SearchIndexConfigServiceInterface $searchIndexConfigService,
-    )
-    {
+    ) {
     }
 
     public function addAlias(string $aliasName, string $indexName): array
@@ -32,6 +44,7 @@ final class IndexAliasService implements IndexAliasServiceInterface
             ],
         ];
         p_r($params);
+
         return $this->openSearchClient->indices()->updateAliases($params);
     }
 
@@ -49,7 +62,7 @@ final class IndexAliasService implements IndexAliasServiceInterface
     public function getAllAliases(): array
     {
         return $this->openSearchClient->cat()->aliases([
-            'name' => $this->searchIndexConfigService->getIndexPrefix() . '*'
+            'name' => $this->searchIndexConfigService->getIndexPrefix() . '*',
         ]);
     }
 
@@ -71,8 +84,8 @@ final class IndexAliasService implements IndexAliasServiceInterface
             $actions[] = [
                 'add' => [
                     'index' => $index,
-                    'alias' => $alias
-                ]
+                    'alias' => $alias,
+                ],
             ];
         }
 
@@ -80,20 +93,19 @@ final class IndexAliasService implements IndexAliasServiceInterface
             $actions[] = [
                 'remove' => [
                     'index' => $index,
-                    'alias' => $alias
-                ]
+                    'alias' => $alias,
+                ],
             ];
         }
 
         if (!empty($actions)) {
             return $this->openSearchClient->indices()->updateAliases([
                 'body' => [
-                    'actions' => $actions
-                ]
+                    'actions' => $actions,
+                ],
             ]);
         }
 
         return null;
     }
-
 }

--- a/src/SearchIndexAdapter/OpenSearch/OpenSearchService.php
+++ b/src/SearchIndexAdapter/OpenSearch/OpenSearchService.php
@@ -25,6 +25,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Debug\SearchInformati
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Search;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\SearchExecutionServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
@@ -46,6 +47,7 @@ final class OpenSearchService implements SearchIndexServiceInterface
         private readonly SearchIndexConfigServiceInterface $searchIndexConfigService,
         private readonly Client $openSearchClient,
         private readonly SearchExecutionServiceInterface $searchExecutionService,
+        private readonly IndexAliasServiceInterface $indexAliasService,
     ) {
     }
 
@@ -160,40 +162,14 @@ final class OpenSearchService implements SearchIndexServiceInterface
         return $this;
     }
 
-    public function addAlias(string $aliasName, string $indexName): OpenSearchService
+    public function addAlias(string $aliasName, string $indexName): array
     {
-        $params['body'] = [
-            'actions' => [
-                [
-                    'add' => [
-                        'index' => $indexName,
-                        'alias' => $aliasName,
-                    ],
-                ],
-            ],
-        ];
-        $this->openSearchClient->indices()->updateAliases($params);
-
-        return $this;
-    }
-
-    public function putAlias(string $aliasName, string $indexName): array
-    {
-        return $this->openSearchClient->indices()->putAlias([
-            'name' => $aliasName,
-            'index' => $indexName,
-        ]);
+        return $this->indexAliasService->addAlias($aliasName, $indexName);
     }
 
     public function existsAlias(string $aliasName, string $indexName = null): bool
     {
-        return $this->openSearchClient->indices()->existsAlias([
-            'name' => $aliasName,
-            'index' => $indexName,
-            'client' => [
-                'ignore' => [404],
-            ],
-        ]);
+        return $this->indexAliasService->existsAlias($aliasName, $indexName);
     }
 
     public function existsIndex(string $indexName): bool
@@ -208,10 +184,7 @@ final class OpenSearchService implements SearchIndexServiceInterface
 
     public function deleteAlias(string $indexName, string $aliasName): array
     {
-        return $this->openSearchClient->indices()->deleteAlias([
-            'name' => $aliasName,
-            'index' => $indexName,
-        ]);
+        return $this->indexAliasService->deleteAlias($indexName, $aliasName);
     }
 
     public function getDocument(string $index, int $id, bool $ignore404 = false): array

--- a/src/SearchIndexAdapter/OpenSearch/Search/Modifier/Filter/DependencyFilters.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/Modifier/Filter/DependencyFilters.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\Modifier\Filter;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Attribute\OpenSearch\AsSearchModifierHandler;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\OpenSearch\ConditionType;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Modifier\SearchModifierContextInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\BoolQuery;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\TermFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\TermsFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\ExcludeFoldersFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\IdFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\IdsFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency\RequiredByFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency\RequiresFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchServiceInterface;
+
+/**
+ * @internal
+ */
+final readonly class DependencyFilters
+{
+    public function __construct(
+        private ElementSearchServiceInterface $elementSearchService,
+    )
+    {
+    }
+
+    #[AsSearchModifierHandler]
+    public function handleRequiredByFilter(
+        RequiredByFilter $requiredByFilter,
+        SearchModifierContextInterface $context
+    ): void
+    {
+        $context->getSearch()->addQuery(
+            new TermFilter(
+                field: SystemField::DEPENDENCIES->getPath($requiredByFilter->getElementType()->getShortValue()),
+                term: $requiredByFilter->getId(),
+            )
+        );
+    }
+
+    #[AsSearchModifierHandler]
+    public function handleRequiresFilter(
+        RequiresFilter $requiresFilter,
+        SearchModifierContextInterface $context
+    ): void
+    {
+        $element = $this->elementSearchService->byId(
+            $requiresFilter->getElementType(),
+            $requiresFilter->getId(),
+            $context->getOriginalSearch()->getUser()
+        );
+
+        $dependencies = SystemField::DEPENDENCIES->getData($element?->getSearchIndexData() ?? []);
+
+        $boolQuery = new BoolQuery();
+        foreach ($dependencies ?? [] as $elementType => $ids) {
+            if (empty($ids)) {
+                continue;
+            }
+            $boolQuery->addCondition(
+                ConditionType::SHOULD->value,
+                (new BoolQuery([
+                    ConditionType::FILTER->value => [
+                        new TermsFilter(
+                            field: SystemField::ID->getPath(),
+                            terms: $ids,
+                        ),
+                        new TermFilter(
+                            field: SystemField::ELEMENT_TYPE->getPath(),
+                            term: ElementType::fromShortValue($elementType)->value,
+                        )
+                    ]
+                ]))->toArray(true)
+            );
+        }
+
+        if ($boolQuery->isEmpty()) {
+            // do not deliver any results if there are no dependencies
+            $context->getSearch()->addQuery(
+                new TermFilter(
+                    field: SystemField::ID->getPath(),
+                    term: 0,
+                )
+            );
+            return;
+        }
+
+        $context->getSearch()->addQuery(
+            new BoolQuery([
+                ConditionType::FILTER->value => $boolQuery->toArray(true),
+            ])
+        );
+    }
+}

--- a/src/SearchIndexAdapter/OpenSearch/Search/Modifier/Filter/DependencyFilters.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/Modifier/Filter/DependencyFilters.php
@@ -24,9 +24,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Modifier\SearchModifi
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\BoolQuery;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\TermFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\TermsFilter;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\ExcludeFoldersFilter;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\IdFilter;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\IdsFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency\RequiredByFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency\RequiresFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchServiceInterface;
@@ -38,16 +35,14 @@ final readonly class DependencyFilters
 {
     public function __construct(
         private ElementSearchServiceInterface $elementSearchService,
-    )
-    {
+    ) {
     }
 
     #[AsSearchModifierHandler]
     public function handleRequiredByFilter(
         RequiredByFilter $requiredByFilter,
         SearchModifierContextInterface $context
-    ): void
-    {
+    ): void {
         $context->getSearch()->addQuery(
             new TermFilter(
                 field: SystemField::DEPENDENCIES->getPath($requiredByFilter->getElementType()->getShortValue()),
@@ -60,8 +55,7 @@ final readonly class DependencyFilters
     public function handleRequiresFilter(
         RequiresFilter $requiresFilter,
         SearchModifierContextInterface $context
-    ): void
-    {
+    ): void {
         $element = $this->elementSearchService->byId(
             $requiresFilter->getElementType(),
             $requiresFilter->getId(),
@@ -86,8 +80,8 @@ final readonly class DependencyFilters
                         new TermFilter(
                             field: SystemField::ELEMENT_TYPE->getPath(),
                             term: ElementType::fromShortValue($elementType)->value,
-                        )
-                    ]
+                        ),
+                    ],
                 ]))->toArray(true)
             );
         }
@@ -100,6 +94,7 @@ final readonly class DependencyFilters
                     term: 0,
                 )
             );
+
             return;
         }
 

--- a/src/SearchIndexAdapter/OpenSearch/Search/Modifier/Filter/Workspace/WorkspaceQueryHandler.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/Modifier/Filter/Workspace/WorkspaceQueryHandler.php
@@ -18,7 +18,9 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Se
 
 use Pimcore\Bundle\GenericDataIndexBundle\Attribute\OpenSearch\AsSearchModifierHandler;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Modifier\SearchModifierContextInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Workspaces\ElementWorkspacesQuery;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Workspaces\WorkspaceQuery;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Workspace\ElementWorkspacesQueryServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Workspace\QueryServiceInterface;
 
 /**
@@ -27,7 +29,8 @@ use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Workspace\QueryServ
 final readonly class WorkspaceQueryHandler
 {
     public function __construct(
-        private QueryServiceInterface $workspaceQueryService
+        private QueryServiceInterface $workspaceQueryService,
+        private ElementWorkspacesQueryServiceInterface $elementWorkspacesQueryService
     ) {
     }
 
@@ -45,6 +48,23 @@ final readonly class WorkspaceQueryHandler
                 workspaceType: $workspaceQuery->getWorkspaceType(),
                 user: $workspaceQuery->getUser(),
                 permission: $workspaceQuery->getPermission()
+            )
+        );
+    }
+
+    #[AsSearchModifierHandler]
+    public function handleElementWorkspacesQuery(
+        ElementWorkspacesQuery $elementWorkspacesQuery,
+        SearchModifierContextInterface $context
+    ): void {
+        if (!$elementWorkspacesQuery->getUser()) {
+            return;
+        }
+
+        $context->getSearch()->addQuery(
+            $this->elementWorkspacesQueryService->getWorkspaceQuery(
+                user: $elementWorkspacesQuery->getUser(),
+                permission: $elementWorkspacesQuery->getPermission()
             )
         );
     }

--- a/src/SearchIndexAdapter/OpenSearch/Workspace/ElementWorkspacesQueryService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Workspace/ElementWorkspacesQueryService.php
@@ -65,7 +65,8 @@ final readonly class ElementWorkspacesQueryService implements ElementWorkspacesQ
             $workspaceQuery = new BoolQuery([
                 ConditionType::FILTER->value => [
                     new TermFilter(
-                        SystemField::ELEMENT_TYPE->getPath(), ElementType::fromShortValue($workspaceType)->value
+                        SystemField::ELEMENT_TYPE->getPath(),
+                        ElementType::fromShortValue($workspaceType)->value
                     ),
                     $this->workspaceQueryService->getWorkspaceQuery($workspaceType, $user, $permission),
                 ],

--- a/src/SearchIndexAdapter/OpenSearch/Workspace/ElementWorkspacesQueryService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Workspace/ElementWorkspacesQueryService.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Workspace;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\UserPermissionTypes;
@@ -54,8 +67,8 @@ final readonly class ElementWorkspacesQueryService implements ElementWorkspacesQ
                     new TermFilter(
                         SystemField::ELEMENT_TYPE->getPath(), ElementType::fromShortValue($workspaceType)->value
                     ),
-                    $this->workspaceQueryService->getWorkspaceQuery($workspaceType, $user, $permission)
-                ]
+                    $this->workspaceQueryService->getWorkspaceQuery($workspaceType, $user, $permission),
+                ],
             ]);
 
             $workspacesQuery->addCondition(ConditionType::SHOULD->value, $workspaceQuery->toArray(true));

--- a/src/SearchIndexAdapter/OpenSearch/Workspace/ElementWorkspacesQueryService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Workspace/ElementWorkspacesQueryService.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Workspace;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\UserPermissionTypes;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\OpenSearch\ConditionType;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\BoolQuery;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\TermFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\TermsFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Permission\Workspace\AssetWorkspace;
+use Pimcore\Bundle\GenericDataIndexBundle\Permission\Workspace\DataObjectWorkspace;
+use Pimcore\Bundle\GenericDataIndexBundle\Permission\Workspace\DocumentWorkspace;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Workspace\ElementWorkspacesQueryServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Workspace\QueryServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Permission\UserPermissionServiceInterface;
+use Pimcore\Model\User;
+
+/**
+ * @internal
+ */
+final readonly class ElementWorkspacesQueryService implements ElementWorkspacesQueryServiceInterface
+{
+    private const WORKSPACE_PERMISSION_MAPPING = [
+        AssetWorkspace::WORKSPACE_TYPE => UserPermissionTypes::ASSETS->value,
+        DataObjectWorkspace::WORKSPACE_TYPE => UserPermissionTypes::OBJECTS->value,
+        DocumentWorkspace::WORKSPACE_TYPE => UserPermissionTypes::DOCUMENTS->value,
+    ];
+
+    public function __construct(
+        private QueryServiceInterface $workspaceQueryService,
+        private UserPermissionServiceInterface $userPermissionService
+    ) {
+    }
+
+    public function getWorkspaceQuery(?User $user, string $permission): BoolQuery
+    {
+        $boolQuery = new BoolQuery();
+        if ($user?->isAdmin()) {
+            return $boolQuery;
+        }
+
+        $boolQuery->addCondition(
+            ConditionType::FILTER->value,
+            $this->getAllowedElementTypesFilter($user)->toArrayAsSubQuery()
+        );
+
+        $workspacesQuery = new BoolQuery();
+        foreach (array_keys(self::WORKSPACE_PERMISSION_MAPPING) as $workspaceType) {
+            $workspaceQuery = new BoolQuery([
+                ConditionType::FILTER->value => [
+                    new TermFilter(
+                        SystemField::ELEMENT_TYPE->getPath(), ElementType::fromShortValue($workspaceType)->value
+                    ),
+                    $this->workspaceQueryService->getWorkspaceQuery($workspaceType, $user, $permission)
+                ]
+            ]);
+
+            $workspacesQuery->addCondition(ConditionType::SHOULD->value, $workspaceQuery->toArray(true));
+        }
+
+        if (!$workspacesQuery->isEmpty()) {
+            $boolQuery->addCondition(ConditionType::MUST->value, $workspacesQuery->toArray(true));
+        }
+
+        return $boolQuery;
+    }
+
+    private function getAllowedElementTypesFilter(User $user): TermsFilter
+    {
+        $allowedElementTypes = [];
+        foreach (self::WORKSPACE_PERMISSION_MAPPING as $workspaceType => $permission) {
+            if ($this->userPermissionService->hasPermission($user, $permission)) {
+                $allowedElementTypes[] = ElementType::fromShortValue($workspaceType)->value;
+            }
+        }
+
+        return new TermsFilter(SystemField::ELEMENT_TYPE->getPath(), $allowedElementTypes);
+    }
+}

--- a/src/SearchIndexAdapter/SearchIndexServiceInterface.php
+++ b/src/SearchIndexAdapter/SearchIndexServiceInterface.php
@@ -38,9 +38,7 @@ interface SearchIndexServiceInterface
 
     public function createIndex(string $indexName, array $mappings = null): self;
 
-    public function addAlias(string $aliasName, string $indexName): self;
-
-    public function putAlias(string $aliasName, string $indexName): array;
+    public function addAlias(string $aliasName, string $indexName): array;
 
     public function existsAlias(string $aliasName, string $indexName = null): bool;
 

--- a/src/SearchIndexAdapter/Workspace/ElementWorkspacesQueryServiceInterface.php
+++ b/src/SearchIndexAdapter/Workspace/ElementWorkspacesQueryServiceInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Workspace;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\BoolQuery;
+use Pimcore\Model\User;
+
+/**
+ * @internal
+ */
+interface ElementWorkspacesQueryServiceInterface
+{
+    /**
+     * Returns a query which respects the workspace permissions for all element types.
+     */
+    public function getWorkspaceQuery(?User $user, string $permission): BoolQuery;
+}

--- a/src/SearchIndexAdapter/Workspace/ElementWorkspacesQueryServiceInterface.php
+++ b/src/SearchIndexAdapter/Workspace/ElementWorkspacesQueryServiceInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Workspace;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\BoolQuery;

--- a/src/Service/Dependency/DependencyService.php
+++ b/src/Service/Dependency/DependencyService.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Dependency;
 
 use Doctrine\DBAL\Connection;
@@ -14,8 +27,7 @@ final readonly class DependencyService implements DependencyServiceInterface
 {
     public function __construct(
         private Connection $connection,
-    )
-    {
+    ) {
     }
 
     public function getRequiresDependencies(ElementInterface $element): array
@@ -33,5 +45,4 @@ final readonly class DependencyService implements DependencyServiceInterface
 
         return $result;
     }
-
 }

--- a/src/Service/Dependency/DependencyService.php
+++ b/src/Service/Dependency/DependencyService.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Dependency;
+
+use Doctrine\DBAL\Connection;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Element\Service;
+
+/**
+ * @internal
+ */
+final readonly class DependencyService implements DependencyServiceInterface
+{
+    public function __construct(
+        private Connection $connection,
+    )
+    {
+    }
+
+    public function getRequiresDependencies(ElementInterface $element): array
+    {
+        $items = $this->connection->fetchAllAssociative(
+            'select * from dependencies where sourceid = ? and sourcetype = ?',
+            [$element->getId(), Service::getElementType($element)]
+        );
+
+        $result = [];
+        foreach ($items as $item) {
+            $result[$item['targettype']] ??= [];
+            $result[$item['targettype']][] = $item['targetid'];
+        }
+
+        return $result;
+    }
+
+}

--- a/src/Service/Dependency/DependencyServiceInterface.php
+++ b/src/Service/Dependency/DependencyServiceInterface.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Dependency;
+
+use Pimcore\Model\Element\ElementInterface;
+
+/**
+ * @internal
+ */
+interface DependencyServiceInterface
+{
+    public function getRequiresDependencies(ElementInterface $element): array;
+}

--- a/src/Service/Dependency/DependencyServiceInterface.php
+++ b/src/Service/Dependency/DependencyServiceInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Dependency;
 
 use Pimcore\Model\Element\ElementInterface;

--- a/src/Service/Permission/UserPermissionService.php
+++ b/src/Service/Permission/UserPermissionService.php
@@ -25,13 +25,16 @@ final class UserPermissionService implements UserPermissionServiceInterface
         User $user,
         string $userPermission
     ): void {
-        if (!$user->isAdmin() && !$this->hasPermission($user, $userPermission)) {
+        if (!$this->hasPermission($user, $userPermission)) {
             throw new UserPermissionException('User does not have permission to view assets');
         }
     }
 
     public function hasPermission(User $user, string $permission): bool
     {
+        if ($user->isAdmin()) {
+            return true;
+        }
         $permissions = $user->getPermissions();
         if (in_array($permission, $permissions)) {
             return true;

--- a/src/Service/Permission/UserPermissionService.php
+++ b/src/Service/Permission/UserPermissionService.php
@@ -26,7 +26,7 @@ final class UserPermissionService implements UserPermissionServiceInterface
         string $userPermission
     ): void {
         if (!$this->hasPermission($user, $userPermission)) {
-            throw new UserPermissionException('User does not have permission to view assets');
+            throw new UserPermissionException('User does not have permission to view ' . $userPermission);
         }
     }
 

--- a/src/Service/Search/SearchService/AbstractSearchHelper.php
+++ b/src/Service/Search/SearchService/AbstractSearchHelper.php
@@ -27,6 +27,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultH
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Modifier\SearchModifierServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Permission\UserPermissionServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Traits\SearchHelperTrait;
 use Pimcore\Model\User;
 
 /**
@@ -34,6 +35,8 @@ use Pimcore\Model\User;
  */
 abstract class AbstractSearchHelper implements SearchHelperInterface
 {
+    use SearchHelperTrait;
+
     public function __construct(
         private readonly SearchIndexServiceInterface $searchIndexService,
         private readonly SearchModifierServiceInterface $searchModifierService,
@@ -61,22 +64,6 @@ abstract class AbstractSearchHelper implements SearchHelperInterface
         }
 
         return $search;
-    }
-
-    public function performSearch(SearchInterface $search, string $indexName): SearchResult
-    {
-        $adapterSearch = $this->searchIndexService->createPaginatedSearch(
-            $search->getPage(),
-            $search->getPageSize(),
-            $search->isAggregationsOnly()
-        );
-
-        $search->addModifier(new OrderByPageNumber($indexName, $search));
-        $this->searchModifierService->applyModifiersFromSearch($search, $adapterSearch);
-
-        return $this
-            ->searchIndexService
-            ->search($adapterSearch, $indexName);
     }
 
     /**
@@ -111,20 +98,6 @@ abstract class AbstractSearchHelper implements SearchHelperInterface
         }
 
         return $childrenCounts;
-    }
-
-    public function hydrateSearchResultHits(
-        SearchResult $searchResult,
-        array $childrenCounts,
-        ?User $user = null
-    ): array {
-        $results = [];
-
-        foreach ($searchResult->getHits() as $hit) {
-            $results[] = $this->hydrateSearchResultHit($hit, $childrenCounts, $user);
-        }
-
-        return $results;
     }
 
     abstract public function hydrateSearchResultHit(

--- a/src/Service/Search/SearchService/AbstractSearchHelper.php
+++ b/src/Service/Search/SearchService/AbstractSearchHelper.php
@@ -17,11 +17,13 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Aggregation\Tree\ChildrenCountAggregation;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Workspaces\WorkspaceQuery;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\OrderByPageNumber;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultHit;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Modifier\SearchModifierServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Permission\UserPermissionServiceInterface;
@@ -111,9 +113,23 @@ abstract class AbstractSearchHelper implements SearchHelperInterface
         return $childrenCounts;
     }
 
-    abstract public function hydrateSearchResultHits(
+    public function hydrateSearchResultHits(
         SearchResult $searchResult,
         array $childrenCounts,
         ?User $user = null
-    ): array;
+    ): array {
+        $results = [];
+
+        foreach ($searchResult->getHits() as $hit) {
+            $results[] = $this->hydrateSearchResultHit($hit, $childrenCounts, $user);
+        }
+
+        return $results;
+    }
+
+    abstract public function hydrateSearchResultHit(
+        SearchResultHit $searchResultHit,
+        array $childrenCounts,
+        ?User $user = null
+    ): ElementSearchResultItemInterface;
 }

--- a/src/Service/Search/SearchService/AbstractSearchHelper.php
+++ b/src/Service/Search/SearchService/AbstractSearchHelper.php
@@ -21,7 +21,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchR
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Aggregation\Tree\ChildrenCountAggregation;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Workspaces\WorkspaceQuery;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\OrderByPageNumber;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultHit;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Modifier\SearchModifierServiceInterface;

--- a/src/Service/Search/SearchService/Asset/SearchHelper.php
+++ b/src/Service/Search/SearchService/Asset/SearchHelper.php
@@ -20,7 +20,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\AssetSearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultHit;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Modifier\SearchModifierServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
@@ -57,8 +56,7 @@ final class SearchHelper extends AbstractSearchHelper
         SearchResultHit $searchResultHit,
         array $childrenCounts,
         ?User $user = null
-    ): ElementSearchResultItemInterface
-    {
+    ): ElementSearchResultItemInterface {
         $source = $searchResultHit->getSource();
 
         $source[FieldCategory::SYSTEM_FIELDS->value][SystemField::HAS_CHILDREN->value] =
@@ -79,6 +77,4 @@ final class SearchHelper extends AbstractSearchHelper
 
         return $result;
     }
-
-
 }

--- a/src/Service/Search/SearchService/DataObject/DataObjectSearchService.php
+++ b/src/Service/Search/SearchService/DataObject/DataObjectSearchService.php
@@ -28,7 +28,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Permission\Workspace\DataObjectWorkspa
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Pagination\PaginationInfoServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\ElementTypeAdapter\DataObjectTypeAdapter;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler\DataObjectIndexHandler;
 use Pimcore\Bundle\StaticResolverBundle\Lib\Cache\RuntimeCacheResolverInterface;
 use Pimcore\Model\User;
 

--- a/src/Service/Search/SearchService/DataObject/DataObjectSearchService.php
+++ b/src/Service/Search/SearchService/DataObject/DataObjectSearchService.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Dat
 
 use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\UserPermissionTypes;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DataObjectSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\SearchResult\DataObjectSearchResult;
@@ -50,7 +51,7 @@ final readonly class DataObjectSearchService implements DataObjectSearchServiceI
      */
     public function search(DataObjectSearchInterface $dataObjectSearch): DataObjectSearchResult
     {
-        $indexContext = $dataObjectSearch->getClassDefinition() ?: DataObjectIndexHandler::DATA_OBJECT_INDEX_ALIAS;
+        $indexContext = $dataObjectSearch->getClassDefinition() ?: IndexName::DATA_OBJECT->value;
 
         $search = $this->searchHelper->addSearchRestrictions(
             search: $dataObjectSearch,

--- a/src/Service/Search/SearchService/DataObject/SearchHelper.php
+++ b/src/Service/Search/SearchService/DataObject/SearchHelper.php
@@ -19,7 +19,9 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Dat
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\SearchResult\DataObjectSearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultHit;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Modifier\SearchModifierServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Permission\PermissionServiceInterface;
@@ -51,35 +53,32 @@ final class SearchHelper extends AbstractSearchHelper
         );
     }
 
-    public function hydrateSearchResultHits(
-        SearchResult $searchResult,
+    public function hydrateSearchResultHit(
+        SearchResultHit $searchResultHit,
         array $childrenCounts,
         ?User $user = null
-    ): array {
-        $results = [];
+    ): ElementSearchResultItemInterface
+    {
+        $source = $searchResultHit->getSource();
 
-        foreach ($searchResult->getHits() as $hit) {
-            $source = $hit->getSource();
+        $source[FieldCategory::SYSTEM_FIELDS->value][SystemField::HAS_CHILDREN->value] =
+            ($childrenCounts[$searchResultHit->getId()] ?? 0) > 0;
 
-            $source[FieldCategory::SYSTEM_FIELDS->value][SystemField::HAS_CHILDREN->value] =
-                ($childrenCounts[$hit->getId()] ?? 0) > 0;
+        $result = $this->denormalizer->denormalize(
+            $source,
+            DataObjectSearchResult::class
+        );
 
-            $result = $this->denormalizer->denormalize(
-                $source,
-                DataObjectSearchResult::class
-            );
+        $this->runtimeCacheResolver->save($result, self::OBJECT_SEARCH . '_' . $result->getId());
+        $result->setPermissions(
+            $this->permissionService->getDataObjectPermissions(
+                $result,
+                $user
+            )
+        );
 
-            $this->runtimeCacheResolver->save($result, self::OBJECT_SEARCH . '_' . $result->getId());
-            $result->setPermissions(
-                $this->permissionService->getDataObjectPermissions(
-                    $result,
-                    $user
-                )
-            );
-
-            $results[] = $result;
-        }
-
-        return $results;
+        return $result;
     }
+
+
 }

--- a/src/Service/Search/SearchService/DataObject/SearchHelper.php
+++ b/src/Service/Search/SearchService/DataObject/SearchHelper.php
@@ -20,7 +20,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\SearchResult\DataObjectSearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultHit;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Modifier\SearchModifierServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
@@ -57,8 +56,7 @@ final class SearchHelper extends AbstractSearchHelper
         SearchResultHit $searchResultHit,
         array $childrenCounts,
         ?User $user = null
-    ): ElementSearchResultItemInterface
-    {
+    ): ElementSearchResultItemInterface {
         $source = $searchResultHit->getSource();
 
         $source[FieldCategory::SYSTEM_FIELDS->value][SystemField::HAS_CHILDREN->value] =
@@ -79,6 +77,4 @@ final class SearchHelper extends AbstractSearchHelper
 
         return $result;
     }
-
-
 }

--- a/src/Service/Search/SearchService/Document/SearchHelper.php
+++ b/src/Service/Search/SearchService/Document/SearchHelper.php
@@ -20,7 +20,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult\DocumentSearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultHit;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Modifier\SearchModifierServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
@@ -57,8 +56,7 @@ final class SearchHelper extends AbstractSearchHelper
         SearchResultHit $searchResultHit,
         array $childrenCounts,
         ?User $user = null
-    ): ElementSearchResultItemInterface
-    {
+    ): ElementSearchResultItemInterface {
         $source = $searchResultHit->getSource();
 
         $source[FieldCategory::SYSTEM_FIELDS->value][SystemField::HAS_CHILDREN->value] =
@@ -79,6 +77,4 @@ final class SearchHelper extends AbstractSearchHelper
 
         return $result;
     }
-
-
 }

--- a/src/Service/Search/SearchService/Document/SearchHelper.php
+++ b/src/Service/Search/SearchService/Document/SearchHelper.php
@@ -19,7 +19,9 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Doc
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult\DocumentSearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultHit;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Modifier\SearchModifierServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Permission\PermissionServiceInterface;
@@ -51,35 +53,32 @@ final class SearchHelper extends AbstractSearchHelper
         );
     }
 
-    public function hydrateSearchResultHits(
-        SearchResult $searchResult,
+    public function hydrateSearchResultHit(
+        SearchResultHit $searchResultHit,
         array $childrenCounts,
         ?User $user = null
-    ): array {
-        $results = [];
+    ): ElementSearchResultItemInterface
+    {
+        $source = $searchResultHit->getSource();
 
-        foreach ($searchResult->getHits() as $hit) {
-            $source = $hit->getSource();
+        $source[FieldCategory::SYSTEM_FIELDS->value][SystemField::HAS_CHILDREN->value] =
+            ($childrenCounts[$searchResultHit->getId()] ?? 0) > 0;
 
-            $source[FieldCategory::SYSTEM_FIELDS->value][SystemField::HAS_CHILDREN->value] =
-                ($childrenCounts[$hit->getId()] ?? 0) > 0;
+        $result = $this->denormalizer->denormalize(
+            $source,
+            DocumentSearchResult::class
+        );
 
-            $result = $this->denormalizer->denormalize(
-                $source,
-                DocumentSearchResult::class
-            );
+        $this->runtimeCacheResolver->save($result, self::DOCUMENT_SEARCH . '_' . $result->getId());
+        $result->setPermissions(
+            $this->permissionService->getDocumentPermissions(
+                $result,
+                $user
+            )
+        );
 
-            $this->runtimeCacheResolver->save($result, self::DOCUMENT_SEARCH . '_' . $result->getId());
-            $result->setPermissions(
-                $this->permissionService->getDocumentPermissions(
-                    $result,
-                    $user
-                )
-            );
-
-            $results[] = $result;
-        }
-
-        return $results;
+        return $result;
     }
+
+
 }

--- a/src/Service/Search/SearchService/Element/ElementSearchHelperInterface.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchHelperInterface.php
@@ -1,7 +1,19 @@
 <?php
 
-namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
 
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;

--- a/src/Service/Search/SearchService/Element/ElementSearchHelperInterface.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchHelperInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
+
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
+use Pimcore\Model\User;
+
+/**
+ * @internal
+ */
+interface ElementSearchHelperInterface
+{
+    public function addSearchRestrictions(SearchInterface $search): SearchInterface;
+
+    public function performSearch(SearchInterface $search, string $indexName): SearchResult;
+
+    public function hydrateSearchResultHits(SearchResult $searchResult, array $childrenCounts, ?User $user = null): array;
+}

--- a/src/Service/Search/SearchService/Element/ElementSearchHelperInterface.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchHelperInterface.php
@@ -28,5 +28,9 @@ interface ElementSearchHelperInterface
 
     public function performSearch(SearchInterface $search, string $indexName): SearchResult;
 
-    public function hydrateSearchResultHits(SearchResult $searchResult, array $childrenCounts, ?User $user = null): array;
+    public function hydrateSearchResultHits(
+        SearchResult $searchResult,
+        array $childrenCounts,
+        ?User $user = null
+    ): array;
 }

--- a/src/Service/Search/SearchService/Element/ElementSearchService.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchService.php
@@ -19,7 +19,6 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Ele
 use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\ElementSearchException;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\SearchResult\ElementSearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
@@ -90,6 +89,4 @@ final readonly class ElementSearchService implements ElementSearchServiceInterfa
         }
 
     }
-
-
 }

--- a/src/Service/Search/SearchService/Element/ElementSearchService.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchService.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
+
+use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\ElementSearchException;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\SearchResult\ElementSearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Pagination\PaginationInfoServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\GlobalIndexAliasServiceInterface;
+
+/**
+ * @internal
+ */
+final readonly class ElementSearchService implements ElementSearchServiceInterface
+{
+    public function __construct(
+        private GlobalIndexAliasServiceInterface $globalIndexAliasService,
+        private PaginationInfoServiceInterface $paginationInfoService,
+        private SearchHelper $searchHelper,
+        private SearchProviderInterface $searchProvider
+    ) {
+    }
+
+
+    public function search(SearchInterface $elementSearch): ElementSearchResult
+    {
+       /* $documentSearch = $this->searchHelper->addSearchRestrictions(
+            search: $elementSearch,
+            userPermission: UserPermissionTypes::DOCUMENTS->value,
+            workspaceType: DocumentWorkspace::WORKSPACE_TYPE
+        );*/
+
+        $searchResult = $this->searchHelper->performSearch(
+            search: $elementSearch,
+            indexName: $this->globalIndexAliasService->getElementSearchAliasName()
+        );
+
+        $childrenCounts = $this->searchHelper->getChildrenCounts(
+            searchResult: $searchResult,
+            indexName: $this->globalIndexAliasService->getElementSearchAliasName(),
+            search: $this->searchProvider->createElementSearch()
+        );
+
+        try {
+            return new ElementSearchResult(
+                items: $this->searchHelper->hydrateSearchResultHits(
+                    $searchResult,
+                    $childrenCounts,
+                    $elementSearch->getUser()
+                ),
+                pagination: $this->paginationInfoService->getPaginationInfoFromSearchResult(
+                    searchResult: $searchResult,
+                    page: $elementSearch->getPage(),
+                    pageSize: $elementSearch->getPageSize()
+                ),
+                aggregations:  $searchResult->getAggregations(),
+            );
+        } catch (Exception $e) {
+            throw new ElementSearchException($e->getMessage());
+        }
+    }
+}

--- a/src/Service/Search/SearchService/Element/ElementSearchService.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchService.php
@@ -37,7 +37,7 @@ final readonly class ElementSearchService implements ElementSearchServiceInterfa
     public function __construct(
         private GlobalIndexAliasServiceInterface $globalIndexAliasService,
         private PaginationInfoServiceInterface $paginationInfoService,
-        private SearchHelper $searchHelper,
+        private ElementSearchHelperInterface $searchHelper,
         private DataObjectSearchServiceInterface $dataObjectSearchService,
         private AssetSearchServiceInterface $assetSearchService,
         private DocumentSearchServiceInterface $documentSearchService,
@@ -46,15 +46,11 @@ final readonly class ElementSearchService implements ElementSearchServiceInterfa
 
     public function search(SearchInterface $elementSearch): ElementSearchResult
     {
-        /* $documentSearch = $this->searchHelper->addSearchRestrictions(
-             search: $elementSearch,
-             userPermission: UserPermissionTypes::DOCUMENTS->value,
-             workspaceType: DocumentWorkspace::WORKSPACE_TYPE
-         );*/
+        $elementSearch = $this->searchHelper->addSearchRestrictions($elementSearch);
 
         $searchResult = $this->searchHelper->performSearch(
-            search: $elementSearch,
-            indexName: $this->globalIndexAliasService->getElementSearchAliasName()
+            $elementSearch,
+            $this->globalIndexAliasService->getElementSearchAliasName()
         );
 
         try {
@@ -84,7 +80,7 @@ final readonly class ElementSearchService implements ElementSearchServiceInterfa
                 ElementType::ASSET => $this->assetSearchService->byId($id, $user),
                 ElementType::DATA_OBJECT => $this->dataObjectSearchService->byId($id, $user),
             };
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             throw new ElementSearchException($e->getMessage(), 0, $e);
         }
 

--- a/src/Service/Search/SearchService/Element/ElementSearchService.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchService.php
@@ -37,14 +37,13 @@ final readonly class ElementSearchService implements ElementSearchServiceInterfa
     ) {
     }
 
-
     public function search(SearchInterface $elementSearch): ElementSearchResult
     {
-       /* $documentSearch = $this->searchHelper->addSearchRestrictions(
-            search: $elementSearch,
-            userPermission: UserPermissionTypes::DOCUMENTS->value,
-            workspaceType: DocumentWorkspace::WORKSPACE_TYPE
-        );*/
+        /* $documentSearch = $this->searchHelper->addSearchRestrictions(
+             search: $elementSearch,
+             userPermission: UserPermissionTypes::DOCUMENTS->value,
+             workspaceType: DocumentWorkspace::WORKSPACE_TYPE
+         );*/
 
         $searchResult = $this->searchHelper->performSearch(
             search: $elementSearch,

--- a/src/Service/Search/SearchService/Element/ElementSearchService.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchService.php
@@ -21,7 +21,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Exception\ElementSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\SearchResult\ElementSearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Pagination\PaginationInfoServiceInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\GlobalIndexAliasServiceInterface;
 
 /**
@@ -33,7 +32,6 @@ final readonly class ElementSearchService implements ElementSearchServiceInterfa
         private GlobalIndexAliasServiceInterface $globalIndexAliasService,
         private PaginationInfoServiceInterface $paginationInfoService,
         private SearchHelper $searchHelper,
-        private SearchProviderInterface $searchProvider
     ) {
     }
 

--- a/src/Service/Search/SearchService/Element/ElementSearchService.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchService.php
@@ -50,17 +50,11 @@ final readonly class ElementSearchService implements ElementSearchServiceInterfa
             indexName: $this->globalIndexAliasService->getElementSearchAliasName()
         );
 
-        $childrenCounts = $this->searchHelper->getChildrenCounts(
-            searchResult: $searchResult,
-            indexName: $this->globalIndexAliasService->getElementSearchAliasName(),
-            search: $this->searchProvider->createElementSearch()
-        );
-
         try {
             return new ElementSearchResult(
                 items: $this->searchHelper->hydrateSearchResultHits(
                     $searchResult,
-                    $childrenCounts,
+                    [],
                     $elementSearch->getUser()
                 ),
                 pagination: $this->paginationInfoService->getPaginationInfoFromSearchResult(

--- a/src/Service/Search/SearchService/Element/ElementSearchServiceInterface.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\ElementSearchException;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\SearchResult\ElementSearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
+
+interface ElementSearchServiceInterface
+{
+    /**
+     * @throws ElementSearchException
+     */
+    public function search(SearchInterface $elementSearch): ElementSearchResult;
+}

--- a/src/Service/Search/SearchService/Element/ElementSearchServiceInterface.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchServiceInterface.php
@@ -16,9 +16,12 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\ElementSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\SearchResult\ElementSearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
+use Pimcore\Model\User;
 
 interface ElementSearchServiceInterface
 {
@@ -26,4 +29,9 @@ interface ElementSearchServiceInterface
      * @throws ElementSearchException
      */
     public function search(SearchInterface $elementSearch): ElementSearchResult;
+
+    /**
+     * @throws ElementSearchException
+     */
+    public function byId(ElementType $elementType, int $id, ?User $user = null): ?ElementSearchResultItemInterface;
 }

--- a/src/Service/Search/SearchService/Element/ElementSearchServiceInterface.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchServiceInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\ElementSearchException;

--- a/src/Service/Search/SearchService/Element/SearchHelper.php
+++ b/src/Service/Search/SearchService/Element/SearchHelper.php
@@ -52,8 +52,7 @@ final class SearchHelper extends AbstractSearchHelper
         SearchResultHit $searchResultHit,
         array $childrenCounts,
         ?User $user = null
-    ): ElementSearchResultItemInterface
-    {
+    ): ElementSearchResultItemInterface {
         $elementType = SystemField::ELEMENT_TYPE->getData($searchResultHit->getSource());
 
         return match($elementType) {

--- a/src/Service/Search/SearchService/Element/SearchHelper.php
+++ b/src/Service/Search/SearchService/Element/SearchHelper.php
@@ -23,8 +23,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Workspaces\ElementWorkspacesQuery;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\OrderByPageNumber;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultHit;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Modifier\SearchModifierServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
@@ -47,7 +45,8 @@ final readonly class SearchHelper implements ElementSearchHelperInterface
     ) {
     }
 
-    public function addSearchRestrictions(SearchInterface $search): SearchInterface {
+    public function addSearchRestrictions(SearchInterface $search): SearchInterface
+    {
         $user = $search->getUser();
         if (!$user) {
             return $search;

--- a/src/Service/Search/SearchService/SearchHelperInterface.php
+++ b/src/Service/Search/SearchService/SearchHelperInterface.php
@@ -16,8 +16,10 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultHit;
 use Pimcore\Model\User;
 
 /**
@@ -47,4 +49,10 @@ interface SearchHelperInterface
         array $childrenCounts,
         ?User $user = null
     ): array;
+
+    public function hydrateSearchResultHit(
+        SearchResultHit $searchResultHit,
+        array $childrenCounts,
+        ?User $user = null
+    ): ElementSearchResultItemInterface;
 }

--- a/src/Service/Search/SearchService/SearchProvider.php
+++ b/src/Service/Search/SearchService/SearchProvider.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\DocumentSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\ElementSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 
 /**
@@ -40,5 +41,10 @@ final class SearchProvider implements SearchProviderInterface
     public function createDocumentSearch(): SearchInterface
     {
         return new DocumentSearch();
+    }
+
+    public function createElementSearch(): SearchInterface
+    {
+        return new ElementSearch();
     }
 }

--- a/src/Service/Search/SearchService/SearchProviderInterface.php
+++ b/src/Service/Search/SearchService/SearchProviderInterface.php
@@ -26,4 +26,6 @@ interface SearchProviderInterface
     public function createDataObjectSearch(): DataObjectSearchInterface;
 
     public function createDocumentSearch(): SearchInterface;
+
+    public function createElementSearch(): SearchInterface;
 }

--- a/src/Service/Search/SearchService/Traits/SearchHelperTrait.php
+++ b/src/Service/Search/SearchService/Traits/SearchHelperTrait.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Traits;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\OrderByPageNumber;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
+use Pimcore\Model\User;
+
+/**
+ * @internal
+ */
+trait SearchHelperTrait
+{
+    public function performSearch(SearchInterface $search, string $indexName): SearchResult
+    {
+        $adapterSearch = $this->searchIndexService->createPaginatedSearch(
+            $search->getPage(),
+            $search->getPageSize(),
+            $search->isAggregationsOnly()
+        );
+
+        $search->addModifier(new OrderByPageNumber($indexName, $search));
+        $this->searchModifierService->applyModifiersFromSearch($search, $adapterSearch);
+
+        return $this
+            ->searchIndexService
+            ->search($adapterSearch, $indexName);
+    }
+
+    public function hydrateSearchResultHits(
+        SearchResult $searchResult,
+        array $childrenCounts,
+        ?User $user = null
+    ): array {
+        $results = [];
+
+        foreach ($searchResult->getHits() as $hit) {
+            $results[] = $this->hydrateSearchResultHit($hit, $childrenCounts, $user);
+        }
+
+        return $results;
+    }
+}

--- a/src/Service/Search/SearchService/Traits/SearchHelperTrait.php
+++ b/src/Service/Search/SearchService/Traits/SearchHelperTrait.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Traits;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;

--- a/src/Service/SearchIndex/GlobalIndexAliasService.php
+++ b/src/Service/SearchIndex/GlobalIndexAliasService.php
@@ -106,8 +106,7 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
         array &$aliasList,
         array $existingAliases,
         string $aliasShortName
-    ): GlobalIndexAliasService
-    {
+    ): GlobalIndexAliasService {
         $aliasList = array_merge(
             $aliasList,
             $this->filterByAliasName(

--- a/src/Service/SearchIndex/GlobalIndexAliasService.php
+++ b/src/Service/SearchIndex/GlobalIndexAliasService.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
+
+use Doctrine\DBAL\Connection;
+use OpenSearch\Client;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
+
+/**
+ * @internal
+ */
+final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceInterface
+{
+    public function __construct(
+        private Connection $connection,
+        private SearchIndexConfigServiceInterface $searchIndexConfigService,
+        private IndexAliasServiceInterface $indexAliasService,
+    )
+    {
+    }
+
+    public function updateDataObjectAlias(): void
+    {
+        $aliases = $this->indexAliasService->getAllAliases();
+
+        $existingClassAliases = $this->filterClassAliases($aliases);
+        $existingIndicesInDataObjectAlias = $this->filterByAliasName(
+            $aliases,
+            $this->getDataObjectAliasName()
+        );
+
+        $this->indexAliasService->updateAliases(
+            $this->getDataObjectAliasName(),
+            $this->getIndexNamesFromAliases($existingClassAliases),
+            $this->getIndexNamesFromAliases($existingIndicesInDataObjectAlias)
+        );
+
+    }
+
+    public function updateElementSearchAlias(): void
+    {
+        $aliases = $this->indexAliasService->getAllAliases();
+
+        $elementSearchIndexAliases = $this->filterClassAliases($aliases);
+
+        $elementSearchIndexAliases = array_merge(
+            $elementSearchIndexAliases,
+            $this->filterByAliasName($aliases, $this->searchIndexConfigService->getIndexName(IndexName::ASSET->value))
+        );
+
+        $elementSearchIndexAliases = array_merge(
+            $elementSearchIndexAliases,
+            $this->filterByAliasName($aliases, $this->searchIndexConfigService->getIndexName(IndexName::DOCUMENT->value))
+        );
+
+        $existingIndicesInElementSearchAlias =  $this->filterByAliasName(
+            $aliases,
+            $this->getElementSearchAliasName()
+        );
+
+        $this->indexAliasService->updateAliases(
+            $this->getElementSearchAliasName(),
+            $this->getIndexNamesFromAliases($elementSearchIndexAliases),
+            $this->getIndexNamesFromAliases($existingIndicesInElementSearchAlias)
+        );
+    }
+
+    public function addToDataObjectAlias(string $indexName): void
+    {
+        $this->indexAliasService->addAlias(
+            $this->getDataObjectAliasName(),
+            $indexName
+        );
+    }
+
+    public function addToElementSearchAlias(string $indexName): void
+    {
+        $this->indexAliasService->addAlias(
+            $this->getElementSearchAliasName(),
+            $indexName
+        );
+    }
+
+    public function getDataObjectAliasName(): string
+    {
+        return $this->searchIndexConfigService->getIndexName(IndexName::DATA_OBJECT->value);
+    }
+
+    public function getElementSearchAliasName(): string
+    {
+        return $this->searchIndexConfigService->getIndexName(IndexName::ELEMENT_SEARCH->value);
+    }
+
+    private function filterClassAliases(array $aliases): array
+    {
+        $classAliases = $this->getAliasesForAllClasses();
+
+        return array_values(array_filter($aliases, static function(array $alias) use ($classAliases) {
+            return in_array($alias['alias'], $classAliases, true);
+        }));
+    }
+
+    private function filterByAliasName(array $aliases, string $aliasName): array
+    {
+        return array_values(array_filter($aliases, static function(array $alias) use ($aliasName) {
+            return $alias['alias'] === $aliasName;
+        }));
+    }
+
+    private function getAliasesForAllClasses(): array
+    {
+        $classes = $this->connection->fetchFirstColumn('select name from classes');
+        return array_map(function(string $class) {
+            return $this->searchIndexConfigService->getIndexName($class);
+        }, $classes);
+    }
+
+    private function getIndexNamesFromAliases(array $aliases): array
+    {
+        return array_map(static function(array $alias) {
+            return $alias['index'];
+        }, $aliases);
+    }
+}

--- a/src/Service/SearchIndex/GlobalIndexAliasService.php
+++ b/src/Service/SearchIndex/GlobalIndexAliasService.php
@@ -1,10 +1,22 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
 
 use Doctrine\DBAL\Connection;
-use OpenSearch\Client;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
 
@@ -17,8 +29,7 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
         private Connection $connection,
         private SearchIndexConfigServiceInterface $searchIndexConfigService,
         private IndexAliasServiceInterface $indexAliasService,
-    )
-    {
+    ) {
     }
 
     public function updateDataObjectAlias(): void
@@ -97,14 +108,14 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
     {
         $classAliases = $this->getAliasesForAllClasses();
 
-        return array_values(array_filter($aliases, static function(array $alias) use ($classAliases) {
+        return array_values(array_filter($aliases, static function (array $alias) use ($classAliases) {
             return in_array($alias['alias'], $classAliases, true);
         }));
     }
 
     private function filterByAliasName(array $aliases, string $aliasName): array
     {
-        return array_values(array_filter($aliases, static function(array $alias) use ($aliasName) {
+        return array_values(array_filter($aliases, static function (array $alias) use ($aliasName) {
             return $alias['alias'] === $aliasName;
         }));
     }
@@ -112,14 +123,15 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
     private function getAliasesForAllClasses(): array
     {
         $classes = $this->connection->fetchFirstColumn('select name from classes');
-        return array_map(function(string $class) {
+
+        return array_map(function (string $class) {
             return $this->searchIndexConfigService->getIndexName($class);
         }, $classes);
     }
 
     private function getIndexNamesFromAliases(array $aliases): array
     {
-        return array_map(static function(array $alias) {
+        return array_map(static function (array $alias) {
             return $alias['index'];
         }, $aliases);
     }

--- a/src/Service/SearchIndex/GlobalIndexAliasService.php
+++ b/src/Service/SearchIndex/GlobalIndexAliasService.php
@@ -36,15 +36,20 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
     {
         $aliases = $this->indexAliasService->getAllAliases();
 
-        $existingClassAliases = $this->filterClassAliases($aliases);
+        $dataObjectIndexAliases = $this->filterClassAliases($aliases);
         $existingIndicesInDataObjectAlias = $this->filterByAliasName(
             $aliases,
             $this->getDataObjectAliasName()
         );
 
+        $dataObjectIndexAliases = array_merge(
+            $dataObjectIndexAliases,
+            $this->filterByAliasName($aliases, $this->searchIndexConfigService->getIndexName(IndexName::DATA_OBJECT_FOLDER->value))
+        );
+
         $this->indexAliasService->updateAliases(
             $this->getDataObjectAliasName(),
-            $this->getIndexNamesFromAliases($existingClassAliases),
+            $this->getIndexNamesFromAliases($dataObjectIndexAliases),
             $this->getIndexNamesFromAliases($existingIndicesInDataObjectAlias)
         );
 
@@ -64,6 +69,11 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
         $elementSearchIndexAliases = array_merge(
             $elementSearchIndexAliases,
             $this->filterByAliasName($aliases, $this->searchIndexConfigService->getIndexName(IndexName::DOCUMENT->value))
+        );
+
+        $elementSearchIndexAliases = array_merge(
+            $elementSearchIndexAliases,
+            $this->filterByAliasName($aliases, $this->searchIndexConfigService->getIndexName(IndexName::DATA_OBJECT_FOLDER->value))
         );
 
         $existingIndicesInElementSearchAlias =  $this->filterByAliasName(

--- a/src/Service/SearchIndex/GlobalIndexAliasService.php
+++ b/src/Service/SearchIndex/GlobalIndexAliasService.php
@@ -42,10 +42,8 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
             $this->getDataObjectAliasName()
         );
 
-        $dataObjectIndexAliases = array_merge(
-            $dataObjectIndexAliases,
-            $this->filterByAliasName($aliases, $this->searchIndexConfigService->getIndexName(IndexName::DATA_OBJECT_FOLDER->value))
-        );
+        $this
+            ->addAliasIfExists($existingIndicesInDataObjectAlias, $aliases, IndexName::DATA_OBJECT_FOLDER->value);
 
         $this->indexAliasService->updateAliases(
             $this->getDataObjectAliasName(),
@@ -61,20 +59,10 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
 
         $elementSearchIndexAliases = $this->filterClassAliases($aliases);
 
-        $elementSearchIndexAliases = array_merge(
-            $elementSearchIndexAliases,
-            $this->filterByAliasName($aliases, $this->searchIndexConfigService->getIndexName(IndexName::ASSET->value))
-        );
-
-        $elementSearchIndexAliases = array_merge(
-            $elementSearchIndexAliases,
-            $this->filterByAliasName($aliases, $this->searchIndexConfigService->getIndexName(IndexName::DOCUMENT->value))
-        );
-
-        $elementSearchIndexAliases = array_merge(
-            $elementSearchIndexAliases,
-            $this->filterByAliasName($aliases, $this->searchIndexConfigService->getIndexName(IndexName::DATA_OBJECT_FOLDER->value))
-        );
+        $this
+            ->addAliasIfExists($elementSearchIndexAliases, $aliases, IndexName::ASSET->value)
+            ->addAliasIfExists($elementSearchIndexAliases, $aliases, IndexName::DOCUMENT->value)
+            ->addAliasIfExists($elementSearchIndexAliases, $aliases, IndexName::DATA_OBJECT_FOLDER->value);
 
         $existingIndicesInElementSearchAlias =  $this->filterByAliasName(
             $aliases,
@@ -112,6 +100,23 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
     public function getElementSearchAliasName(): string
     {
         return $this->searchIndexConfigService->getIndexName(IndexName::ELEMENT_SEARCH->value);
+    }
+
+    private function addAliasIfExists(
+        array &$aliasList,
+        array $existingAliases,
+        string $aliasShortName
+    ): GlobalIndexAliasService
+    {
+        $aliasList = array_merge(
+            $aliasList,
+            $this->filterByAliasName(
+                $existingAliases,
+                $this->searchIndexConfigService->getIndexName($aliasShortName)
+            )
+        );
+
+        return $this;
     }
 
     private function filterClassAliases(array $aliases): array

--- a/src/Service/SearchIndex/GlobalIndexAliasServiceInterface.php
+++ b/src/Service/SearchIndex/GlobalIndexAliasServiceInterface.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
+
+/**
+ * @internal
+ */
+interface GlobalIndexAliasServiceInterface
+{
+    /**
+     * Adds or updates the alias for the data object index as a combination of all indices for all data object types.
+     */
+    public function updateDataObjectAlias(): void;
+
+    /**
+     * Adds or updates the alias for the global element search index as a combination of all indices for all element types.
+     */
+    public function updateElementSearchAlias(): void;
+
+    public function addToDataObjectAlias(string $indexName): void;
+
+    public function addToElementSearchAlias(string $indexName): void;
+
+    public function getDataObjectAliasName(): string;
+
+    public function getElementSearchAliasName(): string;
+}

--- a/src/Service/SearchIndex/GlobalIndexAliasServiceInterface.php
+++ b/src/Service/SearchIndex/GlobalIndexAliasServiceInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
 
 /**

--- a/src/Service/SearchIndex/IndexQueue/EnqueueService.php
+++ b/src/Service/SearchIndex/IndexQueue/EnqueueService.php
@@ -113,6 +113,30 @@ final readonly class EnqueueService implements EnqueueServiceInterface
         return $this;
     }
 
+    public function enqueueDataObjectFolders(): EnqueueServiceInterface
+    {
+        try {
+            $selectQuery = $this->indexQueueRepository->generateSelectQuery(
+                'objects',
+                [
+                    ElementType::DATA_OBJECT->value,
+                    IndexName::DATA_OBJECT_FOLDER->value,
+                    IndexQueueOperation::UPDATE->value,
+                    $this->timeService->getCurrentMillisecondTimestamp(),
+                    0,
+                ],
+            )->where('type = "folder"');
+            $this->indexQueueRepository->enqueueBySelectQuery($selectQuery);
+        } catch (Exception $e) {
+            throw new EnqueueElementsException(
+                $e->getMessage()
+            );
+        }
+
+        return $this;
+    }
+
+
     /**
      * @throws EnqueueElementsException
      */

--- a/src/Service/SearchIndex/IndexQueue/EnqueueService.php
+++ b/src/Service/SearchIndex/IndexQueue/EnqueueService.php
@@ -136,7 +136,6 @@ final readonly class EnqueueService implements EnqueueServiceInterface
         return $this;
     }
 
-
     /**
      * @throws EnqueueElementsException
      */

--- a/src/Service/SearchIndex/IndexQueue/EnqueueServiceInterface.php
+++ b/src/Service/SearchIndex/IndexQueue/EnqueueServiceInterface.php
@@ -40,6 +40,11 @@ interface EnqueueServiceInterface
     /**
      * @throws EnqueueElementsException
      */
+    public function enqueueDataObjectFolders(): self;
+
+    /**
+     * @throws EnqueueElementsException
+     */
     public function enqueueAssets(): self;
 
     /**

--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -24,7 +24,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\UpdateIndexDataEvent;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\UpdateIndexDataEventInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler\DataObjectIndexHandler;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Serializer\Normalizer\DataObjectNormalizer;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\ClassDefinition;

--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Exception;
 use InvalidArgumentException;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\UpdateIndexDataEvent;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\UpdateIndexDataEventInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler\DataObjectIndexHandler;
@@ -64,7 +65,7 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
     {
         return match (true) {
             $context instanceof ClassDefinition => $context->getName(),
-            $context === DataObjectIndexHandler::DATA_OBJECT_INDEX_ALIAS => $context,
+            $context === IndexName::DATA_OBJECT->value => $context,
             default => 'data_object_folders',
         };
     }

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -69,6 +69,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
             $this->getAliasIndexName($context),
             $mappingProperties ?: $this->extractMappingProperties($context)
         );
+        $this->createGlobalIndexAliases($context);
     }
 
     public function deleteIndex(mixed $context = null): void
@@ -131,5 +132,11 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
             ->createIndex($fullIndexName)
             ->addAlias($aliasName, $fullIndexName)
         ;
+
+        $this->createGlobalIndexAliases($context);
+    }
+
+    protected function createGlobalIndexAliases(mixed $context = null): void
+    {
     }
 }

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AssetIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AssetIndexHandler.php
@@ -18,19 +18,33 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService
 
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\Asset\ExtractMappingEvent;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\Asset\MetadataProviderServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\GlobalIndexAliasServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\ElementTypeAdapter\AssetTypeAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigService;
-use Symfony\Contracts\Service\Attribute\Required;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
  */
 final class AssetIndexHandler extends AbstractIndexHandler
 {
-    private AssetTypeAdapter $assetAdapter;
+    public function __construct(
+        SearchIndexServiceInterface $searchIndexService,
+        SearchIndexConfigServiceInterface $searchIndexConfigService,
+        EventDispatcherInterface $eventDispatcher,
+        IndexMappingServiceInterface $indexMappingService,
+        private readonly AssetTypeAdapter $assetAdapter,
+        private readonly MetadataProviderServiceInterface $metadataProviderService,
+        private readonly GlobalIndexAliasServiceInterface $globalIndexAliasService,
+    )
+    {
+        parent::__construct($searchIndexService, $searchIndexConfigService, $eventDispatcher, $indexMappingService);
+    }
 
-    private MetadataProviderServiceInterface $metadataProviderService;
 
     protected function extractMappingProperties(mixed $context = null): array
     {
@@ -59,17 +73,10 @@ final class AssetIndexHandler extends AbstractIndexHandler
         return $this->assetAdapter->getAliasIndexName($context);
     }
 
-    #[Required]
-    public function setAssetAdapter(AssetTypeAdapter $assetAdapter): void
+    protected function createGlobalIndexAliases(mixed $context = null): void
     {
-        $this->assetAdapter = $assetAdapter;
-    }
-
-    #[Required]
-    public function setMetadataProviderService(
-        MetadataProviderServiceInterface $metadataProviderService
-    ): void {
-        $this->metadataProviderService = $metadataProviderService;
+        $currentIndexFullName = $this->getCurrentFullIndexName($context);
+        $this->globalIndexAliasService->addToElementSearchAlias($currentIndexFullName);
     }
 
     private function fireEventAndGetCustomFieldsMapping($customFields): array

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AssetIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AssetIndexHandler.php
@@ -40,11 +40,9 @@ final class AssetIndexHandler extends AbstractIndexHandler
         private readonly AssetTypeAdapter $assetAdapter,
         private readonly MetadataProviderServiceInterface $metadataProviderService,
         private readonly GlobalIndexAliasServiceInterface $globalIndexAliasService,
-    )
-    {
+    ) {
         parent::__construct($searchIndexService, $searchIndexConfigService, $eventDispatcher, $indexMappingService);
     }
-
 
     protected function extractMappingProperties(mixed $context = null): array
     {

--- a/src/Service/SearchIndex/IndexService/IndexHandler/DataObjectIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/DataObjectIndexHandler.php
@@ -96,7 +96,7 @@ final class DataObjectIndexHandler extends AbstractIndexHandler
 
     private function fireEventAndGetCustomFieldsMapping(?ClassDefinition $classDefinition, array $customFields): array
     {
-        if($classDefinition === null) {
+        if ($classDefinition === null) {
             $extractMappingEvent = new ExtractFolderMappingEvent($customFields);
         } else {
             $extractMappingEvent = new ExtractMappingEvent($classDefinition, $customFields);

--- a/src/Service/SearchIndex/IndexService/IndexHandler/DataObjectIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/DataObjectIndexHandler.php
@@ -39,11 +39,9 @@ final class DataObjectIndexHandler extends AbstractIndexHandler
         IndexMappingServiceInterface $indexMappingService,
         private readonly DataObjectTypeAdapter $dataObjectTypeAdapter,
         private readonly GlobalIndexAliasServiceInterface $globalIndexAliasService,
-    )
-    {
+    ) {
         parent::__construct($searchIndexService, $searchIndexConfigService, $eventDispatcher, $indexMappingService);
     }
-
 
     protected function extractMappingProperties(mixed $context = null): array
     {
@@ -67,7 +65,6 @@ final class DataObjectIndexHandler extends AbstractIndexHandler
         $this->globalIndexAliasService->addToDataObjectAlias($currentIndexFullName);
         $this->globalIndexAliasService->addToElementSearchAlias($currentIndexFullName);
     }
-
 
     private function extractMappingByClassDefinition(ClassDefinition $classDefinition): array
     {

--- a/src/Service/SearchIndex/IndexService/IndexHandler/DocumentIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/DocumentIndexHandler.php
@@ -19,16 +19,31 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\StandardField\Document\DocumentStandardField;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\Asset\ExtractMappingEvent;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\GlobalIndexAliasServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\ElementTypeAdapter\DocumentTypeAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigService;
-use Symfony\Contracts\Service\Attribute\Required;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
  */
 final class DocumentIndexHandler extends AbstractIndexHandler
 {
-    private DocumentTypeAdapter $documentAdapter;
+    public function __construct(
+        SearchIndexServiceInterface $searchIndexService,
+        SearchIndexConfigServiceInterface $searchIndexConfigService,
+        EventDispatcherInterface $eventDispatcher,
+        IndexMappingServiceInterface $indexMappingService,
+        private readonly DocumentTypeAdapter $documentAdapter,
+        private readonly GlobalIndexAliasServiceInterface $globalIndexAliasService,
+    )
+    {
+        parent::__construct($searchIndexService, $searchIndexConfigService, $eventDispatcher, $indexMappingService);
+    }
+
 
     protected function extractMappingProperties(mixed $context = null): array
     {
@@ -52,10 +67,10 @@ final class DocumentIndexHandler extends AbstractIndexHandler
         return $this->documentAdapter->getAliasIndexName($context);
     }
 
-    #[Required]
-    public function setDocumentAdapter(DocumentTypeAdapter $documentAdapter): void
+    protected function createGlobalIndexAliases(mixed $context = null): void
     {
-        $this->documentAdapter = $documentAdapter;
+        $currentIndexFullName = $this->getCurrentFullIndexName($context);
+        $this->globalIndexAliasService->addToElementSearchAlias($currentIndexFullName);
     }
 
     private function getMappingForStandardFields(): array

--- a/src/Service/SearchIndex/IndexService/IndexHandler/DocumentIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/DocumentIndexHandler.php
@@ -39,11 +39,9 @@ final class DocumentIndexHandler extends AbstractIndexHandler
         IndexMappingServiceInterface $indexMappingService,
         private readonly DocumentTypeAdapter $documentAdapter,
         private readonly GlobalIndexAliasServiceInterface $globalIndexAliasService,
-    )
-    {
+    ) {
         parent::__construct($searchIndexService, $searchIndexConfigService, $eventDispatcher, $indexMappingService);
     }
-
 
     protected function extractMappingProperties(mixed $context = null): array
     {

--- a/src/Service/SearchIndex/IndexService/IndexService.php
+++ b/src/Service/SearchIndex/IndexService/IndexService.php
@@ -163,7 +163,7 @@ final class IndexService implements IndexServiceInterface
                 FieldCategory::CUSTOM_FIELDS->value => $customFields,
             ];
         } catch (Exception|ExceptionInterface $e) {
-            throw new IndexDataException($e->getMessage());
+            throw new IndexDataException($e->getMessage(), 0, $e);
         }
 
     }

--- a/src/Service/SearchIndex/IndexUpdateService.php
+++ b/src/Service/SearchIndex/IndexUpdateService.php
@@ -48,6 +48,7 @@ final class IndexUpdateService implements IndexUpdateServiceInterface
     public function updateAll(): IndexUpdateService
     {
         $this
+            ->updateDataObjectFolders()
             ->updateClassDefinitions()
             ->updateAssets()
             ->updateDocuments();
@@ -97,9 +98,29 @@ final class IndexUpdateService implements IndexUpdateServiceInterface
             ->enqueueService
             ->enqueueByClassDefinition($classDefinition);
 
-        //@todo $this
-        //    ->dataObjectIndexService
-        //    ->addClassDefinitionToAlias($classDefinition, ElasticSearchAlias::CLASS_DEFINITIONS);
+        return $this;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function updateDataObjectFolders(): IndexUpdateService
+    {
+        if ($this->reCreateIndex) {
+            $this->dataObjectIndexHandler
+                ->deleteIndex();
+        }
+
+        $this
+            ->dataObjectIndexHandler
+            ->updateMapping(
+                forceCreateIndex: $this->reCreateIndex
+            );
+
+        //add dataObjects to update queue
+        $this
+            ->enqueueService
+            ->enqueueDataObjectFolders();
 
         return $this;
     }

--- a/src/Service/Serializer/Denormalizer/Search/AssetSearchResultDenormalizer.php
+++ b/src/Service/Serializer/Denormalizer/Search/AssetSearchResultDenormalizer.php
@@ -60,7 +60,7 @@ readonly class AssetSearchResultDenormalizer implements DenormalizerInterface
             ->setFullPath(SystemField::FULL_PATH->getData($data))
             ->setMimeType(SystemField::MIME_TYPE->getData($data))
             ->setFileSize(SystemField::FILE_SIZE->getData($data))
-            ->setUserOwner(SystemField::USER_OWNER->getData($data))
+            ->setUserOwner(SystemField::USER_OWNER->getData($data) ?? 0)
             ->setUserModification(SystemField::USER_MODIFICATION->getData($data))
             ->setLocked(SystemField::LOCKED->getData($data))
             ->setIsLocked(SystemField::IS_LOCKED->getData($data))

--- a/src/Service/Serializer/Denormalizer/Search/DataObjectSearchResultDenormalizer.php
+++ b/src/Service/Serializer/Denormalizer/Search/DataObjectSearchResultDenormalizer.php
@@ -48,12 +48,14 @@ readonly class DataObjectSearchResultDenormalizer implements DenormalizerInterfa
             $searchResultItem = new DataObjectSearchResultItem();
         }
 
+        $published = SystemField::TYPE->getData($data) === 'folder' || SystemField::PUBLISHED->getData($data);
+
         return $searchResultItem
             ->setId(SystemField::ID->getData($data))
             ->setClassName(SystemField::CLASS_NAME->getData($data) ?? '')
             ->setParentId(SystemField::PARENT_ID->getData($data))
             ->setType(SystemField::TYPE->getData($data))
-            ->setPublished(SystemField::PUBLISHED->getData($data))
+            ->setPublished($published)
             ->setKey(SystemField::KEY->getData($data))
             ->setPath(SystemField::PATH->getData($data))
             ->setFullPath(SystemField::FULL_PATH->getData($data))

--- a/src/Service/Serializer/Denormalizer/Search/DataObjectSearchResultDenormalizer.php
+++ b/src/Service/Serializer/Denormalizer/Search/DataObjectSearchResultDenormalizer.php
@@ -57,7 +57,7 @@ readonly class DataObjectSearchResultDenormalizer implements DenormalizerInterfa
             ->setKey(SystemField::KEY->getData($data))
             ->setPath(SystemField::PATH->getData($data))
             ->setFullPath(SystemField::FULL_PATH->getData($data))
-            ->setUserOwner(SystemField::USER_OWNER->getData($data))
+            ->setUserOwner(SystemField::USER_OWNER->getData($data) ?? 0)
             ->setUserModification(SystemField::USER_MODIFICATION->getData($data))
             ->setLocked(SystemField::LOCKED->getData($data))
             ->setIsLocked(SystemField::IS_LOCKED->getData($data))

--- a/src/Service/Serializer/Denormalizer/Search/DataObjectSearchResultDenormalizer.php
+++ b/src/Service/Serializer/Denormalizer/Search/DataObjectSearchResultDenormalizer.php
@@ -50,7 +50,7 @@ readonly class DataObjectSearchResultDenormalizer implements DenormalizerInterfa
 
         return $searchResultItem
             ->setId(SystemField::ID->getData($data))
-            ->setClassName(SystemField::CLASS_NAME->getData($data))
+            ->setClassName(SystemField::CLASS_NAME->getData($data) ?? '')
             ->setParentId(SystemField::PARENT_ID->getData($data))
             ->setType(SystemField::TYPE->getData($data))
             ->setPublished(SystemField::PUBLISHED->getData($data))

--- a/src/Service/Serializer/Denormalizer/Search/DocumentSearchResultDenormalizer.php
+++ b/src/Service/Serializer/Denormalizer/Search/DocumentSearchResultDenormalizer.php
@@ -56,7 +56,7 @@ readonly class DocumentSearchResultDenormalizer implements DenormalizerInterface
             ->setPath(SystemField::PATH->getData($data))
             ->setPublished(SystemField::PUBLISHED->getData($data))
             ->setFullPath(SystemField::FULL_PATH->getData($data))
-            ->setUserOwner(SystemField::USER_OWNER->getData($data))
+            ->setUserOwner(SystemField::USER_OWNER->getData($data) ?? 0)
             ->setUserModification(SystemField::USER_MODIFICATION->getData($data))
             ->setLocked(SystemField::LOCKED->getData($data))
             ->setIsLocked(SystemField::IS_LOCKED->getData($data))

--- a/src/Service/Serializer/Normalizer/AssetNormalizer.php
+++ b/src/Service/Serializer/Normalizer/AssetNormalizer.php
@@ -16,10 +16,12 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Serializer\Normalizer;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\MappingProperty;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Asset\FieldDefinitionServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Dependency\DependencyServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\Asset\MetadataProviderServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Serializer\AssetTypeSerializationHandlerService;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Workflow\WorkflowServiceInterface;
@@ -39,6 +41,7 @@ final class AssetNormalizer implements NormalizerInterface
         private readonly FieldDefinitionServiceInterface $fieldDefinitionService,
         private readonly WorkflowServiceInterface $workflowService,
         private readonly MetadataProviderServiceInterface $metadataProviderService,
+        private readonly DependencyServiceInterface $dependencyService,
     ) {
     }
 
@@ -84,6 +87,7 @@ final class AssetNormalizer implements NormalizerInterface
 
         $systemFields = [
             SystemField::ID->value => $asset->getId(),
+            SystemField::ELEMENT_TYPE->value => ElementType::ASSET->value,
             SystemField::PARENT_ID->value => $asset->getParentId(),
             SystemField::CREATION_DATE->value => $this->formatTimestamp($asset->getCreationDate()),
             SystemField::MODIFICATION_DATE->value => $this->formatTimestamp($asset->getModificationDate()),
@@ -103,6 +107,7 @@ final class AssetNormalizer implements NormalizerInterface
             SystemField::HAS_WORKFLOW_WITH_PERMISSIONS->value =>
                 $this->workflowService->hasWorkflowWithPermissions($asset),
             SystemField::FILE_SIZE->value => $asset->getFileSize(),
+            SystemField::DEPENDENCIES->value => $this->dependencyService->getRequiresDependencies($asset),
         ];
 
         if ($handler = $this->assetTypeSerializationHandlerService->getSerializationHandler($asset->getType())) {

--- a/src/Service/Serializer/Normalizer/DataObjectNormalizer.php
+++ b/src/Service/Serializer/Normalizer/DataObjectNormalizer.php
@@ -17,10 +17,12 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Serializer\Normalizer;
 
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DataObjectNormalizerException;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject\FieldDefinitionServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Dependency\DependencyServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Workflow\WorkflowServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Traits\ElementNormalizerTrait;
 use Pimcore\Model\DataObject\AbstractObject;
@@ -39,6 +41,7 @@ final class DataObjectNormalizer implements NormalizerInterface
     public function __construct(
         private readonly FieldDefinitionServiceInterface $fieldDefinitionService,
         private readonly WorkflowServiceInterface $workflowService,
+        private readonly DependencyServiceInterface $dependencyService,
     ) {
     }
 
@@ -92,6 +95,7 @@ final class DataObjectNormalizer implements NormalizerInterface
 
         $result = [
             SystemField::ID->value => $dataObject->getId(),
+            SystemField::ELEMENT_TYPE->value => ElementType::DATA_OBJECT->value,
             SystemField::PARENT_ID->value => $dataObject->getParentId(),
             SystemField::CREATION_DATE->value => $this->formatTimestamp($dataObject->getCreationDate()),
             SystemField::MODIFICATION_DATE->value => $this->formatTimestamp($dataObject->getModificationDate()),
@@ -109,6 +113,7 @@ final class DataObjectNormalizer implements NormalizerInterface
             SystemField::IS_LOCKED->value => $dataObject->isLocked(),
             SystemField::HAS_WORKFLOW_WITH_PERMISSIONS->value =>
                 $this->workflowService->hasWorkflowWithPermissions($dataObject),
+            SystemField::DEPENDENCIES->value => $this->dependencyService->getRequiresDependencies($dataObject),
         ];
 
         if ($dataObject instanceof Concrete) {

--- a/src/Service/Serializer/Normalizer/DocumentNormalizer.php
+++ b/src/Service/Serializer/Normalizer/DocumentNormalizer.php
@@ -16,9 +16,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Serializer\Normalizer;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\StandardField\Document\DocumentStandardField;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Dependency\DependencyServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Serializer\DocumentTypeSerializationHandlerService;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Workflow\WorkflowServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Traits\ElementNormalizerTrait;
@@ -35,6 +37,7 @@ final class DocumentNormalizer implements NormalizerInterface
     public function __construct(
         private readonly DocumentTypeSerializationHandlerService $documentTypeSerializationHandlerService,
         private readonly WorkflowServiceInterface $workflowService,
+        private readonly DependencyServiceInterface $dependencyService,
     ) {
     }
 
@@ -80,6 +83,7 @@ final class DocumentNormalizer implements NormalizerInterface
 
         $systemFields = [
             SystemField::ID->value => $document->getId(),
+            SystemField::ELEMENT_TYPE->value => ElementType::DOCUMENT->value,
             SystemField::PARENT_ID->value => $document->getParentId(),
             SystemField::CREATION_DATE->value => $this->formatTimestamp($document->getCreationDate()),
             SystemField::MODIFICATION_DATE->value => $this->formatTimestamp($document->getModificationDate()),
@@ -98,6 +102,7 @@ final class DocumentNormalizer implements NormalizerInterface
             SystemField::IS_LOCKED->value => $document->isLocked(),
             SystemField::HAS_WORKFLOW_WITH_PERMISSIONS->value =>
                 $this->workflowService->hasWorkflowWithPermissions($document),
+            SystemField::DEPENDENCIES->value => $this->dependencyService->getRequiresDependencies($document),
         ];
 
         if ($handler = $this->documentTypeSerializationHandlerService->getSerializationHandler($document->getType())) {

--- a/tests/Functional/OpenSearch/OpenSearchServiceTest.php
+++ b/tests/Functional/OpenSearch/OpenSearchServiceTest.php
@@ -139,7 +139,7 @@ class OpenSearchServiceTest extends \Codeception\Test\Unit
         $openSearchService = $this->tester->grabService(SearchIndexServiceInterface::class);
 
         $openSearchService->createIndex('test_index');
-        $openSearchService->putAlias('test_index_alias', 'test_index');
+        $openSearchService->addAlias('test_index_alias', 'test_index');
 
         $this->assertTrue($openSearchService->existsAlias('test_index_alias', 'test_index'));
         $this->assertFalse($openSearchService->existsAlias('test_index_alias', 'test_index2'));
@@ -165,7 +165,7 @@ class OpenSearchServiceTest extends \Codeception\Test\Unit
         $openSearchService = $this->tester->grabService(SearchIndexServiceInterface::class);
 
         $openSearchService->createIndex('test_index');
-        $openSearchService->putAlias('test_index_alias', 'test_index');
+        $openSearchService->addAlias('test_index_alias', 'test_index');
         $this->assertTrue($openSearchService->existsAlias('test_index_alias', 'test_index'));
         $openSearchService->deleteAlias('test_index', 'test_index_alias');
         $this->assertFalse($openSearchService->existsAlias('test_index_alias', 'test_index'));

--- a/tests/Functional/OpenSearch/OpenSearchServiceTest.php
+++ b/tests/Functional/OpenSearch/OpenSearchServiceTest.php
@@ -133,24 +133,6 @@ class OpenSearchServiceTest extends \Codeception\Test\Unit
 
     }
 
-    public function testPutAlias(): void
-    {
-
-        /** @var OpenSearchService $openSearchService */
-        $openSearchService = $this->tester->grabService(SearchIndexServiceInterface::class);
-        /** @var Client $openSearchClient */
-        $openSearchClient = $this->tester->grabService('generic-data-index.opensearch-client');
-
-        $openSearchService->createIndex('test_index');
-        $openSearchService->createIndex('test_index2');
-        $openSearchService->putAlias('test_index_alias', 'test_index');
-        $openSearchService->putAlias('test_index_alias', 'test_index2');
-        $this->assertTrue($openSearchClient->indices()->existsAlias(['name' => 'test_index_alias', 'index' => 'test_index']));
-        $this->assertTrue($openSearchClient->indices()->existsAlias(['name' => 'test_index_alias', 'index' => 'test_index2']));
-        $openSearchService->deleteIndex('test_index');
-        $openSearchService->deleteIndex('test_index2');
-    }
-
     public function testExistsAlias(): void
     {
         /** @var OpenSearchService $openSearchService */

--- a/tests/Functional/Search/Modifier/Filter/DependencyFiltersTest.php
+++ b/tests/Functional/Search/Modifier/Filter/DependencyFiltersTest.php
@@ -16,9 +16,6 @@
 namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Functional\Search\Modifier\Filter;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\ExcludeFoldersFilter;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\IdFilter;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\IdsFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency\RequiredByFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency\RequiresFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\AssetSearchServiceInterface;

--- a/tests/Functional/Search/Modifier/Filter/DependencyFiltersTest.php
+++ b/tests/Functional/Search/Modifier/Filter/DependencyFiltersTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Functional\Search\Modifier\Filter;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\ExcludeFoldersFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\IdFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\IdsFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency\RequiredByFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Dependency\RequiresFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\AssetSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
+use Pimcore\Model\DataObject\Unittest;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+class DependencyFiltersTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \Pimcore\Bundle\GenericDataIndexBundle\Tests\IndexTester
+     */
+    protected $tester;
+
+    protected function _before()
+    {
+        $this->tester->enableSynchronousProcessing();
+    }
+
+    protected function _after()
+    {
+        TestHelper::cleanUp();
+        $this->tester->flushIndex();
+        $this->tester->cleanupIndex();
+        $this->tester->flushIndex();
+    }
+
+    // tests
+    public function testDependencyFilters()
+    {
+        /**
+         * @var Unittest $object1
+         * @var Unittest $object2
+         * @var Unittest $object3
+         * @var Unittest $object4
+         */
+        $object1 = TestHelper::createEmptyObject();
+        $object2 = TestHelper::createEmptyObject();
+        $object3 = TestHelper::createEmptyObject();
+        $object4 = TestHelper::createEmptyObject();
+
+        $object1
+            ->setObjects([$object2, $object3])
+            ->save()
+        ;
+
+        $object4->setObjects([$object1])->save();
+
+        /** @var AssetSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.element-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        $elementSearch = $searchProvider
+            ->createElementSearch()
+            ->addModifier(new RequiredByFilter($object1->getId(), ElementType::DATA_OBJECT))
+        ;
+        $searchResult = $searchService->search($elementSearch);
+        $this->assertIdArrayEquals([$object4->getId()], $searchResult->getIds());
+
+        $elementSearch = $searchProvider
+            ->createElementSearch()
+            ->addModifier(new RequiresFilter($object1->getId(), ElementType::DATA_OBJECT));
+        $searchResult = $searchService->search($elementSearch);
+        $this->assertIdArrayEquals([$object2->getId(), $object3->getId()], $searchResult->getIds());
+    }
+
+    private function assertIdArrayEquals(array $ids1, array $ids2)
+    {
+        sort($ids1);
+        sort($ids2);
+        $this->assertEquals($ids1, $ids2);
+    }
+}

--- a/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
+++ b/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
@@ -42,9 +42,9 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
     protected function _after()
     {
         TestHelper::cleanUp();
-        // $this->tester->flushIndex();
-        // $this->tester->cleanupIndex();
-        // $this->tester->flushIndex();
+        $this->tester->flushIndex();
+        $this->tester->cleanupIndex();
+        $this->tester->flushIndex();
     }
 
     // tests

--- a/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
+++ b/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
@@ -480,9 +480,9 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
         $folder?->save();
 
         $folders = [
-            '/test-object-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
-            '/test-object-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
-            '/test-object-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+            '/test-document-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-document-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/test-document-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
         ];
 
         foreach ($folders as $folder) {

--- a/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
+++ b/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Functional\Search\Modifier
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\AssetSearchResultItem;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\AssetSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element\ElementSearchServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Db;
 use Pimcore\Model\Asset;
@@ -314,6 +315,49 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
             '/test-object-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
         ], $user);
 
+
+        $user = $this->createUserWithWorkspaces(
+            [
+                '/test-asset-folder-1' => true,
+                '/test-asset-folder-2' => true,
+            ],
+            [
+                '/test-document-folder-2' => true,
+            ],
+            [
+                '/test-object-folder-3' => true,
+            ]
+        );
+
+        $user->setPermission('assets', false)->save();
+
+        $this->assertElementSearchResultFolders([
+            '/',
+            '/test-document-folder-2',
+            '/test-document-folder-2/sub-folder-2',
+            '/test-document-folder-2/sub-folder-2/sub-sub-folder-2',
+            '/test-document-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/',
+            '/test-object-folder-3',
+            '/test-object-folder-3/sub-folder-3',
+            '/test-object-folder-3/sub-folder-3/sub-sub-folder-3',
+            '/test-object-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+        ], $user);
+
+        $user->setPermission('documents', false)->save();
+
+        $this->assertElementSearchResultFolders([
+            '/',
+            '/test-object-folder-3',
+            '/test-object-folder-3/sub-folder-3',
+            '/test-object-folder-3/sub-folder-3/sub-sub-folder-3',
+            '/test-object-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+        ], $user);
+
+        $user->setPermission('objects', false)->save();
+
+        $this->assertElementSearchResultFolders([], $user);
+
     }
 
     private function assertAssetSearchResultFolders(array $expectedPaths, User $user)
@@ -341,7 +385,7 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
 
     private function assertElementSearchResultFolders(array $expectedPaths, User $user)
     {
-        /** @var AssetSearchServiceInterface $searchService */
+        /** @var ElementSearchServiceInterface $searchService */
         $searchService = $this->tester->grabService('generic-data-index.test.service.element-search-service');
         /** @var SearchProviderInterface $searchProvider */
         $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
@@ -392,6 +436,8 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
         $user = new User();
         $user
             ->setPermission('assets', true)
+            ->setPermission('documents', true)
+            ->setPermission('objects', true)
             ->setUsername('test-user-' . uniqid())
             ->save();
 

--- a/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
+++ b/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
@@ -42,9 +42,9 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
     protected function _after()
     {
         TestHelper::cleanUp();
-       # $this->tester->flushIndex();
-       # $this->tester->cleanupIndex();
-       # $this->tester->flushIndex();
+        // $this->tester->flushIndex();
+        // $this->tester->cleanupIndex();
+        // $this->tester->flushIndex();
     }
 
     // tests

--- a/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
+++ b/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
@@ -314,7 +314,6 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
             '/test-object-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
         ], $user);
 
-
     }
 
     private function assertAssetSearchResultFolders(array $expectedPaths, User $user)
@@ -387,6 +386,7 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
 
         return $user;
     }
+
     private function createUserWithWorkspaces(array $assetWorkspaces, array $documentWorkspaces, array $objectWorkspaces): User
     {
         $user = new User();

--- a/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
+++ b/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
@@ -42,9 +42,9 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
     protected function _after()
     {
         TestHelper::cleanUp();
-        $this->tester->flushIndex();
-        $this->tester->cleanupIndex();
-        $this->tester->flushIndex();
+       # $this->tester->flushIndex();
+       # $this->tester->cleanupIndex();
+       # $this->tester->flushIndex();
     }
 
     // tests
@@ -521,7 +521,7 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
 
     private function createTestDocumentFolders(): void
     {
-        $folder = Document\Folder::getByPath('/');
+        $folder = Document::getByPath('/');
         $folder?->save();
 
         $folders = [

--- a/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
+++ b/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
@@ -315,7 +315,6 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
             '/test-object-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
         ], $user);
 
-
         $user = $this->createUserWithWorkspaces(
             [
                 '/test-asset-folder-1' => true,

--- a/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
+++ b/tests/Functional/Search/Modifier/Filter/Workspace/WorkspaceQueryHandlerTest.php
@@ -16,11 +16,13 @@
 namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Functional\Search\Modifier\Filter\Workspace;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\AssetSearchResultItem;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\AssetSearchServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Db;
-use Pimcore\Model\Asset\Folder;
-use Pimcore\Model\Asset\Service;
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\Document;
 use Pimcore\Model\User;
 use Pimcore\Tests\Support\Util\TestHelper;
 
@@ -46,230 +48,276 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
 
     // tests
 
-    public function testAdmin()
+    public function testHandleWorkspaceQueryAdmin()
     {
         $this->createTestAssetFolders();
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
-            '/test-folder-1/sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
-            '/test-folder-2',
-            '/test-folder-2/sub-folder-2',
-            '/test-folder-2/sub-folder-2/sub-sub-folder-2',
-            '/test-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
-            '/test-folder-3',
-            '/test-folder-3/sub-folder-3',
-            '/test-folder-3/sub-folder-3/sub-sub-folder-3',
-            '/test-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
+            '/test-asset-folder-2',
+            '/test-asset-folder-2/sub-folder-2',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/test-asset-folder-3',
+            '/test-asset-folder-3/sub-folder-3',
+            '/test-asset-folder-3/sub-folder-3/sub-sub-folder-3',
+            '/test-asset-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
         ], User::getByName('admin'));
     }
 
-    public function testIncludeFolders(): void
+    public function testHandleWorkspaceQueryIncludeFolders(): void
     {
         $this->createTestAssetFolders();
 
         $user = $this->createUserWithAssetWorkspaces([
-            '/test-folder-1' => true,
-            '/test-folder-2' => true,
+            '/test-asset-folder-1' => true,
+            '/test-asset-folder-2' => true,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
-            '/test-folder-1/sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
-            '/test-folder-2',
-            '/test-folder-2/sub-folder-2',
-            '/test-folder-2/sub-folder-2/sub-sub-folder-2',
-            '/test-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
+            '/test-asset-folder-2',
+            '/test-asset-folder-2/sub-folder-2',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
         ], $user);
 
         $user = $this->createUserWithAssetWorkspaces([
-            '/test-folder-1' => true,
-            '/test-folder-1/sub-folder-1' => true,
+            '/test-asset-folder-1' => true,
+            '/test-asset-folder-1/sub-folder-1' => true,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
-            '/test-folder-1/sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
         ], $user);
 
         $user = $this->createUserWithAssetWorkspaces([
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1' => true,
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1' => true,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
-            '/test-folder-1/sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
         ], $user);
 
     }
 
-    public function testExcludeFolders(): void
+    public function testHandleWorkspaceQueryExcludeFolders(): void
     {
         $this->createTestAssetFolders();
 
         $user = $this->createUserWithAssetWorkspaces([
             '/' => true,
-            '/test-folder-2' => false,
+            '/test-asset-folder-2' => false,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
-            '/test-folder-1/sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
-            '/test-folder-3',
-            '/test-folder-3/sub-folder-3',
-            '/test-folder-3/sub-folder-3/sub-sub-folder-3',
-            '/test-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
+            '/test-asset-folder-3',
+            '/test-asset-folder-3/sub-folder-3',
+            '/test-asset-folder-3/sub-folder-3/sub-sub-folder-3',
+            '/test-asset-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
         ], $user);
 
         $user = $this->createUserWithAssetWorkspaces([
             '/' => true,
-            '/test-folder-1' => false,
-            '/test-folder-1/sub-folder-1' => false,
+            '/test-asset-folder-1' => false,
+            '/test-asset-folder-1/sub-folder-1' => false,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-2',
-            '/test-folder-2/sub-folder-2',
-            '/test-folder-2/sub-folder-2/sub-sub-folder-2',
-            '/test-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
-            '/test-folder-3',
-            '/test-folder-3/sub-folder-3',
-            '/test-folder-3/sub-folder-3/sub-sub-folder-3',
-            '/test-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+            '/test-asset-folder-2',
+            '/test-asset-folder-2/sub-folder-2',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/test-asset-folder-3',
+            '/test-asset-folder-3/sub-folder-3',
+            '/test-asset-folder-3/sub-folder-3/sub-sub-folder-3',
+            '/test-asset-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
         ], $user);
 
         $user = $this->createUserWithAssetWorkspaces([
             '/' => true,
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3' => false,
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3' => false,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
-            '/test-folder-1/sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
-            '/test-folder-2',
-            '/test-folder-2/sub-folder-2',
-            '/test-folder-2/sub-folder-2/sub-sub-folder-2',
-            '/test-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
-            '/test-folder-3',
-            '/test-folder-3/sub-folder-3',
-            '/test-folder-3/sub-folder-3/sub-sub-folder-3',
-            '/test-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
+            '/test-asset-folder-2',
+            '/test-asset-folder-2/sub-folder-2',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/test-asset-folder-3',
+            '/test-asset-folder-3/sub-folder-3',
+            '/test-asset-folder-3/sub-folder-3/sub-sub-folder-3',
+            '/test-asset-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
         ], $user);
     }
 
-    public function testCombineIncludeExclude(): void
+    public function testHandleWorkspaceQueryCombineIncludeExclude(): void
     {
         $this->createTestAssetFolders();
 
         $user = $this->createUserWithAssetWorkspaces([
-            '/test-folder-1' => true,
-            '/test-folder-1/sub-folder-1' => false,
+            '/test-asset-folder-1' => true,
+            '/test-asset-folder-1/sub-folder-1' => false,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
+            '/test-asset-folder-1',
         ], $user);
 
         $user = $this->createUserWithAssetWorkspaces([
-            '/test-folder-1' => true,
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1' => false,
+            '/test-asset-folder-1' => true,
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1' => false,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
-            '/test-folder-1/sub-folder-1',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1',
         ], $user);
 
         $user = $this->createUserWithAssetWorkspaces([
-            '/test-folder-1' => true,
-            '/test-folder-1/sub-folder-1' => false,
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1' => true,
+            '/test-asset-folder-1' => true,
+            '/test-asset-folder-1/sub-folder-1' => false,
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1' => true,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
         ], $user);
 
         $user = $this->createUserWithAssetWorkspaces([
-            '/test-folder-1' => true,
-            '/test-folder-1/sub-folder-1' => false,
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1' => true,
+            '/test-asset-folder-1' => true,
+            '/test-asset-folder-1/sub-folder-1' => false,
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1' => true,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
         ], $user);
 
         $user = $this->createUserWithAssetWorkspaces([
-            '/test-folder-1' => true,
-            '/test-folder-1/sub-folder-1' => false,
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1' => true,
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1' => false,
+            '/test-asset-folder-1' => true,
+            '/test-asset-folder-1/sub-folder-1' => false,
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1' => true,
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1' => false,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
         ], $user);
 
         $user = $this->createUserWithAssetWorkspaces([
             '/' => true,
-            '/test-folder-1' => false,
-            '/test-folder-1/sub-folder-1' => true,
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1' => false,
-            '/test-folder-2' => false,
-            '/test-folder-3' => false,
+            '/test-asset-folder-1' => false,
+            '/test-asset-folder-1/sub-folder-1' => true,
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1' => false,
+            '/test-asset-folder-2' => false,
+            '/test-asset-folder-3' => false,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1/sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1',
         ], $user);
         $user = $this->createUserWithAssetWorkspaces([
             '/' => true,
-            '/test-folder-1' => false,
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1' => true,
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2' => false,
-            '/test-folder-2' => false,
-            '/test-folder-3' => false,
+            '/test-asset-folder-1' => false,
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1' => true,
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2' => false,
+            '/test-asset-folder-2' => false,
+            '/test-asset-folder-3' => false,
         ]);
-        $this->assertSearchResultFolders([
+        $this->assertAssetSearchResultFolders([
             '/',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
         ], $user);
 
     }
 
-    private function assertSearchResultFolders(array $expectedPaths, User $user)
+    public function testHandleElementWorkspacesQuery(): void
+    {
+        $this->createTestAssetFolders();
+        $this->createTestDataObjectFolders();
+        $this->createTestDocumentFolders();
+
+        $user = $this->createUserWithWorkspaces(
+            [
+                '/test-asset-folder-1' => true,
+                '/test-asset-folder-2' => true,
+            ],
+            [
+                '/test-document-folder-2' => true,
+            ],
+            [
+                '/test-object-folder-3' => true,
+            ]
+        );
+
+        $this->assertElementSearchResultFolders([
+            '/',
+            '/test-asset-folder-1',
+            '/test-asset-folder-1/sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
+            '/test-asset-folder-2',
+            '/test-asset-folder-2/sub-folder-2',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/',
+            '/test-document-folder-2',
+            '/test-document-folder-2/sub-folder-2',
+            '/test-document-folder-2/sub-folder-2/sub-sub-folder-2',
+            '/test-document-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/',
+            '/test-object-folder-3',
+            '/test-object-folder-3/sub-folder-3',
+            '/test-object-folder-3/sub-folder-3/sub-sub-folder-3',
+            '/test-object-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+        ], $user);
+
+
+    }
+
+    private function assertAssetSearchResultFolders(array $expectedPaths, User $user)
     {
         /** @var AssetSearchServiceInterface $searchService */
         $searchService = $this->tester->grabService('generic-data-index.test.service.asset-search-service');
@@ -283,6 +331,29 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
         $searchResult = $searchService->search($assetSearch);
 
         $paths = array_map(function (AssetSearchResultItem $item) {
+            return $item->getPath() . $item->getKey();
+        }, $searchResult->getItems());
+
+        sort($expectedPaths);
+        sort($paths);
+
+        $this->assertEquals($expectedPaths, $paths);
+    }
+
+    private function assertElementSearchResultFolders(array $expectedPaths, User $user)
+    {
+        /** @var AssetSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.element-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        $elementSearch = $searchProvider
+            ->createElementSearch()
+            ->setUser($user)
+        ;
+        $searchResult = $searchService->search($elementSearch);
+
+        $paths = array_map(function (ElementSearchResultItemInterface $item) {
             return $item->getPath() . $item->getKey();
         }, $searchResult->getItems());
 
@@ -316,22 +387,106 @@ class WorkspaceQueryHandlerTest extends \Codeception\Test\Unit
 
         return $user;
     }
+    private function createUserWithWorkspaces(array $assetWorkspaces, array $documentWorkspaces, array $objectWorkspaces): User
+    {
+        $user = new User();
+        $user
+            ->setPermission('assets', true)
+            ->setUsername('test-user-' . uniqid())
+            ->save();
+
+        $workspaceArray = [];
+        foreach ($assetWorkspaces as $workspace => $permission) {
+
+            $workspaceObject = (new User\Workspace\Asset())
+                ->setList($permission)
+                ->setCpath($workspace)
+                ->setCid(Db::get()->fetchOne('select id from assets where concat(path, filename) = ?', [$workspace]))
+                ->setUserId($user->getId());
+
+            $workspaceObject->save();
+            $workspaceArray[] = $workspaceObject;
+        }
+        $user->setWorkspacesAsset($workspaceArray);
+
+        $workspaceArray = [];
+        foreach ($documentWorkspaces as $workspace => $permission) {
+
+            $workspaceObject = (new User\Workspace\Document())
+                ->setList($permission)
+                ->setCpath($workspace)
+                ->setCid(Db::get()->fetchOne('select id from documents where concat(path, `key`) = ?', [$workspace]))
+                ->setUserId($user->getId());
+
+            $workspaceObject->save();
+            $workspaceArray[] = $workspaceObject;
+        }
+        $user->setWorkspacesDocument($workspaceArray);
+
+        $workspaceArray = [];
+        foreach ($objectWorkspaces as $workspace => $permission) {
+
+            $workspaceObject = (new User\Workspace\DataObject())
+                ->setList($permission)
+                ->setCpath($workspace)
+                ->setCid(Db::get()->fetchOne('select id from objects where concat(path, `key`) = ?', [$workspace]))
+                ->setUserId($user->getId());
+
+            $workspaceObject->save();
+            $workspaceArray[] = $workspaceObject;
+        }
+        $user->setWorkspacesObject($workspaceArray);
+
+        return $user;
+    }
 
     private function createTestAssetFolders(): void
     {
-        $folder = Folder::getById(1);
-        $folder->save();
+        $folder = Asset\Folder::getByPath('/');
+        $folder?->save();
 
         $folders = [
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
-            '/test-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
-            '/test-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
-            '/test-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-2',
+            '/test-asset-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-3',
+            '/test-asset-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/test-asset-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
         ];
 
         foreach ($folders as $folder) {
-            Service::createFolderByPath($folder);
+            Asset\Service::createFolderByPath($folder);
+        }
+    }
+
+    private function createTestDataObjectFolders(): void
+    {
+        $folder = DataObject\Folder::getByPath('/');
+        $folder?->save();
+
+        $folders = [
+            '/test-object-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-object-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/test-object-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+        ];
+
+        foreach ($folders as $folder) {
+            DataObject\Service::createFolderByPath($folder);
+        }
+    }
+
+    private function createTestDocumentFolders(): void
+    {
+        $folder = Document\Folder::getByPath('/');
+        $folder?->save();
+
+        $folders = [
+            '/test-object-folder-1/sub-folder-1/sub-sub-folder-1/sub-sub-sub-folder-1',
+            '/test-object-folder-2/sub-folder-2/sub-sub-folder-2/sub-sub-sub-folder-2',
+            '/test-object-folder-3/sub-folder-3/sub-sub-folder-3/sub-sub-sub-folder-3',
+        ];
+
+        foreach ($folders as $folder) {
+            Document\Service::createFolderByPath($folder);
         }
     }
 }


### PR DESCRIPTION
This PR solves the folowing aspects:

- Move OpenSearch index alias handling to separate `IndexAliasService`
- Improve the logic for generating the global `data-object` index alias for searching through all data objects.
- Add data object folder indexing and search
- Add a new global `element-search` index alias for searching through all elements (assets, data objects, documents)
- Add a `ElementSearchService` to search for all element types in parallel.
- Add the element's dependencies to it's search index.
- Add search modifiers to be able to filter by requires and required-by dependencies.