### PR TITLE
Add ignore_above configs to keyword fields to avoid max_bytes_length_exceeded_exception

### DIFF
--- a/config/pimcore/config.yaml
+++ b/config/pimcore/config.yaml
@@ -197,6 +197,7 @@ pimcore_generic_data_index:
           type: float
         text:
           type: keyword
+          ignore_above: 256
           fields:
             analyzed_ngram:
               type: text

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -157,6 +157,8 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->scalarNode('analyzer')
                     ->end()
+                    ->scalarNode('ignore_above')
+                    ->end()
                     ->append($this->buildVariableNode('properties'))
                     ->append($this->buildVariableNode('fields'))
                 ->end()

--- a/src/SearchIndexAdapter/OpenSearch/Asset/FieldDefinitionAdapter/KeywordAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/Asset/FieldDefinitionAdapter/KeywordAdapter.php
@@ -29,6 +29,7 @@ final class KeywordAdapter extends AbstractAdapter
     {
         return [
             'type' => AttributeType::KEYWORD->value,
+            'ignore_above' => 10000,
         ];
     }
 

--- a/src/SearchIndexAdapter/OpenSearch/IndexMappingService.php
+++ b/src/SearchIndexAdapter/OpenSearch/IndexMappingService.php
@@ -112,7 +112,6 @@ readonly class IndexMappingService implements IndexMappingServiceInterface
                         ],
                         'type' => [
                             'type' => AttributeType::KEYWORD->value,
-                            'ignore_above' => 1024,
                         ],
                     ],
                 ],

--- a/src/SearchIndexAdapter/OpenSearch/IndexMappingService.php
+++ b/src/SearchIndexAdapter/OpenSearch/IndexMappingService.php
@@ -63,6 +63,7 @@ readonly class IndexMappingService implements IndexMappingServiceInterface
                 [
                     'keyword' => [
                         'type' => AttributeType::KEYWORD->value,
+                        'ignore_above' => 1024,
                     ],
                 ]
             ),
@@ -111,6 +112,7 @@ readonly class IndexMappingService implements IndexMappingServiceInterface
                         ],
                         'type' => [
                             'type' => AttributeType::KEYWORD->value,
+                            'ignore_above' => 1024,
                         ],
                     ],
                 ],

--- a/tests/Unit/SearchIndexAdapter/Asset/FieldDefinitionAdapter/KeywordAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/Asset/FieldDefinitionAdapter/KeywordAdapterTest.php
@@ -38,6 +38,7 @@ final class KeywordAdapterTest extends Unit
         $mapping = $adapter->getIndexMapping();
         $this->assertSame([
             'type' => 'keyword',
+            'ignore_above' => 10000,
         ], $mapping);
     }
 

--- a/tests/Unit/SearchIndexAdapter/OpenSearch/IndexMappingServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/OpenSearch/IndexMappingServiceTest.php
@@ -213,6 +213,7 @@ final class IndexMappingServiceTest extends Unit
                                 'fields' => [
                                     'keyword' => [
                                         'type' => 'keyword',
+                                        'ignore_above' => 1024,
                                     ],
                                 ],
                             ],
@@ -241,6 +242,7 @@ final class IndexMappingServiceTest extends Unit
                                 'fields' => [
                                     'keyword' => [
                                         'type' => 'keyword',
+                                        'ignore_above' => 1024,
                                     ],
                                 ],
                             ],

--- a/tests/Unit/SearchIndexAdapter/OpenSearch/IndexMappingServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/OpenSearch/IndexMappingServiceTest.php
@@ -167,6 +167,7 @@ final class IndexMappingServiceTest extends Unit
                     ],
                     'keyword' => [
                         'type' => 'keyword',
+                        'ignore_above' => 1024,
                     ],
                 ],
             ],

--- a/tests/Unit/SearchIndexAdapter/OpenSearch/IndexMappingServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/OpenSearch/IndexMappingServiceTest.php
@@ -131,6 +131,7 @@ final class IndexMappingServiceTest extends Unit
                 'fields' => [
                     'keyword' => [
                         'type' => 'keyword',
+                        'ignore_above' => 1024,
                     ],
                 ],
             ],


### PR DESCRIPTION
Fixes #175