### PR TITLE
Fix element to search result items transformers

### DIFF
--- a/src/Service/Transformer/SearchResultItem/AssetToSearchResultItemTransformer.php
+++ b/src/Service/Transformer/SearchResultItem/AssetToSearchResultItemTransformer.php
@@ -51,8 +51,10 @@ final readonly class AssetToSearchResultItemTransformer implements AssetToSearch
                 $context
             );
 
-            return $this->lazyLoadingHandler
-                ->apply($searchResultItem, $user)
+            $searchResultItem = $this->lazyLoadingHandler
+                ->apply($searchResultItem, $user);
+
+            return $searchResultItem
                 ->setPermissions($this->permissionService->getAssetPermissions($searchResultItem, $user));
 
         } catch (Exception|ExceptionInterface $e) {

--- a/src/Service/Transformer/SearchResultItem/DataObjectToSearchResultItemTransformer.php
+++ b/src/Service/Transformer/SearchResultItem/DataObjectToSearchResultItemTransformer.php
@@ -50,8 +50,10 @@ final readonly class DataObjectToSearchResultItemTransformer implements DataObje
                 $context
             );
 
-            return $this->lazyLoadingHandler
-                ->apply($searchResultItem, $user)
+            $searchResultItem = $this->lazyLoadingHandler
+                ->apply($searchResultItem, $user);
+
+            return $searchResultItem
                 ->setPermissions($this->permissionService->getDataObjectPermissions($searchResultItem, $user));
 
         } catch (Exception $e) {

--- a/src/Service/Transformer/SearchResultItem/DocumentToSearchResultItemTransformer.php
+++ b/src/Service/Transformer/SearchResultItem/DocumentToSearchResultItemTransformer.php
@@ -52,8 +52,10 @@ final readonly class DocumentToSearchResultItemTransformer implements DocumentTo
                 $context
             );
 
-            return $this->lazyLoadingHandler
-                ->apply($searchResultItem, $user)
+            $searchResultItem = $this->lazyLoadingHandler
+                ->apply($searchResultItem, $user);
+
+            return $searchResultItem
                 ->setPermissions($this->permissionService->getDocumentPermissions($searchResultItem, $user));
 
         } catch (Exception|ExceptionInterface $e) {


### PR DESCRIPTION
Follow-up to #181 

As `$this->lazyLoadingHandler->apply()` creates a new instance of the search result item the wrong instance is passed to the permission service in the next lines. This leads to the problem that the lazy loading handler does not apply in the permission events.