### PR TITLE
Do not catch exceptions which occur during handling the index queue

### DIFF
--- a/src/Exception/HandleIndexQueueEntriesException.php
+++ b/src/Exception/HandleIndexQueueEntriesException.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Exception;
+
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class HandleIndexQueueEntriesException extends RuntimeException implements GenericDataIndexBundleExceptionInterface
+{
+}

--- a/src/Service/SearchIndex/IndexQueueService.php
+++ b/src/Service/SearchIndex/IndexQueueService.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
 use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\Entity\IndexQueue;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexQueueOperation;
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\HandleIndexQueueEntriesException;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\IndexDataException;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\InvalidArgumentException;
 use Pimcore\Bundle\GenericDataIndexBundle\Repository\IndexQueueRepository;
@@ -110,7 +111,7 @@ final class IndexQueueService implements IndexQueueServiceInterface
             $this->indexQueueRepository->deleteQueueEntries($entries);
 
         } catch (Exception $e) {
-            $this->logger->warning('handleIndexQueueEntry failed! Error: ' . $e->getMessage());
+           throw new HandleIndexQueueEntriesException('handleIndexQueueEntry failed! Error: ' . $e->getMessage(), 0, $e);
         }
     }
 

--- a/src/Service/SearchIndex/IndexQueueService.php
+++ b/src/Service/SearchIndex/IndexQueueService.php
@@ -111,7 +111,7 @@ final class IndexQueueService implements IndexQueueServiceInterface
             $this->indexQueueRepository->deleteQueueEntries($entries);
 
         } catch (Exception $e) {
-           throw new HandleIndexQueueEntriesException('handleIndexQueueEntry failed! Error: ' . $e->getMessage(), 0, $e);
+            throw new HandleIndexQueueEntriesException('handleIndexQueueEntry failed! Error: ' . $e->getMessage(), 0, $e);
         }
     }
 


### PR DESCRIPTION
Failed items need to go to the failed items queue instead of just logging them.