### PR TITLE
Introduce CachedSearchIndexMappingService

### DIFF
--- a/config/services/search/index.yaml
+++ b/config/services/search/index.yaml
@@ -73,3 +73,6 @@ services:
 
     Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\GlobalIndexAliasServiceInterface:
         class: Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\GlobalIndexAliasService
+
+    Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\CachedSearchIndexMappingServiceInterface:
+        class: Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\CachedSearchIndexMappingService

--- a/src/QueryLanguage/Pql/Processor.php
+++ b/src/QueryLanguage/Pql/Processor.php
@@ -22,7 +22,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\QueryLanguage\LexerInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\QueryLanguage\ParserInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\QueryLanguage\ProcessorInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\QueryLanguage\PqlAdapterInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\CachedSearchIndexMappingServiceInterface;
 
 /**
  * @internal
@@ -33,7 +33,7 @@ final readonly class Processor implements ProcessorInterface
         private LexerInterface $lexer,
         private ParserInterface $parser,
         private PqlAdapterInterface $pqlAdapter,
-        private SearchIndexServiceInterface $searchIndexService,
+        private CachedSearchIndexMappingServiceInterface $cachedSearchIndexMappingService,
     ) {
     }
 
@@ -44,7 +44,7 @@ final readonly class Processor implements ProcessorInterface
         $tokens = $this->lexer->getTokens();
 
         $parseResult = $this->parser
-            ->apply($query, $tokens, $this->searchIndexService->getMapping($indexEntity->getIndexName()))
+            ->apply($query, $tokens, $this->cachedSearchIndexMappingService->getMapping($indexEntity->getIndexName()))
             ->parse();
 
         $resultQuery = $parseResult->getQuery();

--- a/src/SearchIndexAdapter/OpenSearch/Search/Modifier/SearchModifierService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/Modifier/SearchModifierService.php
@@ -23,6 +23,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchI
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\Modifier\SearchModifierServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\CachedSearchIndexMappingServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Traits\LoggerAwareTrait;
 
 /**
@@ -31,6 +32,12 @@ use Pimcore\Bundle\GenericDataIndexBundle\Traits\LoggerAwareTrait;
 final class SearchModifierService implements SearchModifierServiceInterface
 {
     use LoggerAwareTrait;
+
+    public function __construct(
+        private readonly CachedSearchIndexMappingServiceInterface $cachedSearchIndexMappingService
+    )
+    {
+    }
 
     /**
      * @var callable[][]
@@ -77,8 +84,23 @@ final class SearchModifierService implements SearchModifierServiceInterface
         SearchInterface $search,
         AdapterSearchInterface $adapterSearch
     ): void {
-        $context = new SearchModifierContext($adapterSearch, $search);
 
+        $cachingWasAlreadyStarted = $this->cachedSearchIndexMappingService->isCachingStarted();
+        $this->cachedSearchIndexMappingService->startCaching();
+
+        $this->doApplyModifiersFromSearch($search, $adapterSearch);
+
+        if (!$cachingWasAlreadyStarted) {
+            $this->cachedSearchIndexMappingService->stopCaching();
+        }
+    }
+
+    private function doApplyModifiersFromSearch(
+        SearchInterface $search,
+        Search $adapterSearch
+    ): void
+    {
+        $context = new SearchModifierContext($adapterSearch, $search);
         foreach ($search->getModifiers() as $modifier) {
             $this->applyModifier($modifier, $context);
         }

--- a/src/SearchIndexAdapter/OpenSearch/Search/Modifier/SearchModifierService.php
+++ b/src/SearchIndexAdapter/OpenSearch/Search/Modifier/SearchModifierService.php
@@ -35,8 +35,7 @@ final class SearchModifierService implements SearchModifierServiceInterface
 
     public function __construct(
         private readonly CachedSearchIndexMappingServiceInterface $cachedSearchIndexMappingService
-    )
-    {
+    ) {
     }
 
     /**
@@ -98,8 +97,7 @@ final class SearchModifierService implements SearchModifierServiceInterface
     private function doApplyModifiersFromSearch(
         SearchInterface $search,
         Search $adapterSearch
-    ): void
-    {
+    ): void {
         $context = new SearchModifierContext($adapterSearch, $search);
         foreach ($search->getModifiers() as $modifier) {
             $this->applyModifier($modifier, $context);

--- a/src/Service/SearchIndex/CachedSearchIndexMappingService.php
+++ b/src/Service/SearchIndex/CachedSearchIndexMappingService.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
 
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
@@ -16,8 +29,7 @@ final readonly class CachedSearchIndexMappingService implements CachedSearchInde
     public function __construct(
         private RuntimeCacheResolverInterface $runtimeCache,
         private SearchIndexServiceInterface $searchIndexService,
-    )
-    {
+    ) {
     }
 
     public function startCaching(): void
@@ -33,13 +45,13 @@ final readonly class CachedSearchIndexMappingService implements CachedSearchInde
         $this->runtimeCache->save(null, self::CACHE_KEY);
     }
 
-
     public function getMapping(string $indexName): array
     {
         if ($this->isCachingStarted()) {
             $cachedMappings = $this->getCachedMappings();
             $cachedMappings[$indexName] ??= $this->searchIndexService->getMapping($indexName);
             $this->writeCachedMappings($cachedMappings);
+
             return $cachedMappings[$indexName];
         }
 

--- a/src/Service/SearchIndex/CachedSearchIndexMappingService.php
+++ b/src/Service/SearchIndex/CachedSearchIndexMappingService.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
+
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+use Pimcore\Bundle\StaticResolverBundle\Lib\Cache\RuntimeCacheResolverInterface;
+
+/**
+ * @internal
+ */
+final readonly class CachedSearchIndexMappingService implements CachedSearchIndexMappingServiceInterface
+{
+    private const CACHE_KEY = 'gdi_cached_search_index_mappingi';
+
+    public function __construct(
+        private RuntimeCacheResolverInterface $runtimeCache,
+        private SearchIndexServiceInterface $searchIndexService,
+    )
+    {
+    }
+
+    public function startCaching(): void
+    {
+        if ($this->isCachingStarted()) {
+            return;
+        }
+        $this->runtimeCache->save([], self::CACHE_KEY);
+    }
+
+    public function stopCaching(): void
+    {
+        $this->runtimeCache->save(null, self::CACHE_KEY);
+    }
+
+
+    public function getMapping(string $indexName): array
+    {
+        if ($this->isCachingStarted()) {
+            $cachedMappings = $this->getCachedMappings();
+            $cachedMappings[$indexName] ??= $this->searchIndexService->getMapping($indexName);
+            $this->writeCachedMappings($cachedMappings);
+            return $cachedMappings[$indexName];
+        }
+
+        return $this->searchIndexService->getMapping($indexName);
+    }
+
+    public function isCachingStarted(): bool
+    {
+        return is_array($this->getCachedMappings());
+    }
+
+    public function getCachedMappings(): ?array
+    {
+        $cachedMappings = $this->runtimeCache->isRegistered(self::CACHE_KEY)
+            ? $this->runtimeCache->load(self::CACHE_KEY) : null;
+
+        return is_array($cachedMappings) ? $cachedMappings : null;
+    }
+
+    private function writeCachedMappings(array $mappings): void
+    {
+        $this->runtimeCache->save($mappings, self::CACHE_KEY);
+    }
+}

--- a/src/Service/SearchIndex/CachedSearchIndexMappingServiceInterface.php
+++ b/src/Service/SearchIndex/CachedSearchIndexMappingServiceInterface.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
+
+/**
+ * @internal
+ */
+interface CachedSearchIndexMappingServiceInterface
+{
+    public function startCaching(): void;
+    public function stopCaching(): void;
+    public function isCachingStarted(): bool;
+    public function getMapping(string $indexName): array;
+}

--- a/src/Service/SearchIndex/CachedSearchIndexMappingServiceInterface.php
+++ b/src/Service/SearchIndex/CachedSearchIndexMappingServiceInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
 
 /**
@@ -9,7 +22,10 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
 interface CachedSearchIndexMappingServiceInterface
 {
     public function startCaching(): void;
+
     public function stopCaching(): void;
+
     public function isCachingStarted(): bool;
+
     public function getMapping(string $indexName): array;
 }

--- a/tests/Unit/Service/SearchIndex/CachedSearchIndexMappingServiceTest.php
+++ b/tests/Unit/Service/SearchIndex/CachedSearchIndexMappingServiceTest.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Service\SearchIndex;
+
+use Codeception\Test\Unit;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Repository\IndexQueueRepository;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\CachedSearchIndexMappingService;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexQueue\QueueMessageService;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\TimeServiceInterface;
+use Pimcore\Bundle\StaticResolverBundle\Lib\Cache\RuntimeCacheResolver;
+use Pimcore\Bundle\StaticResolverBundle\Lib\Cache\RuntimeCacheResolverInterface;
+use Pimcore\Cache\RuntimeCache;
+use Pimcore\Model\DataObject\Fieldcollection;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * @internal
+ */
+final class CachedSearchIndexMappingServiceTest extends Unit
+{
+    private CachedSearchIndexMappingService $cachedSearchIndexMappingService;
+
+    public function _before(): void
+    {
+        $runtimeCacheResolver = new class implements RuntimeCacheResolverInterface {
+            private ?array $cacheEntry = null;
+            public function load(string $id): mixed
+            {
+                return $this->cacheEntry;
+            }
+
+            public function save(mixed $data, string $id): void
+            {
+                $this->cacheEntry = $data;
+            }
+
+            public function isRegistered(string $index): bool
+            {
+                return is_array($this->cacheEntry);
+            }
+
+            public function clear(array $keepItems = []): void
+            {
+                $this->cacheEntry = null;
+            }
+        };
+
+
+        $searchIndexServiceMock = $this->createMock(SearchIndexServiceInterface::class);
+        $searchIndexServiceMock->method('getMapping')->willReturnCallback(function (string $indexName) {
+            return [$indexName . 'df' . uniqid('', true)];
+        });
+
+        $this->cachedSearchIndexMappingService = new CachedSearchIndexMappingService(
+            $runtimeCacheResolver,
+            $searchIndexServiceMock
+        );
+    }
+    public function testStartStopCaching(): void
+    {
+        $this->assertFalse($this->cachedSearchIndexMappingService->isCachingStarted());
+        $this->cachedSearchIndexMappingService->startCaching();
+        $this->assertTrue($this->cachedSearchIndexMappingService->isCachingStarted());
+        $this->cachedSearchIndexMappingService->stopCaching();
+        $this->assertFalse($this->cachedSearchIndexMappingService->isCachingStarted());
+    }
+
+    public function testGetMapping(): void
+    {
+        $this->cachedSearchIndexMappingService->startCaching();
+        $mapping = $this->cachedSearchIndexMappingService->getMapping('test');
+        $this->assertSame($mapping, $this->cachedSearchIndexMappingService->getMapping('test'));
+        $this->assertNotSame($mapping, $this->cachedSearchIndexMappingService->getMapping('testing'));
+
+        $this->cachedSearchIndexMappingService->stopCaching();
+        $this->assertNotSame(
+            $this->cachedSearchIndexMappingService->getMapping('test'),
+            $this->cachedSearchIndexMappingService->getMapping('test')
+        );
+        $this->assertNotSame(
+            $this->cachedSearchIndexMappingService->getMapping('test'),
+            $this->cachedSearchIndexMappingService->getMapping('test')
+        );
+
+        $this->cachedSearchIndexMappingService->startCaching();
+        $this->assertSame(
+            $this->cachedSearchIndexMappingService->getMapping('test'),
+            $this->cachedSearchIndexMappingService->getMapping('test')
+        );
+        $this->assertSame(
+            $this->cachedSearchIndexMappingService->getMapping('test'),
+            $this->cachedSearchIndexMappingService->getMapping('test')
+        );
+    }
+}

--- a/tests/Unit/Service/SearchIndex/CachedSearchIndexMappingServiceTest.php
+++ b/tests/Unit/Service/SearchIndex/CachedSearchIndexMappingServiceTest.php
@@ -17,19 +17,9 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Service\SearchIndex;
 
 use Codeception\Test\Unit;
-use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManagerInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Repository\IndexQueueRepository;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\CachedSearchIndexMappingService;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexQueue\QueueMessageService;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\TimeServiceInterface;
-use Pimcore\Bundle\StaticResolverBundle\Lib\Cache\RuntimeCacheResolver;
 use Pimcore\Bundle\StaticResolverBundle\Lib\Cache\RuntimeCacheResolverInterface;
-use Pimcore\Cache\RuntimeCache;
-use Pimcore\Model\DataObject\Fieldcollection;
-use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
  * @internal
@@ -42,6 +32,7 @@ final class CachedSearchIndexMappingServiceTest extends Unit
     {
         $runtimeCacheResolver = new class implements RuntimeCacheResolverInterface {
             private ?array $cacheEntry = null;
+
             public function load(string $id): mixed
             {
                 return $this->cacheEntry;
@@ -63,7 +54,6 @@ final class CachedSearchIndexMappingServiceTest extends Unit
             }
         };
 
-
         $searchIndexServiceMock = $this->createMock(SearchIndexServiceInterface::class);
         $searchIndexServiceMock->method('getMapping')->willReturnCallback(function (string $indexName) {
             return [$indexName . 'df' . uniqid('', true)];
@@ -74,6 +64,7 @@ final class CachedSearchIndexMappingServiceTest extends Unit
             $searchIndexServiceMock
         );
     }
+
     public function testStartStopCaching(): void
     {
         $this->assertFalse($this->cachedSearchIndexMappingService->isCachingStarted());


### PR DESCRIPTION
This avoids that the OpenSearch mapping is fetched multiple times within one executed search. This is currently relevant for PQL queries but is also a preparation for additional filter conditions and sort modifiers which will be needed for Pimcore studio. The OpenSearch mapping will be cached in the runtime cache for all modifiers within one search. 