### PR TITLE
[Task] Disable roave/security due to a twig security issue and update upload-artifact to v4

### DIFF
--- a/.github/ci/files/config/packages/test/config.yaml
+++ b/.github/ci/files/config/packages/test/config.yaml
@@ -37,6 +37,13 @@ pimcore_open_search_client:
             hosts: ['%env(PIMCORE_OPEN_SEARCH_HOST)%']
 
 pimcore:
+    applicationlog:
+        mail_notification:
+            send_log_summary: false
+            filter_priority: 0
+            mail_receiver: ''
+        archive_treshold: '30'
+        archive_alternative_database: ''
     assets:
         metadata:
             predefined:

--- a/.github/ci/files/config/packages/test/config.yaml
+++ b/.github/ci/files/config/packages/test/config.yaml
@@ -37,13 +37,6 @@ pimcore_open_search_client:
             hosts: ['%env(PIMCORE_OPEN_SEARCH_HOST)%']
 
 pimcore:
-    applicationlog:
-        mail_notification:
-            send_log_summary: false
-            filter_priority: 0
-            mail_receiver: ''
-        archive_treshold: '30'
-        archive_alternative_database: ''
     assets:
         metadata:
             predefined:

--- a/.github/ci/files/config/system.yaml
+++ b/.github/ci/files/config/system.yaml
@@ -52,7 +52,7 @@ pimcore:
     applicationlog:
         mail_notification:
             send_log_summary: false
-            filter_priority: null
+            filter_priority: 0
             mail_receiver: ''
         archive_treshold: '30'
         archive_alternative_database: ''

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -60,7 +60,7 @@ jobs:
 
             - name: "Upload baseline file"
               if: ${{ failure() }}
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                   name: phpstan-baseline.neon
                   path: phpstan-baseline.neon

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     "symfony/messenger": "^6.4"
   },
   "require-dev": {
-    "roave/security-advisories": "dev-latest",
     "codeception/codeception": "^5.0.10",
     "codeception/phpunit-wrapper": "^9",
     "codeception/module-asserts": "^2",


### PR DESCRIPTION
## Changes in this pull request
Disabling security check due to https://github.com/pimcore/pimcore/issues/17582

Enabling it again when issue is resolved

actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.

https://github.com/actions/upload-artifact
