### PR TITLE
Fix data object table data type with activated column config

### DIFF
--- a/config/services/search/data-object/field-definition-adapters.yml
+++ b/config/services/search/data-object/field-definition-adapters.yml
@@ -17,7 +17,6 @@ services:
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "countrymultiselect" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "language" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "languagemultiselect" }
-            - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "table" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "password" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "time" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "user" }
@@ -162,6 +161,11 @@ services:
         shared: false
         tags:
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "imageGallery" }
+
+    Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\DataObject\FieldDefinitionAdapter\TableAdapter:
+        shared: false
+        tags:
+            - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "table" }
 
     Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\DataObject\FieldDefinitionAdapter\StructuredTableAdapter:
         shared: false

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/TableAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/TableAdapter.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\DataObject\FieldDefinitionAdapter;
+
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject\FieldDefinitionServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+
+/**
+ * @internal
+ */
+final class TableAdapter extends AbstractAdapter
+{
+    public function __construct(
+        protected SearchIndexConfigServiceInterface $searchIndexConfigService,
+        protected FieldDefinitionServiceInterface $fieldDefinitionService,
+        private readonly IndexMappingServiceInterface $indexMappingService,
+    ) {
+        parent::__construct(
+            $searchIndexConfigService,
+            $fieldDefinitionService
+        );
+    }
+
+    public function getIndexMapping(): array
+    {
+        if ($this->isColumnConfigActivated() && !$this->hasIntegerColumnsOnly()) {
+            $mapping = [
+                'type' => 'nested',
+                'properties' => [],
+            ];
+
+            foreach ($this->getFieldDefinition()->columnConfig as $columnConfig) {
+                $mapping['properties'][$columnConfig['key']] = $this->indexMappingService->getMappingForTextKeyword(
+                    $this->searchIndexConfigService->getSearchAnalyzerAttributes()
+                );
+            }
+            return $mapping;
+        }
+
+        return $this->indexMappingService->getMappingForTextKeyword(
+            $this->searchIndexConfigService->getSearchAnalyzerAttributes()
+        );
+    }
+
+    private function hasIntegerColumnsOnly(): bool
+    {
+        foreach ($this->getFieldDefinition()->columnConfig as $columnConfig) {
+            if (filter_var($columnConfig['key'], FILTER_VALIDATE_INT) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isColumnConfigActivated(): bool
+    {
+        return property_exists($this->getFieldDefinition(), 'columnConfigActivated')
+            && $this->getFieldDefinition()->columnConfigActivated === true;
+    }
+}

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/TableAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/TableAdapter.php
@@ -77,6 +77,7 @@ final class TableAdapter extends AbstractAdapter
         ) {
             return $this->getFieldDefinition()->columnConfig;
         }
+
         return [];
     }
 

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/TableAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/TableAdapter.php
@@ -44,7 +44,7 @@ final class TableAdapter extends AbstractAdapter
                 'properties' => [],
             ];
 
-            foreach ($this->getFieldDefinition()->columnConfig as $columnConfig) {
+            foreach ($this->getColumnConfig() as $columnConfig) {
                 $mapping['properties'][$columnConfig['key']] = $this->indexMappingService->getMappingForTextKeyword(
                     $this->searchIndexConfigService->getSearchAnalyzerAttributes()
                 );
@@ -59,13 +59,24 @@ final class TableAdapter extends AbstractAdapter
 
     private function hasIntegerColumnsOnly(): bool
     {
-        foreach ($this->getFieldDefinition()->columnConfig as $columnConfig) {
+        foreach ($this->getColumnConfig() as $columnConfig) {
             if (filter_var($columnConfig['key'], FILTER_VALIDATE_INT) === false) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private function getColumnConfig(): array
+    {
+        if (
+            property_exists($this->getFieldDefinition(), 'columnConfig')
+            && is_array($this->getFieldDefinition()->columnConfig)
+        ) {
+            return $this->getFieldDefinition()->columnConfig;
+        }
+        return [];
     }
 
     private function isColumnConfigActivated(): bool

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/TableAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/TableAdapter.php
@@ -49,6 +49,7 @@ final class TableAdapter extends AbstractAdapter
                     $this->searchIndexConfigService->getSearchAnalyzerAttributes()
                 );
             }
+
             return $mapping;
         }
 


### PR DESCRIPTION
When the column config is activated for the table data type the json entry changes from a simple array to an object with keys related to the name of the column. Therefore the OpenSearch mapping needs to change to a nested data structure in that case.