### PR TITLE
[Bug]: Deleting objects/assets does not update generic data index

### DIFF
--- a/src/EventSubscriber/AssetIndexUpdateSubscriber.php
+++ b/src/EventSubscriber/AssetIndexUpdateSubscriber.php
@@ -77,6 +77,6 @@ final readonly class AssetIndexUpdateSubscriber implements EventSubscriberInterf
                 processSynchronously: $this->synchronousProcessing->isEnabled()
             )
             ->commit();
-
+        $this->queueMessagesDispatcher->dispatchQueueMessages();
     }
 }

--- a/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
+++ b/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
@@ -47,7 +47,7 @@ final class DataObjectIndexUpdateSubscriber implements EventSubscriberInterface
         return [
             DataObjectEvents::POST_UPDATE => 'updateDataObject',
             DataObjectEvents::POST_ADD => 'updateDataObject',
-            DataObjectEvents::PRE_DELETE => 'deleteDataObject',
+            DataObjectEvents::POST_DELETE => 'deleteDataObject',
         ];
     }
 

--- a/src/Service/SearchIndex/IndexQueue/EnqueueService.php
+++ b/src/Service/SearchIndex/IndexQueue/EnqueueService.php
@@ -193,13 +193,14 @@ final readonly class EnqueueService implements EnqueueServiceInterface
      */
     public function enqueueRelatedItemsOnUpdate(
         ElementInterface $element,
-        bool $includeElement
+        bool $includeElement,
+        string $operation
     ): void {
         $subQuery = $this->typeAdapterService
             ->getTypeAdapter($element)
             ->getRelatedItemsOnUpdateQuery(
                 element: $element,
-                operation: IndexQueueOperation::UPDATE->value,
+                operation: $operation,
                 operationTime: $this->timeService->getCurrentMillisecondTimestamp(),
                 includeElement: $includeElement,
             );

--- a/src/Service/SearchIndex/IndexQueue/EnqueueServiceInterface.php
+++ b/src/Service/SearchIndex/IndexQueue/EnqueueServiceInterface.php
@@ -57,7 +57,8 @@ interface EnqueueServiceInterface
      */
     public function enqueueRelatedItemsOnUpdate(
         ElementInterface $element,
-        bool $includeElement
+        bool $includeElement,
+        string $operation
     ): void;
 
     public function dispatchQueueMessages(bool $synchronously = false): void;

--- a/src/Service/SearchIndex/IndexService/IndexService.php
+++ b/src/Service/SearchIndex/IndexService/IndexService.php
@@ -105,6 +105,11 @@ final class IndexService implements IndexServiceInterface
 
         $elementId = $element->getId();
 
+        return $this->deleteFromSpecificIndex($indexName, $elementId);
+    }
+
+    public function deleteFromSpecificIndex(string $indexName, int $elementId): IndexService
+    {
         $this->bulkOperationService->addDeletion(
             $indexName,
             $elementId

--- a/src/Service/SearchIndex/IndexService/IndexServiceInterface.php
+++ b/src/Service/SearchIndex/IndexService/IndexServiceInterface.php
@@ -32,5 +32,7 @@ interface IndexServiceInterface
 
     public function deleteFromIndex(ElementInterface $element): IndexService;
 
+    public function deleteFromSpecificIndex(string $indexName, int $elementId): IndexService;
+
     public function updateAssetDependencies(Asset $asset): array;
 }


### PR DESCRIPTION
## Changes in this pull request
Resolves #201 

## Additional info
- elements were not deleted from index since they are not existing in Pimcore anymore
- pass correct operation to async queue updates