### PR TITLE
Catch throwable instead of exception for thumbnail generation to avoid that the indexing queue breaks

### DIFF
--- a/src/Service/Serializer/AssetTypeSerializationHandler/DocumentSerializationHandler.php
+++ b/src/Service/Serializer/AssetTypeSerializationHandler/DocumentSerializationHandler.php
@@ -24,6 +24,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Traits\LoggerAwareTrait;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Asset\Document;
 use Pimcore\Model\Asset\Image;
+use Throwable;
 
 class DocumentSerializationHandler extends AbstractHandler
 {
@@ -56,7 +57,7 @@ class DocumentSerializationHandler extends AbstractHandler
     {
         try {
             return $document->getImageThumbnail(Image\Thumbnail\Config::getPreviewConfig())->getPath();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->logger->error('Thumbnail generation failed for document asset: ' .
                 $document->getId() .
                 ' error ' .

--- a/src/Service/Serializer/AssetTypeSerializationHandler/ImageSerializationHandler.php
+++ b/src/Service/Serializer/AssetTypeSerializationHandler/ImageSerializationHandler.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Serializer\AssetTypeSerializationHandler;
 
-use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField\Asset\ImageSystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\AssetSearchResultItem;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\SearchResultItem;
 use Pimcore\Bundle\GenericDataIndexBundle\Traits\LoggerAwareTrait;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Asset\Image;
+use Throwable;
 
 class ImageSerializationHandler extends AbstractHandler
 {
@@ -53,7 +53,7 @@ class ImageSerializationHandler extends AbstractHandler
     {
         try {
             return $image->getThumbnail(Image\Thumbnail\Config::getPreviewConfig())->getPath();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->logger->error('Thumbnail generation failed for image asset: ' .
                 $image->getId() .
                 ' error ' .


### PR DESCRIPTION
There are edge cases where the tumbnail generation produces a `TypeError` which will not be catched by `Exception`.