### PR TITLE
Combine multiple queries to BoolQuery in QueryList

### DIFF
--- a/tests/Unit/Model/OpenSearch/Query/QueryListTest.php
+++ b/tests/Unit/Model/OpenSearch/Query/QueryListTest.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Model\OpenSearch\Quer
 
 use Codeception\Test\Unit;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\BoolQuery;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\Query;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Query\QueryList;
 
 /**
@@ -83,6 +84,51 @@ final class QueryListTest extends Unit
                     ['term' => ['field2' => 'value2']],
                 ],
                 'should' => ['term' => ['field3' => 'value3']],
+            ],
+        ], $queryList->toArray());
+    }
+
+    public function testCombineToBoolQuery(): void
+    {
+        $queryList = new QueryList();
+        $queryList->addQuery(new Query('term', [
+            'field1' => 'value1'
+        ]));
+        $queryList->addQuery(new Query('term', [
+            'field2' => 'value2'
+        ]));
+
+        self::assertSame([
+            'bool' => [
+                'filter' => [
+                    ['term' => ['field1' => 'value1']],
+                    ['term' => ['field2' => 'value2']],
+                ],
+            ],
+        ], $queryList->toArray());
+
+        $queryList = new QueryList();
+        $queryList->addQuery(new Query('term', [
+            'field1' => 'value1'
+        ]));
+
+        $queryList->addQuery(new BoolQuery([
+            'should' => [
+                ['term' => ['field3' => 'value3']],
+            ],
+        ]));
+
+        $queryList->addQuery(new Query('term', [
+            'field2' => 'value2'
+        ]));
+
+        self::assertSame([
+            'bool' => [
+                'should' => ['term' => ['field3' => 'value3']],
+                'filter' => [
+                    ['term' => ['field1' => 'value1']],
+                    ['term' => ['field2' => 'value2']],
+                ],
             ],
         ], $queryList->toArray());
     }

--- a/tests/Unit/Model/OpenSearch/Query/QueryListTest.php
+++ b/tests/Unit/Model/OpenSearch/Query/QueryListTest.php
@@ -92,10 +92,10 @@ final class QueryListTest extends Unit
     {
         $queryList = new QueryList();
         $queryList->addQuery(new Query('term', [
-            'field1' => 'value1'
+            'field1' => 'value1',
         ]));
         $queryList->addQuery(new Query('term', [
-            'field2' => 'value2'
+            'field2' => 'value2',
         ]));
 
         self::assertSame([
@@ -109,7 +109,7 @@ final class QueryListTest extends Unit
 
         $queryList = new QueryList();
         $queryList->addQuery(new Query('term', [
-            'field1' => 'value1'
+            'field1' => 'value1',
         ]));
 
         $queryList->addQuery(new BoolQuery([
@@ -119,7 +119,7 @@ final class QueryListTest extends Unit
         ]));
 
         $queryList->addQuery(new Query('term', [
-            'field2' => 'value2'
+            'field2' => 'value2',
         ]));
 
         self::assertSame([


### PR DESCRIPTION
When multiple queries are added to a search the are internally converted to a bool query automatically as otherwise the search will product an exception in that case. The bool queries are handled as `filter` by default (therefore they are combined with `and` conditions).