### PR TITLE
Fix hasWorkflowWithPermissions check in combination with user authentication

### DIFF
--- a/src/Service/Workflow/WorkflowService.php
+++ b/src/Service/Workflow/WorkflowService.php
@@ -16,9 +16,10 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Workflow;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Workflow\WorkflowService\WorkflowDummyUser;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Workflow\Manager;
-use Symfony\Component\Security\Core\Authentication\Token\NullToken;
+use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
@@ -36,7 +37,7 @@ final readonly class WorkflowService implements WorkflowServiceInterface
     {
         $resetToken = false;
         if (!$this->tokenStorage->getToken()) {
-            $this->tokenStorage->setToken(new NullToken());
+            $this->tokenStorage->setToken(new PreAuthenticatedToken(new WorkflowDummyUser(), 'main'));
             $resetToken = true;
         }
 

--- a/src/Service/Workflow/WorkflowService/WorkflowDummyUser.php
+++ b/src/Service/Workflow/WorkflowService/WorkflowDummyUser.php
@@ -30,6 +30,7 @@ final readonly class WorkflowDummyUser implements UserInterface
 
     public function eraseCredentials(): void
     {
+        // not needed for dummy user
     }
 
     public function getUserIdentifier(): string

--- a/src/Service/Workflow/WorkflowService/WorkflowDummyUser.php
+++ b/src/Service/Workflow/WorkflowService/WorkflowDummyUser.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Workflow\WorkflowService;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @internal
+ */
+final readonly class WorkflowDummyUser implements UserInterface
+{
+    public function getRoles(): array
+    {
+        return [];
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return 'workflow dummy user';
+    }
+
+}

--- a/src/Service/Workflow/WorkflowService/WorkflowDummyUser.php
+++ b/src/Service/Workflow/WorkflowService/WorkflowDummyUser.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Workflow\WorkflowService;
 
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -23,5 +36,4 @@ final readonly class WorkflowDummyUser implements UserInterface
     {
         return 'workflow dummy user';
     }
-
 }


### PR DESCRIPTION
"hasWorkflowWithPermissions" is not set correctly all the time.

e.g. when workflow has expression supports strategy and uses is_fully_authenticated()  in expression (e.g. the asset workflow in the demo).

Then, when saving the asset in pimcore backend (with existing admin session), hasWorkflowWithPermissions is set correctly into index.

When saving asset via API or just updating index via commands, hasWorkflowWithPermissions is not set correctly.


Fixes https://github.com/pimcore/portal-engine/issues/289