### PR TITLE
Respect defined sort order in SearchResultIdListService

### DIFF
--- a/doc/04_Searching_For_Data_In_Index/README.md
+++ b/doc/04_Searching_For_Data_In_Index/README.md
@@ -122,8 +122,8 @@ public function searchAction(SearchProviderInterface $searchProvider, SearchResu
                 ->setPageSize(50)
                 ->setPage(1);
 
-    $allIds = $searchResultIdListService->getAllIds($dataObjectSearch); // returns an ordered array of IDs for the full search result without pagination
-    $idsOnPage = $searchResultIdListService->getIdsForCurrentPage($dataObjectSearch); // returns an ordered array of IDs for the current page
+    $allIds = $searchResultIdListService->getAllIds($dataObjectSearch); // returns an array of IDs for the full search result without pagination
+    $idsOnPage = $searchResultIdListService->getIdsForCurrentPage($dataObjectSearch); // returns an array of IDs for the current page
 }
 ```
 

--- a/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/FetchIdsService.php
@@ -16,8 +16,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Search;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\OpenSearchSearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Sort\FieldSort;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Sort\FieldSortList;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\FetchIdsServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
@@ -45,11 +48,16 @@ final readonly class FetchIdsService implements FetchIdsServiceInterface
         ;
     }
 
-    public function fetchAllIds(AdapterSearchInterface $search, string $indexName, bool $sortById = true): array
+    public function fetchAllIds(AdapterSearchInterface $search, string $indexName): array
     {
         $search = $this->validateSearch($search);
 
-        return $this->fetchIdsBySearchService->fetchAllIds($search, $indexName, $sortById);
+        // if sort is not defined sort by id to be able to fetch all ids using search after
+        if ($search->getSortList()->isEmpty()) {
+            $search->setSortList(new FieldSortList([new FieldSort(SystemField::ID->getPath())]));
+        }
+
+        return $this->fetchIdsBySearchService->fetchAllIds($search, $indexName, false);
     }
 
     private function validateSearch(AdapterSearchInterface $search): OpenSearchSearchInterface

--- a/src/SearchIndexAdapter/Search/FetchIdsServiceInterface.php
+++ b/src/SearchIndexAdapter/Search/FetchIdsServiceInterface.php
@@ -25,5 +25,5 @@ interface FetchIdsServiceInterface
 {
     public function fetchIdsForCurrentPage(AdapterSearchInterface $search, string $indexName): array;
 
-    public function fetchAllIds(AdapterSearchInterface $search, string $indexName, bool $sortById = true): array;
+    public function fetchAllIds(AdapterSearchInterface $search, string $indexName): array;
 }

--- a/src/Service/Search/SearchService/SearchResultIdListServiceInterface.php
+++ b/src/Service/Search/SearchService/SearchResultIdListServiceInterface.php
@@ -21,7 +21,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterfac
 interface SearchResultIdListServiceInterface
 {
     /**
-     * Returns all IDs for all pages that match the search criteria ordered by ID.
+     * Returns all IDs for all pages that match the search criteria ordered by defined sort order.
      */
     public function getAllIds(SearchInterface $search): array;
 

--- a/tests/Functional/Search/SearchService/SearchResultIdListServiceTest.php
+++ b/tests/Functional/Search/SearchService/SearchResultIdListServiceTest.php
@@ -66,6 +66,15 @@ final class SearchResultIdListServiceTest extends \Codeception\Test\Unit
         );
 
         $this->assertEquals([$asset3->getId(), $asset2->getId()], $assetIds);
+
+        $assetIds = $searchResultIdListService->getAllIds(
+            (new AssetSearch())
+                ->addModifier(new OrderByFullPath(SortDirection::DESC))
+                ->setPage(1)
+                ->setPageSize(2)
+        );
+
+        $this->assertEquals([$asset3->getId(), $asset2->getId(), $asset->getId()], $assetIds);
     }
 
     public function testSearchDataObjectIdList(): void
@@ -93,6 +102,16 @@ final class SearchResultIdListServiceTest extends \Codeception\Test\Unit
         );
 
         $this->assertEquals([$object3->getId(), $object2->getId()], $objectIds);
+
+        $objectIds = $searchResultIdListService->getAllIds(
+            (new DataObjectSearch())
+                ->setClassDefinition($object1->getClass())
+                ->addModifier(new OrderByFullPath(SortDirection::DESC))
+                ->setPage(1)
+                ->setPageSize(2)
+        );
+
+        $this->assertEquals([$object3->getId(), $object2->getId(), $object1->getId()], $objectIds);
     }
 
     public function testSearchDocumentIdList(): void
@@ -118,6 +137,15 @@ final class SearchResultIdListServiceTest extends \Codeception\Test\Unit
         );
 
         $this->assertEquals([$document3->getId(), $document2->getId()], $documentIds);
+
+        $documentIds = $searchResultIdListService->getAllIds(
+            (new DocumentSearch())
+                ->addModifier(new OrderByFullPath(SortDirection::DESC))
+                ->setPage(1)
+                ->setPageSize(2)
+        );
+
+        $this->assertEquals([$document3->getId(), $document2->getId(), $document1->getId()], $documentIds);
     }
 
     private function assertIdArrayEquals(array $ids1, array $ids2): void


### PR DESCRIPTION
Follow-up to #172

It now respects the defined sort order instead of sorting it by id.