### PR TITLE
[PQL] Add synonym field name transformer

### DIFF
--- a/config/services/search-index-adapter/open-search/pql-field-name-transformers.yaml
+++ b/config/services/search-index-adapter/open-search/pql-field-name-transformers.yaml
@@ -34,3 +34,8 @@ services:
     Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameTransformer\SortTransformer:
       tags:
         - {name: pimcore.generic_data_index.pql_field_name_transformer_sort, priority: 1}
+
+    Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameTransformer\SynonymTransformer:
+      tags:
+        - {name: pimcore.generic_data_index.pql_field_name_transformer, priority: 11}
+        - {name: pimcore.generic_data_index.pql_field_name_transformer_sort, priority: 11}

--- a/config/services/search-index-adapter/open-search/pql-field-name-transformers.yaml
+++ b/config/services/search-index-adapter/open-search/pql-field-name-transformers.yaml
@@ -35,7 +35,7 @@ services:
       tags:
         - {name: pimcore.generic_data_index.pql_field_name_transformer_sort, priority: 1}
 
-   # Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameTransformer\SynonymTransformer:
-   #   tags:
-    #    - {name: pimcore.generic_data_index.pql_field_name_transformer, priority: 11}
-   #     - {name: pimcore.generic_data_index.pql_field_name_transformer_sort, priority: 11}
+    Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameTransformer\SynonymTransformer:
+      tags:
+        - {name: pimcore.generic_data_index.pql_field_name_transformer, priority: 11}
+        - {name: pimcore.generic_data_index.pql_field_name_transformer_sort, priority: 11}

--- a/config/services/search-index-adapter/open-search/pql-field-name-transformers.yaml
+++ b/config/services/search-index-adapter/open-search/pql-field-name-transformers.yaml
@@ -35,7 +35,7 @@ services:
       tags:
         - {name: pimcore.generic_data_index.pql_field_name_transformer_sort, priority: 1}
 
-    Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameTransformer\SynonymTransformer:
-      tags:
-        - {name: pimcore.generic_data_index.pql_field_name_transformer, priority: 11}
-        - {name: pimcore.generic_data_index.pql_field_name_transformer_sort, priority: 11}
+   # Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameTransformer\SynonymTransformer:
+   #   tags:
+    #    - {name: pimcore.generic_data_index.pql_field_name_transformer, priority: 11}
+   #     - {name: pimcore.generic_data_index.pql_field_name_transformer_sort, priority: 11}

--- a/src/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameTransformer/SynonymTransformer.php
+++ b/src/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameTransformer/SynonymTransformer.php
@@ -30,6 +30,7 @@ final readonly class SynonymTransformer implements FieldNameTransformerInterface
     private const SYNONYM_FIELDS = [
         'fullPath' => 'fullpath',
     ];
+
     private const SYNONYM_FIELDS_ASSET = [
         'filename' => 'key',
     ];

--- a/src/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameTransformer/SynonymTransformer.php
+++ b/src/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameTransformer/SynonymTransformer.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameTransformer;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexType;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndex\IndexEntity;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameTransformerInterface;
+
+/**
+ * Used to filter based on a keyword subfield if available.
+ *
+ * @internal
+ */
+final readonly class SynonymTransformer implements FieldNameTransformerInterface
+{
+    private const SYNONYM_FIELDS = [
+        'fullPath' => 'fullpath',
+    ];
+    private const SYNONYM_FIELDS_ASSET = [
+        'filename' => 'key',
+    ];
+
+    public function transformFieldName(string $fieldName, array $indexMapping, ?IndexEntity $targetEntity): ?string
+    {
+        $synonymFields = self::SYNONYM_FIELDS;
+        if ($targetEntity && $targetEntity->getIndexType() === IndexType::ASSET) {
+            $synonymFields = array_merge($synonymFields, self::SYNONYM_FIELDS_ASSET);
+        }
+
+        return $synonymFields[$fieldName] ?? null;
+    }
+
+    public function stopPropagation(): bool
+    {
+        return false;
+    }
+}

--- a/src/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameTransformer/SynonymTransformer.php
+++ b/src/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameTransformer/SynonymTransformer.php
@@ -28,7 +28,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLan
 final readonly class SynonymTransformer implements FieldNameTransformerInterface
 {
     private const SYNONYM_FIELDS = [
-        'fullPath' => 'fullpath',
+        'fullpath' => 'fullPath',
     ];
 
     private const SYNONYM_FIELDS_ASSET = [

--- a/tests/Functional/Search/Modifier/FullTextSearch/FullTextSearchTest.php
+++ b/tests/Functional/Search/Modifier/FullTextSearch/FullTextSearchTest.php
@@ -124,6 +124,20 @@ final class FullTextSearchTest extends \Codeception\Test\Unit
 
         $assetSearch = $searchProvider
             ->createAssetSearch()
+            ->addModifier(new WildcardSearch('fullpath', '*/Test*'))
+        ;
+        $searchResult = $searchService->search($assetSearch);
+        $this->assertEquals([$asset->getId()], $searchResult->getIds());
+
+        $assetSearch = $searchProvider
+            ->createAssetSearch()
+            ->addModifier(new WildcardSearch('filename', 'Test*'))
+        ;
+        $searchResult = $searchService->search($assetSearch);
+        $this->assertEquals([$asset->getId()], $searchResult->getIds());
+
+        $assetSearch = $searchProvider
+            ->createAssetSearch()
             ->addModifier(new WildcardSearch('fullPath', '/Test'))
         ;
         $searchResult = $searchService->search($assetSearch);

--- a/tests/Unit/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameTransformer/SynonymTransformerTest.php
+++ b/tests/Unit/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameTransformer/SynonymTransformerTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameTransformer;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexType;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndex\IndexEntity;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameTransformer\SynonymTransformer;
+
+/**
+ * @internal
+ */
+final class SynonymTransformerTest extends Unit
+{
+    public function testTransformFieldName(): void
+    {
+        $transformer = new SynonymTransformer();
+
+        $this->assertEquals(
+            null,
+            $transformer->transformFieldName('filename', [], null)
+        );
+
+        $this->assertEquals(
+            'key',
+            $transformer->transformFieldName('filename', [], new IndexEntity(IndexName::ASSET->value, IndexName::ASSET->value, IndexType::ASSET))
+        );
+
+        $this->assertEquals(
+            'fullpath',
+            $transformer->transformFieldName('fullPath', [], null)
+        );
+
+    }
+
+    public function testStopPropagation(): void
+    {
+        $transformer = new SynonymTransformer();
+
+        $this->assertFalse($transformer->stopPropagation());
+    }
+}

--- a/tests/Unit/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameTransformer/SynonymTransformerTest.php
+++ b/tests/Unit/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameTransformer/SynonymTransformerTest.php
@@ -42,8 +42,8 @@ final class SynonymTransformerTest extends Unit
         );
 
         $this->assertEquals(
-            'fullpath',
-            $transformer->transformFieldName('fullPath', [], null)
+            'fullPath',
+            $transformer->transformFieldName('fullpath', [], null)
         );
 
     }


### PR DESCRIPTION
This PR makes it possible to use the following field names as synonyms:

- fullPath => fullpath (for all searches)
- filename => key (for asset searches only)