### PR TITLE
Create index if not exists while trying to reindex its mapping

### DIFF
--- a/src/MessageHandler/UpdateClassMappingHandler.php
+++ b/src/MessageHandler/UpdateClassMappingHandler.php
@@ -18,9 +18,7 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\MessageHandler;
 
 use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\Message\UpdateClassMappingMessage;
-use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexQueue\EnqueueServiceInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\ElementTypeAdapter\DataObjectTypeAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler\DataObjectIndexHandler;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SettingsStoreServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Traits\LoggerAwareTrait;
@@ -36,9 +34,7 @@ final class UpdateClassMappingHandler
 
     public function __construct(
         private readonly DataObjectIndexHandler $dataObjectMappingHandler,
-        private readonly DataObjectTypeAdapter $dataObjectTypeAdapter,
         private readonly EnqueueServiceInterface $enqueueService,
-        private readonly SearchIndexServiceInterface $searchIndexService,
         private readonly SettingsStoreServiceInterface $settingsStoreService,
     ) {
     }
@@ -59,20 +55,11 @@ final class UpdateClassMappingHandler
             return;
         }
 
-        $alias = $this->dataObjectTypeAdapter->getAliasIndexName($classDefinition);
-        if (!$this->searchIndexService->existsAlias($alias)) {
-            $this->dataObjectMappingHandler
-                ->updateMapping(
-                    context: $classDefinition,
-                    mappingProperties: $mappingProperties
-                );
-        } else {
-            $this->dataObjectMappingHandler
-                ->reindexMapping(
-                    context: $classDefinition,
-                    mappingProperties: $mappingProperties
-                );
-        }
+        $this->dataObjectMappingHandler
+            ->reindexMapping(
+                context: $classDefinition,
+                mappingProperties: $mappingProperties
+            );
 
         $this->settingsStoreService->storeClassMapping(
             classDefinitionId: $classDefinition->getId(),

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -66,6 +66,8 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
         ?array $mappingProperties = null
     ): void {
         $alias = $this->getAliasIndexName($context);
+        $mappingProperties = $mappingProperties ?: $this->extractMappingProperties($context);
+
         if (!$this->searchIndexService->existsAlias($alias)) {
             $this->updateMapping(
                 context: $context,
@@ -74,7 +76,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
         } else {
             $this->searchIndexService->reindex(
                 $alias,
-                $mappingProperties ?: $this->extractMappingProperties($context)
+                $mappingProperties
             );
         }
 

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -73,7 +73,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
                 );
         } else {
             $this->searchIndexService->reindex(
-                $this->getAliasIndexName($context),
+                $alias,
                 $mappingProperties ?: $this->extractMappingProperties($context)
             );
         }

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -65,10 +65,19 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
         ?ClassDefinition $context = null,
         ?array $mappingProperties = null
     ): void {
-        $this->searchIndexService->reindex(
-            $this->getAliasIndexName($context),
-            $mappingProperties ?: $this->extractMappingProperties($context)
-        );
+        $alias = $this->getAliasIndexName($context);
+        if (!$this->searchIndexService->existsAlias($alias)) {
+            $this->updateMapping(
+                    context: $context,
+                    mappingProperties: $mappingProperties
+                );
+        } else {
+            $this->searchIndexService->reindex(
+                $this->getAliasIndexName($context),
+                $mappingProperties ?: $this->extractMappingProperties($context)
+            );
+        }
+
         $this->createGlobalIndexAliases($context);
     }
 

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -68,9 +68,9 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
         $alias = $this->getAliasIndexName($context);
         if (!$this->searchIndexService->existsAlias($alias)) {
             $this->updateMapping(
-                    context: $context,
-                    mappingProperties: $mappingProperties
-                );
+                context: $context,
+                mappingProperties: $mappingProperties
+            );
         } else {
             $this->searchIndexService->reindex(
                 $this->getAliasIndexName($context),


### PR DESCRIPTION
This is a follow up to #190.

The logic for checking if the index exists is now on a central place to ensure that it works in all cases.