### PR TITLE
Skip data object folder indexing to avoid index not found exceptions

### DIFF
--- a/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
+++ b/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
@@ -30,6 +30,7 @@ use Pimcore\Event\DataObjectEvents;
 use Pimcore\Event\Model\DataObject\ClassDefinitionEvent;
 use Pimcore\Event\Model\DataObjectEvent;
 use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\Webservice\Data\DataObject\Folder;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -75,6 +76,10 @@ final class DataObjectIndexUpdateSubscriber implements EventSubscriberInterface
             return;
         }
 
+        if ($event->getObject() instanceof Folder) {
+            return;
+        }
+
         $inheritanceBackup = AbstractObject::getGetInheritedValues();
         AbstractObject::setGetInheritedValues(true);
 
@@ -93,6 +98,10 @@ final class DataObjectIndexUpdateSubscriber implements EventSubscriberInterface
     public function deleteDataObject(DataObjectEvent $event): void
     {
         if (!$this->installer->isInstalled()) {
+            return;
+        }
+
+        if ($event->getObject() instanceof Folder) {
             return;
         }
 

--- a/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
+++ b/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
@@ -30,7 +30,7 @@ use Pimcore\Event\DataObjectEvents;
 use Pimcore\Event\Model\DataObject\ClassDefinitionEvent;
 use Pimcore\Event\Model\DataObjectEvent;
 use Pimcore\Model\DataObject\AbstractObject;
-use Pimcore\Model\Webservice\Data\DataObject\Folder;
+use Pimcore\Model\DataObject\Folder;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**

--- a/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
+++ b/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
@@ -76,7 +76,7 @@ final class DataObjectIndexUpdateSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ($event->getObject() instanceof Folder) {
+        if (!$this->isIndexable($event->getObject())) {
             return;
         }
 
@@ -101,7 +101,7 @@ final class DataObjectIndexUpdateSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ($event->getObject() instanceof Folder) {
+        if (!$this->isIndexable($event->getObject())) {
             return;
         }
 
@@ -169,5 +169,10 @@ final class DataObjectIndexUpdateSubscriber implements EventSubscriberInterface
         } catch (Exception $e) {
             $this->logger->error($e->getMessage());
         }
+    }
+    
+    private function isIndexable(AbstractObject $object): bool
+    {
+        return !($object instanceof Folder);
     }
 }

--- a/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
+++ b/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
@@ -170,7 +170,7 @@ final class DataObjectIndexUpdateSubscriber implements EventSubscriberInterface
             $this->logger->error($e->getMessage());
         }
     }
-    
+
     private function isIndexable(AbstractObject $object): bool
     {
         return !($object instanceof Folder);


### PR DESCRIPTION
Resolves #162 

Data object folder indexing and search will work in version 1.1.0 of the generic data index bundle. 