### PR TITLE
Add classDefinitionIcon to data object indices

### DIFF
--- a/config/pimcore/config.yaml
+++ b/config/pimcore/config.yaml
@@ -207,7 +207,7 @@ pimcore_generic_data_index:
             sort:
               type: keyword
               normalizer: generic_data_index_sort_normalizer
-        icon:
+        classDefinitionIcon:
           type: keyword
       asset:
         mimetype:

--- a/config/pimcore/config.yaml
+++ b/config/pimcore/config.yaml
@@ -207,6 +207,8 @@ pimcore_generic_data_index:
             sort:
               type: keyword
               normalizer: generic_data_index_sort_normalizer
+        icon:
+          type: keyword
       asset:
         mimetype:
           type: keyword

--- a/config/services/search-index-adapter/open-search.yaml
+++ b/config/services/search-index-adapter/open-search.yaml
@@ -72,3 +72,8 @@ services:
     Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\QueryLanguage\FieldNameValidator\:
         resource: '../../../src/SearchIndexAdapter/OpenSearch/QueryLanguage/FieldNameValidator'
         tags: ['pimcore.generic_data_index.pql_field_name_validator']
+
+    Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject\IndexIconUpdateServiceInterface:
+        class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\DataObject\IndexIconUpdateService
+        arguments:
+            $openSearchClient: '@generic-data-index.opensearch-client'

--- a/src/Enum/SearchIndex/FieldCategory/SystemField.php
+++ b/src/Enum/SearchIndex/FieldCategory/SystemField.php
@@ -41,6 +41,7 @@ enum SystemField: string
     case PARENT_TAGS = 'parentTags';
     case MIME_TYPE = 'mimetype';
     case CLASS_NAME = 'className';
+    case ICON = 'icon';
     case CHECKSUM = 'checksum';
     case USER_OWNER = 'userOwner';
     case USER_MODIFICATION = 'userModification';

--- a/src/Enum/SearchIndex/FieldCategory/SystemField.php
+++ b/src/Enum/SearchIndex/FieldCategory/SystemField.php
@@ -41,7 +41,7 @@ enum SystemField: string
     case PARENT_TAGS = 'parentTags';
     case MIME_TYPE = 'mimetype';
     case CLASS_NAME = 'className';
-    case ICON = 'icon';
+    case CLASS_DEFINITION_ICON = 'classDefinitionIcon';
     case CHECKSUM = 'checksum';
     case USER_OWNER = 'userOwner';
     case USER_MODIFICATION = 'userModification';

--- a/src/Model/Search/DataObject/SearchResult/DataObjectSearchResultItem.php
+++ b/src/Model/Search/DataObject/SearchResult/DataObjectSearchResultItem.php
@@ -51,7 +51,7 @@ class DataObjectSearchResultItem implements ElementSearchResultItemInterface
 
     private string $className;
 
-    private ?string $icon;
+    private ?string $classDefinitionIcon;
 
     private bool $workflowWithPermissions;
 
@@ -236,14 +236,14 @@ class DataObjectSearchResultItem implements ElementSearchResultItemInterface
         return $this;
     }
 
-    public function getIcon(): ?string
+    public function getClassDefinitionIcon(): ?string
     {
-        return $this->icon;
+        return $this->classDefinitionIcon;
     }
 
-    public function setIcon(?string $icon): DataObjectSearchResultItem
+    public function setClassDefinitionIcon(?string $classDefinitionIcon): DataObjectSearchResultItem
     {
-        $this->icon = $icon;
+        $this->classDefinitionIcon = $classDefinitionIcon;
 
         return $this;
     }

--- a/src/Model/Search/DataObject/SearchResult/DataObjectSearchResultItem.php
+++ b/src/Model/Search/DataObject/SearchResult/DataObjectSearchResultItem.php
@@ -50,6 +50,7 @@ class DataObjectSearchResultItem implements ElementSearchResultItemInterface
     private ?int $modificationDate;
 
     private string $className;
+    private ?string $icon;
 
     private bool $workflowWithPermissions;
 
@@ -233,6 +234,19 @@ class DataObjectSearchResultItem implements ElementSearchResultItemInterface
 
         return $this;
     }
+
+    public function getIcon(): ?string
+    {
+        return $this->icon;
+    }
+
+    public function setIcon(?string $icon): DataObjectSearchResultItem
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+
 
     public function isHasWorkflowWithPermissions(): bool
     {

--- a/src/Model/Search/DataObject/SearchResult/DataObjectSearchResultItem.php
+++ b/src/Model/Search/DataObject/SearchResult/DataObjectSearchResultItem.php
@@ -50,6 +50,7 @@ class DataObjectSearchResultItem implements ElementSearchResultItemInterface
     private ?int $modificationDate;
 
     private string $className;
+
     private ?string $icon;
 
     private bool $workflowWithPermissions;
@@ -246,7 +247,6 @@ class DataObjectSearchResultItem implements ElementSearchResultItemInterface
 
         return $this;
     }
-
 
     public function isHasWorkflowWithPermissions(): bool
     {

--- a/src/SearchIndexAdapter/DataObject/IndexIconUpdateServiceInterface.php
+++ b/src/SearchIndexAdapter/DataObject/IndexIconUpdateServiceInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject;
 
 /**

--- a/src/SearchIndexAdapter/DataObject/IndexIconUpdateServiceInterface.php
+++ b/src/SearchIndexAdapter/DataObject/IndexIconUpdateServiceInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject;
+
+/**
+ * @internal
+ */
+interface IndexIconUpdateServiceInterface
+{
+    public function updateIcon(string $indexName, string $icon): void;
+}

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/IndexIconUpdateService.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/IndexIconUpdateService.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\DataObject;
 
 use OpenSearch\Client;
@@ -29,11 +42,11 @@ final readonly class IndexIconUpdateService implements IndexIconUpdateServiceInt
                     'source' => 'ctx._source.system_fields.icon = params.icon',
                     'lang' => 'painless',
                     'params' => [
-                        'icon' => $icon
-                    ]
+                        'icon' => $icon,
+                    ],
                 ],
-                'query' => $query
-            ]
+                'query' => $query,
+            ],
         ];
         $this->openSearchClient->updateByQuery($params);
     }
@@ -43,9 +56,9 @@ final readonly class IndexIconUpdateService implements IndexIconUpdateServiceInt
         return [
             'bool' => [
                 'filter' => [
-                    'exists' => ['field' => SystemField::ICON->getPath()]
-                ]
-            ]
+                    'exists' => ['field' => SystemField::ICON->getPath()],
+                ],
+            ],
         ];
     }
 
@@ -57,20 +70,20 @@ final readonly class IndexIconUpdateService implements IndexIconUpdateServiceInt
                     [
                         'bool' => [
                             'must_not' => [
-                                'exists' => ['field' => SystemField::ICON->getPath()]
-                            ]
-                        ]
+                                'exists' => ['field' => SystemField::ICON->getPath()],
+                            ],
+                        ],
                     ],
                     [
                         'bool' => [
                             'must_not' => [
-                                'term' => [SystemField::ICON->getPath() => $icon]
-                            ]
-                        ]
-                    ]
+                                'term' => [SystemField::ICON->getPath() => $icon],
+                            ],
+                        ],
+                    ],
                 ],
-                'minimum_should_match' => 1
-            ]
+                'minimum_should_match' => 1,
+            ],
         ];
     }
 }

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/IndexIconUpdateService.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/IndexIconUpdateService.php
@@ -39,7 +39,7 @@ final readonly class IndexIconUpdateService implements IndexIconUpdateServiceInt
             'refresh' => true,
             'body' => [
                 'script' => [
-                    'source' => 'ctx._source.system_fields.icon = params.icon',
+                    'source' => 'ctx._source.system_fields.classDefinitionIcon = params.icon',
                     'lang' => 'painless',
                     'params' => [
                         'icon' => $icon,
@@ -56,7 +56,7 @@ final readonly class IndexIconUpdateService implements IndexIconUpdateServiceInt
         return [
             'bool' => [
                 'filter' => [
-                    'exists' => ['field' => SystemField::ICON->getPath()],
+                    'exists' => ['field' => SystemField::CLASS_DEFINITION_ICON->getPath()],
                 ],
             ],
         ];
@@ -70,14 +70,14 @@ final readonly class IndexIconUpdateService implements IndexIconUpdateServiceInt
                     [
                         'bool' => [
                             'must_not' => [
-                                'exists' => ['field' => SystemField::ICON->getPath()],
+                                'exists' => ['field' => SystemField::CLASS_DEFINITION_ICON->getPath()],
                             ],
                         ],
                     ],
                     [
                         'bool' => [
                             'must_not' => [
-                                'term' => [SystemField::ICON->getPath() => $icon],
+                                'term' => [SystemField::CLASS_DEFINITION_ICON->getPath() => $icon],
                             ],
                         ],
                     ],

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/IndexIconUpdateService.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/IndexIconUpdateService.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\DataObject;
+
+use OpenSearch\Client;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject\IndexIconUpdateServiceInterface;
+
+/**
+ * @internal
+
+ */
+final readonly class IndexIconUpdateService implements IndexIconUpdateServiceInterface
+{
+    public function __construct(private  Client $openSearchClient)
+    {
+    }
+
+    public function updateIcon(string $indexName, ?string $icon): void
+    {
+        $query = $icon === null ? $this->getQueryForNullIcon() : $this->getQueryForIconString($icon);
+
+        $params = [
+            'index' => $indexName,
+            'refresh' => true,
+            'body' => [
+                'script' => [
+                    'source' => 'ctx._source.system_fields.icon = params.icon',
+                    'lang' => 'painless',
+                    'params' => [
+                        'icon' => $icon
+                    ]
+                ],
+                'query' => $query
+            ]
+        ];
+        $this->openSearchClient->updateByQuery($params);
+    }
+
+    private function getQueryForNullIcon(): array
+    {
+        return [
+            'bool' => [
+                'filter' => [
+                    'exists' => ['field' => SystemField::ICON->getPath()]
+                ]
+            ]
+        ];
+    }
+
+    private function getQueryForIconString(string $icon): array
+    {
+        return [
+            'bool' => [
+                'should' => [
+                    [
+                        'bool' => [
+                            'must_not' => [
+                                'exists' => ['field' => SystemField::ICON->getPath()]
+                            ]
+                        ]
+                    ],
+                    [
+                        'bool' => [
+                            'must_not' => [
+                                'term' => [SystemField::ICON->getPath() => $icon]
+                            ]
+                        ]
+                    ]
+                ],
+                'minimum_should_match' => 1
+            ]
+        ];
+    }
+}

--- a/src/Service/Serializer/Denormalizer/Search/DataObjectSearchResultDenormalizer.php
+++ b/src/Service/Serializer/Denormalizer/Search/DataObjectSearchResultDenormalizer.php
@@ -54,6 +54,7 @@ readonly class DataObjectSearchResultDenormalizer implements DenormalizerInterfa
         $searchResultItem
             ->setId(SystemField::ID->getData($data))
             ->setClassName(SystemField::CLASS_NAME->getData($data) ?? '')
+            ->setIcon(SystemField::ICON->getData($data))
             ->setParentId(SystemField::PARENT_ID->getData($data))
             ->setType(SystemField::TYPE->getData($data))
             ->setPublished($published)

--- a/src/Service/Serializer/Denormalizer/Search/DataObjectSearchResultDenormalizer.php
+++ b/src/Service/Serializer/Denormalizer/Search/DataObjectSearchResultDenormalizer.php
@@ -54,7 +54,7 @@ readonly class DataObjectSearchResultDenormalizer implements DenormalizerInterfa
         $searchResultItem
             ->setId(SystemField::ID->getData($data))
             ->setClassName(SystemField::CLASS_NAME->getData($data) ?? '')
-            ->setIcon(SystemField::ICON->getData($data))
+            ->setClassDefinitionIcon(SystemField::CLASS_DEFINITION_ICON->getData($data))
             ->setParentId(SystemField::PARENT_ID->getData($data))
             ->setType(SystemField::TYPE->getData($data))
             ->setPublished($published)

--- a/src/Service/Serializer/Normalizer/DataObjectNormalizer.php
+++ b/src/Service/Serializer/Normalizer/DataObjectNormalizer.php
@@ -92,6 +92,9 @@ final class DataObjectNormalizer implements NormalizerInterface
         ];
     }
 
+    /**
+     * @throws Exception
+     */
     private function normalizeSystemFields(AbstractObject $dataObject, bool $skipLazyLoadedFields): array
     {
         $pathLevels = $this->extractPathLevels($dataObject);
@@ -115,6 +118,7 @@ final class DataObjectNormalizer implements NormalizerInterface
         if ($dataObject instanceof Concrete) {
             $result = array_merge($result, [
                 SystemField::CLASS_NAME->value => $dataObject->getClassName(),
+                SystemField::ICON->value => $dataObject->getClass()->getIcon() ?: null,
                 SystemField::PUBLISHED->value => $dataObject->getPublished(),
             ]);
         }

--- a/src/Service/Serializer/Normalizer/DataObjectNormalizer.php
+++ b/src/Service/Serializer/Normalizer/DataObjectNormalizer.php
@@ -118,7 +118,7 @@ final class DataObjectNormalizer implements NormalizerInterface
         if ($dataObject instanceof Concrete) {
             $result = array_merge($result, [
                 SystemField::CLASS_NAME->value => $dataObject->getClassName(),
-                SystemField::ICON->value => $dataObject->getClass()->getIcon() ?: null,
+                SystemField::CLASS_DEFINITION_ICON->value => $dataObject->getClass()->getIcon() ?: null,
                 SystemField::PUBLISHED->value => $dataObject->getPublished(),
             ]);
         }

--- a/tests/Functional/SearchIndex/DataObjectBasicTest.php
+++ b/tests/Functional/SearchIndex/DataObjectBasicTest.php
@@ -268,7 +268,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
 
         $indexName = $this->tester->getIndexName($object->getClassName());
         $response = $this->tester->checkIndexEntry($object->getId(), $indexName);
-        $updatedIcon = $response['_source']['system_fields']['icon'];
+        $updatedIcon = $response['_source']['system_fields']['classDefinitionIcon'];
 
         $this->assertEquals($newIcon, $updatedIcon);
     }

--- a/tests/Functional/SearchIndex/DataObjectBasicTest.php
+++ b/tests/Functional/SearchIndex/DataObjectBasicTest.php
@@ -256,7 +256,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
         $class->setIcon($newIcon);
         $class->save();
 
-        $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
+        $this->tester->runCommand('messenger:consume', ['--limit'=>1], ['pimcore_generic_data_index_queue']);
 
         $indexName = $this->tester->getIndexName($object->getClassName());
         $response = $this->tester->checkIndexEntry($object->getId(), $indexName);

--- a/tests/Functional/SearchIndex/DataObjectBasicTest.php
+++ b/tests/Functional/SearchIndex/DataObjectBasicTest.php
@@ -22,7 +22,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchPro
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SettingsStoreServiceInterface;
 use Pimcore\Db;
-use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\MappingTest;

--- a/tests/Functional/SearchIndex/DataObjectBasicTest.php
+++ b/tests/Functional/SearchIndex/DataObjectBasicTest.php
@@ -247,6 +247,24 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
         $this->assertArrayNotHasKey('mappingTest', $standardFields);
     }
 
+    public function testClassDefinitionIconChange(): void
+    {
+        $object = TestHelper::createEmptyObject();
+        $class = $object->getClass();
+
+        $newIcon = '/new-icon.svg';
+        $class->setIcon($newIcon);
+        $class->save();
+
+        $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
+
+        $indexName = $this->tester->getIndexName($object->getClassName());
+        $response = $this->tester->checkIndexEntry($object->getId(), $indexName);
+        $updatedIcon = $response['_source']['system_fields']['icon'];
+
+        $this->assertEquals($newIcon, $updatedIcon);
+    }
+
     private function assertIdArrayEquals(array $ids1, array $ids2)
     {
         sort($ids1);

--- a/tests/Functional/SearchIndex/DataObjectBasicTest.php
+++ b/tests/Functional/SearchIndex/DataObjectBasicTest.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchPro
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SettingsStoreServiceInterface;
 use Pimcore\Db;
+use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\MappingTest;
@@ -250,9 +251,16 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
     public function testClassDefinitionIconChange(): void
     {
         $object = TestHelper::createEmptyObject();
-        $class = $object->getClass();
 
-        $newIcon = '/new-icon.svg';
+        $this->classDefinitionIconChangeTest($object, '/my-icon.svg');
+        $this->classDefinitionIconChangeTest($object, '/my-new-icon.svg');
+        $this->classDefinitionIconChangeTest($object, null);
+        $this->classDefinitionIconChangeTest($object, '/my-final-icon.svg');
+    }
+
+    private function classDefinitionIconChangeTest(Concrete $object, ?string $newIcon): void
+    {
+        $class = $object->getClass();
         $class->setIcon($newIcon);
         $class->save();
 


### PR DESCRIPTION
This PR adds the class definition icon of a data object to the index and `DataObjectSearchResultItem` model. 

When the icon get's changed in the class definition a `_update_by_query` OpenSearch call updates the icon in all documents of the class definition index.