### PR TITLE
Improve console output messages

### DIFF
--- a/src/Command/DeploymentReindexCommand.php
+++ b/src/Command/DeploymentReindexCommand.php
@@ -94,18 +94,20 @@ final class DeploymentReindexCommand extends AbstractCommand
                         '<info>Updated following ClassDefinitions: [%s]</info>',
                         implode(', ', $updatedIds)
                     ),
-                    OutputInterface::VERBOSITY_VERBOSE
+                    OutputInterface::VERBOSITY_NORMAL
                 );
 
                 $output->writeln(
                     '<info>Dispatch queue messages</info>',
-                    OutputInterface::VERBOSITY_VERBOSE
+                    OutputInterface::VERBOSITY_NORMAL
                 );
 
                 $this->enqueueService->dispatchQueueMessages(true);
+            } else {
+                $output->writeln('<info>No updates needed - everything is up to date</info>', OutputInterface::VERBOSITY_NORMAL);
             }
 
-            $output->writeln('<info>Finished</info>', OutputInterface::VERBOSITY_VERBOSE);
+            $output->writeln('<info>Finished</info>', OutputInterface::VERBOSITY_NORMAL);
         } catch (Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
         } finally {

--- a/src/Command/ReindexItemsCommand.php
+++ b/src/Command/ReindexItemsCommand.php
@@ -60,12 +60,22 @@ final class ReindexItemsCommand extends AbstractCommand
         }
 
         try {
+            $output->writeln(
+                '<info>Reindex all indices</info>',
+                OutputInterface::VERBOSITY_NORMAL
+            );
+
             $this->reindexService->reindexAllIndices();
         } catch (Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
         } finally {
             $this->release();
         }
+
+        $output->writeln(
+            '<info>Finished</info>',
+            OutputInterface::VERBOSITY_NORMAL
+        );
 
         return self::SUCCESS;
     }

--- a/src/Command/Update/IndexUpdateCommand.php
+++ b/src/Command/Update/IndexUpdateCommand.php
@@ -148,7 +148,7 @@ final class IndexUpdateCommand extends AbstractCommand
                         '<info>Update index and indices for ClassDefinition with id %s</info>',
                         $classDefinitionId
                     ),
-                    OutputInterface::VERBOSITY_VERBOSE
+                    OutputInterface::VERBOSITY_NORMAL
                 );
 
                 $this
@@ -165,7 +165,7 @@ final class IndexUpdateCommand extends AbstractCommand
             try {
                 $output->writeln(
                     '<info>Update asset index</info>',
-                    OutputInterface::VERBOSITY_VERBOSE
+                    OutputInterface::VERBOSITY_NORMAL
                 );
 
                 $this
@@ -180,7 +180,7 @@ final class IndexUpdateCommand extends AbstractCommand
             try {
                 $this->output->writeln(
                     '<info>Update all mappings and indices for objects/assets</info>',
-                    OutputInterface::VERBOSITY_VERBOSE
+                    OutputInterface::VERBOSITY_NORMAL
                 );
 
                 $this
@@ -193,7 +193,7 @@ final class IndexUpdateCommand extends AbstractCommand
 
         $this->output->writeln(
             '<info>Dispatch queue messages</info>',
-            OutputInterface::VERBOSITY_VERBOSE
+            OutputInterface::VERBOSITY_NORMAL
         );
 
         $this->enqueueService->dispatchQueueMessages(true);
@@ -201,7 +201,7 @@ final class IndexUpdateCommand extends AbstractCommand
 
         $this->release();
 
-        $this->output->writeln('<info>Finished</info>', OutputInterface::VERBOSITY_VERBOSE);
+        $this->output->writeln('<info>Finished</info>', OutputInterface::VERBOSITY_NORMAL);
 
         return self::SUCCESS;
     }


### PR DESCRIPTION
Resolves #177 

There where already some success messages when the verbosity level was set to verbose (`-v`). Those messages are now changed to verbosity normal. If for some reason it is needed to hide all outputs except errors (e.g. to avoid logs in deployment szenarios) it's possible to use the quiet verbosity level when running the commands (`-q`).