### PR TITLE
Add SearchResultIdListService

### DIFF
--- a/.github/ci/files/config/services_test.yaml
+++ b/.github/ci/files/config/services_test.yaml
@@ -15,3 +15,7 @@ services:
   Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\LocateInTreeServiceInterface:
     class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\LocateInTreeService
     public: true
+
+  Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchResultIdListServiceInterface:
+    class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchResultIdListService
+    public: true

--- a/config/services/search-index-adapter/open-search.yaml
+++ b/config/services/search-index-adapter/open-search.yaml
@@ -38,6 +38,9 @@ services:
     Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\LocateInTreeServiceInterface:
         class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\LocateInTreeService
 
+    Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\FetchIdsServiceInterface:
+        class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\FetchIdsService
+
     Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\FetchIdsBySearchServiceInterface:
         class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\FetchIdsBySearchService
 

--- a/config/services/search/search-services.yaml
+++ b/config/services/search/search-services.yaml
@@ -27,3 +27,9 @@ services:
 
   Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\IndexNameResolverInterface:
       class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\IndexNameResolver
+
+  Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\TransformToAdapterSearchServiceInterface:
+    class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\TransformToAdapterSearchService
+
+  Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchResultIdListServiceInterface:
+    class: Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchResultIdListService

--- a/doc/04_Searching_For_Data_In_Index/README.md
+++ b/doc/04_Searching_For_Data_In_Index/README.md
@@ -107,6 +107,7 @@ Find out details about search modifiers in the [search modifiers documentation](
 ## Retrieve IDs only instead of full objects
 
 If you only want to retrieve your search results as list of IDs for your `AssetSearch`, `DataObjectSearch` or `DocumentSearch` you can use the `SearchResultIdListServiceInterface` to retrieve the IDs only.
+
 ```php
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\ParentIdFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;

--- a/doc/04_Searching_For_Data_In_Index/README.md
+++ b/doc/04_Searching_For_Data_In_Index/README.md
@@ -104,6 +104,28 @@ public function searchAction(SearchProviderInterface $searchProvider, ElementSea
 To influence the data which gets fetched its possible to use so-called search modifiers.
 Find out details about search modifiers in the [search modifiers documentation](05_Search_Modifiers/README.md). There you will also find information on how to create your own custom search modifiers.
 
+## Retrieve IDs only instead of full objects
+
+If you only want to retrieve your search results as list of IDs for your `AssetSearch`, `DataObjectSearch` or `DocumentSearch` you can use the `SearchResultIdListServiceInterface` to retrieve the IDs only.
+```php
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\ParentIdFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchResultIdListServiceInterface;
+
+public function searchAction(SearchProviderInterface $searchProvider, SearchResultIdListServiceInterface $searchResultIdListService)
+{
+    $dataObjectSearch = $searchProvider->createDataObjectSearch()
+                ->addModifier(new ParentIdFilter(1))
+                ->addModifier(new OrderByFullPath())
+                ->setPageSize(50)
+                ->setPage(1);
+
+    $allIds = $searchResultIdListService->getAllIds($dataObjectSearch); // returns an ordered array of IDs for the full search result without pagination
+    $idsOnPage = $searchResultIdListService->getIdsForCurrentPage($dataObjectSearch); // returns an ordered array of IDs for the current page
+}
+```
+
 ## OpenSearch Search Models
 The search services mentioned above offer a flexible and structured way to search for assets, data objects and documents. Nevertheless if there are requirements which are not covered by the search services it might be needed to develop your own customized open search queries. The OpenSearch search models offer a streamlined way for executing such customized search queries. They are also used by the search services internally to create the executed OpenSearch search queries.
 

--- a/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsBySearchService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsBySearchService.php
@@ -34,6 +34,7 @@ final readonly class FetchIdsBySearchService implements FetchIdsBySearchServiceI
 
     public function fetchAllIds(OpenSearchSearchInterface $search, string $indexName, bool $sortById = true): array
     {
+        $search = clone($search);
         if ($sortById) {
             $search->setSortList(new FieldSortList([new FieldSort(SystemField::ID->getPath())]));
         }

--- a/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsBySearchService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsBySearchService.php
@@ -34,7 +34,7 @@ final readonly class FetchIdsBySearchService implements FetchIdsBySearchServiceI
 
     public function fetchAllIds(OpenSearchSearchInterface $search, string $indexName, bool $sortById = true): array
     {
-        $search = clone($search);
+        $search = clone $search;
         if ($sortById) {
             $search->setSortList(new FieldSortList([new FieldSort(SystemField::ID->getPath())]));
         }

--- a/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
@@ -23,6 +23,7 @@ final readonly class FetchIdsService implements FetchIdsServiceInterface
 
     public function fetchIdsForCurrentPage(AdapterSearchInterface $search, string $indexName): array
     {
+        $search = $this->validateSearch($search);
         $search = clone($search);
         $search->setSource(false);
         return $this->searchIndexService
@@ -34,11 +35,16 @@ final readonly class FetchIdsService implements FetchIdsServiceInterface
 
     public function fetchAllIds(AdapterSearchInterface $search, string $indexName, bool $sortById = true): array
     {
-        if (!$search instanceof OpenSearchSearchInterface) {
-            throw new InvalidArgumentException('Search must be an instance of OpenSearchSearchInterface');
-        }
+        $search = $this->validateSearch($search);
 
         return $this->fetchIdsBySearchService->fetchAllIds($search, $indexName, $sortById);
     }
 
+    private function validateSearch(AdapterSearchInterface $search): OpenSearchSearchInterface
+    {
+        if (!$search instanceof OpenSearchSearchInterface) {
+            throw new InvalidArgumentException('Search must be an instance of OpenSearchSearchInterface');
+        }
+        return $search;
+    }
 }

--- a/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
@@ -37,7 +37,7 @@ final readonly class FetchIdsService implements FetchIdsServiceInterface
     {
         $search = clone $search;
         $search = $this->validateSearch($search);
-        $search = clone($search);
+        $search = clone $search;
         $search->setSource(false);
 
         return $this->searchIndexService
@@ -58,6 +58,7 @@ final readonly class FetchIdsService implements FetchIdsServiceInterface
         if (!$search instanceof OpenSearchSearchInterface) {
             throw new InvalidArgumentException('Search must be an instance of OpenSearchSearchInterface');
         }
+
         return $search;
     }
 }

--- a/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\OpenSearchSearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\FetchIdsServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+
+/**
+ * @internal
+ */
+final readonly class FetchIdsService implements FetchIdsServiceInterface
+{
+    public function __construct(
+        private FetchIdsBySearchServiceInterface $fetchIdsBySearchService,
+        private SearchIndexServiceInterface $searchIndexService,
+    )
+    {
+    }
+
+    public function fetchIdsForCurrentPage(AdapterSearchInterface $search, string $indexName): array
+    {
+        $search = clone($search);
+        $search->setSource(false);
+        return $this->searchIndexService
+            ->search($search, $indexName)
+            ->getIds()
+        ;
+    }
+
+
+    public function fetchAllIds(AdapterSearchInterface $search, string $indexName, bool $sortById = true): array
+    {
+        if (!$search instanceof OpenSearchSearchInterface) {
+            throw new InvalidArgumentException('Search must be an instance of OpenSearchSearchInterface');
+        }
+
+        return $this->fetchIdsBySearchService->fetchAllIds($search, $indexName, $sortById);
+    }
+
+}

--- a/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
@@ -35,7 +35,6 @@ final readonly class FetchIdsService implements FetchIdsServiceInterface
 
     public function fetchIdsForCurrentPage(AdapterSearchInterface $search, string $indexName): array
     {
-        $search = clone $search;
         $search = $this->validateSearch($search);
         $search = clone $search;
         $search->setSource(false);

--- a/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
@@ -17,20 +30,19 @@ final readonly class FetchIdsService implements FetchIdsServiceInterface
     public function __construct(
         private FetchIdsBySearchServiceInterface $fetchIdsBySearchService,
         private SearchIndexServiceInterface $searchIndexService,
-    )
-    {
+    ) {
     }
 
     public function fetchIdsForCurrentPage(AdapterSearchInterface $search, string $indexName): array
     {
-        $search = clone($search);
+        $search = clone $search;
         $search->setSource(false);
+
         return $this->searchIndexService
             ->search($search, $indexName)
             ->getIds()
         ;
     }
-
 
     public function fetchAllIds(AdapterSearchInterface $search, string $indexName, bool $sortById = true): array
     {
@@ -40,5 +52,4 @@ final readonly class FetchIdsService implements FetchIdsServiceInterface
 
         return $this->fetchIdsBySearchService->fetchAllIds($search, $indexName, $sortById);
     }
-
 }

--- a/src/SearchIndexAdapter/Search/FetchIdsServiceInterface.php
+++ b/src/SearchIndexAdapter/Search/FetchIdsServiceInterface.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
+
+/**
+ * @internal
+ */
+interface FetchIdsServiceInterface
+{
+    public function fetchIdsForCurrentPage(AdapterSearchInterface $search, string $indexName): array;
+    public function fetchAllIds(AdapterSearchInterface $search, string $indexName, bool $sortById = true): array;
+}

--- a/src/SearchIndexAdapter/Search/FetchIdsServiceInterface.php
+++ b/src/SearchIndexAdapter/Search/FetchIdsServiceInterface.php
@@ -24,5 +24,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchI
 interface FetchIdsServiceInterface
 {
     public function fetchIdsForCurrentPage(AdapterSearchInterface $search, string $indexName): array;
+
     public function fetchAllIds(AdapterSearchInterface $search, string $indexName, bool $sortById = true): array;
 }

--- a/src/Service/Search/SearchService/Element/ElementSearchHelperInterface.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchHelperInterface.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
 use Pimcore\Model\User;
@@ -27,6 +28,12 @@ interface ElementSearchHelperInterface
     public function addSearchRestrictions(SearchInterface $search): SearchInterface;
 
     public function performSearch(SearchInterface $search, string $indexName): SearchResult;
+
+    public function createAdapterSearch(
+        SearchInterface $search,
+        string $indexName,
+        bool $enableOrderByPageNumber = false
+    ): AdapterSearchInterface;
 
     public function hydrateSearchResultHits(
         SearchResult $searchResult,

--- a/src/Service/Search/SearchService/IndexNameResolver.php
+++ b/src/Service/Search/SearchService/IndexNameResolver.php
@@ -16,10 +16,12 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\DocumentSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\ElementSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\ElementTypeAdapter\AssetTypeAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\ElementTypeAdapter\DataObjectTypeAdapter;
@@ -49,6 +51,10 @@ final readonly class IndexNameResolver implements IndexNameResolverInterface
 
         if ($search instanceof DocumentSearch) {
             return $this->documentTypeAdapter->getAliasIndexName();
+        }
+
+        if ($search instanceof ElementSearch) {
+            return IndexName::ELEMENT_SEARCH->value;
         }
 
         throw new InvalidArgumentException('Unsupported search type: ' . get_class($search));

--- a/src/Service/Search/SearchService/SearchResultIdListService.php
+++ b/src/Service/Search/SearchService/SearchResultIdListService.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\DocumentSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\ElementSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\FetchIdsServiceInterface;
+
+/**
+ * @internal
+ */
+final readonly class SearchResultIdListService implements SearchResultIdListServiceInterface
+{
+    public function __construct(
+        private TransformToAdapterSearchServiceInterface $transformToAdapterSearchService,
+        private IndexNameResolverInterface $indexNameResolver,
+        private FetchIdsServiceInterface $fetchIdsService,
+    )
+    {
+    }
+
+    public function getAllIds(SearchInterface $search): array
+    {
+        $this->validateSearch($search);
+
+        return $this->fetchIdsService->fetchAllIds(
+            $this->transformToAdapterSearchService->transform($search, true),
+            $this->indexNameResolver->resolveIndexName($search)
+        );
+    }
+
+    public function getIdsForCurrentPage(SearchInterface $search): array
+    {
+        $this->validateSearch($search);
+
+        return $this->fetchIdsService->fetchIdsForCurrentPage(
+            $this->transformToAdapterSearchService->transform($search),
+            $this->indexNameResolver->resolveIndexName($search)
+        );
+    }
+
+    private function validateSearch(SearchInterface $search): void
+    {
+        if ($search instanceof AssetSearch
+            || $search instanceof DataObjectSearch
+            || $search instanceof DocumentSearch
+        ) {
+            return;
+        }
+
+        if ($search instanceof ElementSearch) {
+            throw new InvalidArgumentException(
+                'ElementSearch is not supported by SearchResultIdListService as it might return different element types. Use ElementSearchService instead.'
+            );
+        }
+
+        throw new InvalidArgumentException(
+            'SearchInterface must be an instance of AssetSearch, DataObjectSearch or DocumentSearch'
+        );
+    }
+
+}

--- a/src/Service/Search/SearchService/SearchResultIdListService.php
+++ b/src/Service/Search/SearchService/SearchResultIdListService.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
@@ -20,8 +33,7 @@ final readonly class SearchResultIdListService implements SearchResultIdListServ
         private TransformToAdapterSearchServiceInterface $transformToAdapterSearchService,
         private IndexNameResolverInterface $indexNameResolver,
         private FetchIdsServiceInterface $fetchIdsService,
-    )
-    {
+    ) {
     }
 
     public function getAllIds(SearchInterface $search): array
@@ -63,5 +75,4 @@ final readonly class SearchResultIdListService implements SearchResultIdListServ
             'SearchInterface must be an instance of AssetSearch, DataObjectSearch or DocumentSearch'
         );
     }
-
 }

--- a/src/Service/Search/SearchService/SearchResultIdListServiceInterface.php
+++ b/src/Service/Search/SearchService/SearchResultIdListServiceInterface.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
+
+interface SearchResultIdListServiceInterface
+{
+    /**
+     * Returns all IDs for all pages that match the search criteria ordered by ID.
+     */
+    public function getAllIds(SearchInterface $search): array;
+
+    /**
+     * Returns the IDs for the current page that match the search criteria ordered by defined sort order.
+     */
+    public function getIdsForCurrentPage(SearchInterface $search): array;
+}

--- a/src/Service/Search/SearchService/SearchResultIdListServiceInterface.php
+++ b/src/Service/Search/SearchService/SearchResultIdListServiceInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;

--- a/src/Service/Search/SearchService/Traits/SearchHelperTrait.php
+++ b/src/Service/Search/SearchService/Traits/SearchHelperTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Traits;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\OrderByPageNumber;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
@@ -28,18 +29,28 @@ trait SearchHelperTrait
 {
     public function performSearch(SearchInterface $search, string $indexName): SearchResult
     {
+        $adapterSearch = $this->createAdapterSearch($search, $indexName, true);
+
+        return $this
+            ->searchIndexService
+            ->search($adapterSearch, $indexName);
+    }
+
+    public function createAdapterSearch(SearchInterface $search, string $indexName, bool $enableOrderByPageNumber = false): AdapterSearchInterface
+    {
         $adapterSearch = $this->searchIndexService->createPaginatedSearch(
             $search->getPage(),
             $search->getPageSize(),
             $search->isAggregationsOnly()
         );
 
-        $search->addModifier(new OrderByPageNumber($indexName, $search));
+        if ($enableOrderByPageNumber) {
+            $search->addModifier(new OrderByPageNumber($indexName, $search));
+        }
+
         $this->searchModifierService->applyModifiersFromSearch($search, $adapterSearch);
 
-        return $this
-            ->searchIndexService
-            ->search($adapterSearch, $indexName);
+        return $adapterSearch;
     }
 
     public function hydrateSearchResultHits(

--- a/src/Service/Search/SearchService/Traits/SearchHelperTrait.php
+++ b/src/Service/Search/SearchService/Traits/SearchHelperTrait.php
@@ -40,8 +40,7 @@ trait SearchHelperTrait
         SearchInterface $search,
         string $indexName,
         bool $enableOrderByPageNumber = false
-    ): AdapterSearchInterface
-    {
+    ): AdapterSearchInterface {
         $adapterSearch = $this->searchIndexService->createPaginatedSearch(
             $search->getPage(),
             $search->getPageSize(),

--- a/src/Service/Search/SearchService/Traits/SearchHelperTrait.php
+++ b/src/Service/Search/SearchService/Traits/SearchHelperTrait.php
@@ -36,7 +36,11 @@ trait SearchHelperTrait
             ->search($adapterSearch, $indexName);
     }
 
-    public function createAdapterSearch(SearchInterface $search, string $indexName, bool $enableOrderByPageNumber = false): AdapterSearchInterface
+    public function createAdapterSearch(
+        SearchInterface $search,
+        string $indexName,
+        bool $enableOrderByPageNumber = false
+    ): AdapterSearchInterface
     {
         $adapterSearch = $this->searchIndexService->createPaginatedSearch(
             $search->getPage(),

--- a/src/Service/Search/SearchService/TransformToAdapterSearchService.php
+++ b/src/Service/Search/SearchService/TransformToAdapterSearchService.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\DocumentSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\ElementSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
+
+/**
+ * @internal
+ */
+final readonly class TransformToAdapterSearchService implements TransformToAdapterSearchServiceInterface
+{
+    public function __construct(
+        private IndexNameResolverInterface $indexNameResolver,
+        private Asset\SearchHelper $assetSearchHelper,
+        private DataObject\SearchHelper $dataObjectSearchHelper,
+        private Document\SearchHelper $documentSearchHelper,
+        private Element\ElementSearchHelperInterface $elementSearchHelper,
+    )
+    {
+    }
+
+    public function transform(SearchInterface $search, bool $enableOrderByPageNumber = false): AdapterSearchInterface
+    {
+        $index = $this->indexNameResolver->resolveIndexName($search);
+
+        return match(true) {
+            $search instanceof AssetSearch
+                => $this->assetSearchHelper->createAdapterSearch($search, $index, $enableOrderByPageNumber),
+            $search instanceof DataObjectSearch
+                => $this->dataObjectSearchHelper->createAdapterSearch($search, $index, $enableOrderByPageNumber),
+            $search instanceof DocumentSearch
+                => $this->documentSearchHelper->createAdapterSearch($search, $index, $enableOrderByPageNumber),
+            $search instanceof ElementSearch
+                => $this->elementSearchHelper->createAdapterSearch($search, $index, $enableOrderByPageNumber),
+        };
+    }
+
+}

--- a/src/Service/Search/SearchService/TransformToAdapterSearchService.php
+++ b/src/Service/Search/SearchService/TransformToAdapterSearchService.php
@@ -1,9 +1,21 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
 
-use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\DocumentSearch;
@@ -22,8 +34,7 @@ final readonly class TransformToAdapterSearchService implements TransformToAdapt
         private DataObject\SearchHelper $dataObjectSearchHelper,
         private Document\SearchHelper $documentSearchHelper,
         private Element\ElementSearchHelperInterface $elementSearchHelper,
-    )
-    {
+    ) {
     }
 
     public function transform(SearchInterface $search, bool $enableOrderByPageNumber = false): AdapterSearchInterface
@@ -41,5 +52,4 @@ final readonly class TransformToAdapterSearchService implements TransformToAdapt
                 => $this->elementSearchHelper->createAdapterSearch($search, $index, $enableOrderByPageNumber),
         };
     }
-
 }

--- a/src/Service/Search/SearchService/TransformToAdapterSearchService.php
+++ b/src/Service/Search/SearchService/TransformToAdapterSearchService.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\DocumentSearch;
@@ -50,6 +51,7 @@ final readonly class TransformToAdapterSearchService implements TransformToAdapt
                 => $this->documentSearchHelper->createAdapterSearch($search, $index, $enableOrderByPageNumber),
             $search instanceof ElementSearch
                 => $this->elementSearchHelper->createAdapterSearch($search, $index, $enableOrderByPageNumber),
+            default => throw new InvalidArgumentException('Unsupported search type ' . get_class($search)),
         };
     }
 }

--- a/src/Service/Search/SearchService/TransformToAdapterSearchServiceInterface.php
+++ b/src/Service/Search/SearchService/TransformToAdapterSearchServiceInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;

--- a/src/Service/Search/SearchService/TransformToAdapterSearchServiceInterface.php
+++ b/src/Service/Search/SearchService/TransformToAdapterSearchServiceInterface.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
+
+/**
+ * @internal
+ */
+interface TransformToAdapterSearchServiceInterface
+{
+    public function transform(SearchInterface $search, bool $enableOrderByPageNumber = false): AdapterSearchInterface;
+}

--- a/tests/Functional/Search/SearchService/SearchResultIdListServiceTest.php
+++ b/tests/Functional/Search/SearchService/SearchResultIdListServiceTest.php
@@ -16,16 +16,11 @@
 namespace Functional\Search\SearchService;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\Search\SortDirection;
-use Pimcore\Bundle\GenericDataIndexBundle\Exception\OpenSearch\ResultWindowTooLargeException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\DocumentSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
-use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\Modifier\Sort\TreeSortHandlers;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\AssetSearchServiceInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchResultIdListServiceInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Pimcore\Tests\Support\Util\TestHelper;
 
 final class SearchResultIdListServiceTest extends \Codeception\Test\Unit

--- a/tests/Functional/Search/SearchService/SearchResultIdListServiceTest.php
+++ b/tests/Functional/Search/SearchService/SearchResultIdListServiceTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Functional\Search\SearchService;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Search\SortDirection;
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\OpenSearch\ResultWindowTooLargeException;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\DocumentSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search\Modifier\Sort\TreeSortHandlers;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\AssetSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchResultIdListServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+final class SearchResultIdListServiceTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \Pimcore\Bundle\GenericDataIndexBundle\Tests\IndexTester
+     */
+    protected $tester;
+
+    protected function _before()
+    {
+        $this->tester->enableSynchronousProcessing();
+    }
+
+    protected function _after()
+    {
+        TestHelper::cleanUp();
+        $this->tester->flushIndex();
+        $this->tester->cleanupIndex();
+        $this->tester->flushIndex();
+    }
+
+    public function testSearchAssetIdList(): void
+    {
+        $asset = TestHelper::createImageAsset()->setKey('asset1')->save();
+        $asset2 = TestHelper::createImageAsset()->setKey('asset2')->save();
+        $asset3 = TestHelper::createImageAsset()->setKey('asset3')->save();
+
+        /** @var SearchResultIdListServiceInterface $searchResultIdListService */
+        $searchResultIdListService = $this->tester->grabService(SearchResultIdListServiceInterface::class);
+
+        $assetIds = $searchResultIdListService->getAllIds(
+            new AssetSearch()
+        );
+
+        $this->assertIdArrayEquals([$asset->getId(), $asset2->getId(), $asset3->getId()], $assetIds);
+
+        $assetIds = $searchResultIdListService->getIdsForCurrentPage(
+            (new AssetSearch())
+                ->addModifier(new OrderByFullPath(SortDirection::DESC))
+                ->setPage(1)
+                ->setPageSize(2)
+        );
+
+        $this->assertEquals([$asset3->getId(), $asset2->getId()], $assetIds);
+    }
+
+    public function testSearchDataObjectIdList(): void
+    {
+        $object1 = TestHelper::createEmptyObject()->setKey('object1')->save();
+        $object2 = TestHelper::createEmptyObject()->setKey('object2')->save();
+        $object3 = TestHelper::createEmptyObject()->setKey('object3')->save();
+
+        /** @var SearchResultIdListServiceInterface $searchResultIdListService */
+        $searchResultIdListService = $this->tester->grabService(SearchResultIdListServiceInterface::class);
+
+        $objectIds = $searchResultIdListService->getAllIds(
+            (new DataObjectSearch())
+                ->setClassDefinition($object1->getClass())
+        );
+
+        $this->assertIdArrayEquals([$object1->getId(), $object2->getId(), $object3->getId()], $objectIds);
+
+        $objectIds = $searchResultIdListService->getIdsForCurrentPage(
+            (new DataObjectSearch())
+                ->setClassDefinition($object1->getClass())
+                ->addModifier(new OrderByFullPath(SortDirection::DESC))
+                ->setPage(1)
+                ->setPageSize(2)
+        );
+
+        $this->assertEquals([$object3->getId(), $object2->getId()], $objectIds);
+    }
+
+    public function testSearchDocumentIdList(): void
+    {
+        $document1 = TestHelper::createEmptyDocument()->setKey('document1')->save();
+        $document2 = TestHelper::createEmptyDocument()->setKey('document2')->save();
+        $document3 = TestHelper::createEmptyDocument()->setKey('document3')->save();
+
+        /** @var SearchResultIdListServiceInterface $searchResultIdListService */
+        $searchResultIdListService = $this->tester->grabService(SearchResultIdListServiceInterface::class);
+
+        $documentIds = $searchResultIdListService->getAllIds(
+            new DocumentSearch()
+        );
+
+        $this->assertIdArrayEquals([$document1->getId(), $document2->getId(), $document3->getId()], $documentIds);
+
+        $documentIds = $searchResultIdListService->getIdsForCurrentPage(
+            (new DocumentSearch())
+                ->addModifier(new OrderByFullPath(SortDirection::DESC))
+                ->setPage(1)
+                ->setPageSize(2)
+        );
+
+        $this->assertEquals([$document3->getId(), $document2->getId()], $documentIds);
+    }
+
+    private function assertIdArrayEquals(array $ids1, array $ids2): void
+    {
+        sort($ids1);
+        sort($ids2);
+        $this->assertEquals($ids1, $ids2);
+    }
+}


### PR DESCRIPTION
Adds a new `SearchResultIdListServiceInterface` service which allows the retrival of either all ids or the ids of the current page for a given `AssetSearch`, `DocumentSearch` or `DataObjectSearch`
