### PR TITLE
Fix missing data-object-folder index in data-object alias

### DIFF
--- a/src/Service/SearchIndex/GlobalIndexAliasService.php
+++ b/src/Service/SearchIndex/GlobalIndexAliasService.php
@@ -37,13 +37,14 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
         $aliases = $this->indexAliasService->getAllAliases();
 
         $dataObjectIndexAliases = $this->filterClassAliases($aliases);
+
+        $this
+            ->addAliasIfExists($dataObjectIndexAliases, $aliases, IndexName::DATA_OBJECT_FOLDER->value);
+
         $existingIndicesInDataObjectAlias = $this->filterByAliasName(
             $aliases,
             $this->getDataObjectAliasName()
         );
-
-        $this
-            ->addAliasIfExists($existingIndicesInDataObjectAlias, $aliases, IndexName::DATA_OBJECT_FOLDER->value);
 
         $this->indexAliasService->updateAliases(
             $this->getDataObjectAliasName(),


### PR DESCRIPTION
The `data-object` index alias did not contain the `data-object-folder` index.