### PR TITLE
[BC] Change permission checks to `view` for `searchById`

### DIFF
--- a/src/Service/Search/SearchService/AbstractSearchHelper.php
+++ b/src/Service/Search/SearchService/AbstractSearchHelper.php
@@ -46,7 +46,8 @@ abstract class AbstractSearchHelper implements SearchHelperInterface
     public function addSearchRestrictions(
         SearchInterface $search,
         string $userPermission,
-        string $workspaceType
+        string $workspaceType,
+        PermissionTypes $permissionType = PermissionTypes::LIST
     ): SearchInterface {
         $user = $search->getUser();
         if (!$user) {
@@ -58,7 +59,7 @@ abstract class AbstractSearchHelper implements SearchHelperInterface
             $search->addModifier(new WorkspaceQuery(
                 $workspaceType,
                 $user,
-                PermissionTypes::LIST->value
+                $permissionType->value
             ));
         }
 

--- a/src/Service/Search/SearchService/Asset/AssetSearchService.php
+++ b/src/Service/Search/SearchService/Asset/AssetSearchService.php
@@ -51,8 +51,7 @@ final readonly class AssetSearchService implements AssetSearchServiceInterface
     public function search(
         SearchInterface $assetSearch,
         PermissionTypes $permissionType = PermissionTypes::LIST
-    ): AssetSearchResult
-    {
+    ): AssetSearchResult {
         $assetSearch = $this->searchHelper->addSearchRestrictions(
             search: $assetSearch,
             userPermission: UserPermissionTypes::ASSETS->value,

--- a/src/Service/Search/SearchService/Asset/AssetSearchService.php
+++ b/src/Service/Search/SearchService/Asset/AssetSearchService.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset;
 
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\UserPermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\AssetSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\AssetSearchResult;
@@ -47,12 +48,16 @@ final readonly class AssetSearchService implements AssetSearchServiceInterface
     /**
      * @throws AssetSearchException
      */
-    public function search(SearchInterface $assetSearch): AssetSearchResult
+    public function search(
+        SearchInterface $assetSearch,
+        PermissionTypes $permissionType = PermissionTypes::LIST
+    ): AssetSearchResult
     {
         $assetSearch = $this->searchHelper->addSearchRestrictions(
             search: $assetSearch,
             userPermission: UserPermissionTypes::ASSETS->value,
-            workspaceType: AssetWorkspace::WORKSPACE_TYPE
+            workspaceType: AssetWorkspace::WORKSPACE_TYPE,
+            permissionType: $permissionType
         );
 
         $searchResult = $this->searchHelper->performSearch(
@@ -124,6 +129,6 @@ final readonly class AssetSearchService implements AssetSearchServiceInterface
             $assetSearch->setUser($user);
         }
 
-        return $this->search($assetSearch)->getItems()[0] ?? null;
+        return $this->search($assetSearch, PermissionTypes::VIEW)->getItems()[0] ?? null;
     }
 }

--- a/src/Service/Search/SearchService/Asset/AssetSearchServiceInterface.php
+++ b/src/Service/Search/SearchService/Asset/AssetSearchServiceInterface.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\AssetSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\AssetSearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\AssetSearchResultItem;
@@ -27,7 +28,10 @@ interface AssetSearchServiceInterface
     /**
      * @throws AssetSearchException
      */
-    public function search(SearchInterface $assetSearch): AssetSearchResult;
+    public function search(
+        SearchInterface $assetSearch,
+        PermissionTypes $permissionType = PermissionTypes::LIST
+    ): AssetSearchResult;
 
     /**
      * @throws AssetSearchException

--- a/src/Service/Search/SearchService/DataObject/DataObjectSearchService.php
+++ b/src/Service/Search/SearchService/DataObject/DataObjectSearchService.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject;
 
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\UserPermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DataObjectSearchException;
@@ -48,14 +49,18 @@ final readonly class DataObjectSearchService implements DataObjectSearchServiceI
     /**
      * @throws DataObjectSearchException
      */
-    public function search(DataObjectSearchInterface $dataObjectSearch): DataObjectSearchResult
+    public function search(
+        DataObjectSearchInterface $dataObjectSearch,
+        PermissionTypes $permissionType = PermissionTypes::LIST
+    ): DataObjectSearchResult
     {
         $indexContext = $dataObjectSearch->getClassDefinition() ?: IndexName::DATA_OBJECT->value;
 
         $search = $this->searchHelper->addSearchRestrictions(
             search: $dataObjectSearch,
             userPermission: UserPermissionTypes::OBJECTS->value,
-            workspaceType: DataObjectWorkspace::WORKSPACE_TYPE
+            workspaceType: DataObjectWorkspace::WORKSPACE_TYPE,
+            permissionType: $permissionType
         );
 
         $searchResult = $this->searchHelper->performSearch(
@@ -127,6 +132,6 @@ final readonly class DataObjectSearchService implements DataObjectSearchServiceI
             $dataObjectSearch->setUser($user);
         }
 
-        return $this->search($dataObjectSearch)->getItems()[0] ?? null;
+        return $this->search($dataObjectSearch, PermissionTypes::VIEW)->getItems()[0] ?? null;
     }
 }

--- a/src/Service/Search/SearchService/DataObject/DataObjectSearchService.php
+++ b/src/Service/Search/SearchService/DataObject/DataObjectSearchService.php
@@ -52,8 +52,7 @@ final readonly class DataObjectSearchService implements DataObjectSearchServiceI
     public function search(
         DataObjectSearchInterface $dataObjectSearch,
         PermissionTypes $permissionType = PermissionTypes::LIST
-    ): DataObjectSearchResult
-    {
+    ): DataObjectSearchResult {
         $indexContext = $dataObjectSearch->getClassDefinition() ?: IndexName::DATA_OBJECT->value;
 
         $search = $this->searchHelper->addSearchRestrictions(

--- a/src/Service/Search/SearchService/DataObject/DataObjectSearchServiceInterface.php
+++ b/src/Service/Search/SearchService/DataObject/DataObjectSearchServiceInterface.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DataObjectSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\SearchResult\DataObjectSearchResult;
@@ -27,7 +28,10 @@ interface DataObjectSearchServiceInterface
     /**
      * @throws DataObjectSearchException
      */
-    public function search(DataObjectSearchInterface $dataObjectSearch): DataObjectSearchResult;
+    public function search(
+        DataObjectSearchInterface $dataObjectSearch,
+        PermissionTypes $permissionType = PermissionTypes::LIST
+    ): DataObjectSearchResult;
 
     /**
      * @throws DataObjectSearchException

--- a/src/Service/Search/SearchService/Document/DocumentSearchService.php
+++ b/src/Service/Search/SearchService/Document/DocumentSearchService.php
@@ -51,8 +51,7 @@ final readonly class DocumentSearchService implements DocumentSearchServiceInter
     public function search(
         SearchInterface $documentSearch,
         PermissionTypes $permissionType = PermissionTypes::LIST
-    ): DocumentSearchResult
-    {
+    ): DocumentSearchResult {
         $documentSearch = $this->searchHelper->addSearchRestrictions(
             search: $documentSearch,
             userPermission: UserPermissionTypes::DOCUMENTS->value,

--- a/src/Service/Search/SearchService/Document/DocumentSearchService.php
+++ b/src/Service/Search/SearchService/Document/DocumentSearchService.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document;
 
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\UserPermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DocumentSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult\DocumentSearchResult;
@@ -47,12 +48,16 @@ final readonly class DocumentSearchService implements DocumentSearchServiceInter
     /**
      * @throws DocumentSearchException
      */
-    public function search(SearchInterface $documentSearch): DocumentSearchResult
+    public function search(
+        SearchInterface $documentSearch,
+        PermissionTypes $permissionType = PermissionTypes::LIST
+    ): DocumentSearchResult
     {
         $documentSearch = $this->searchHelper->addSearchRestrictions(
             search: $documentSearch,
             userPermission: UserPermissionTypes::DOCUMENTS->value,
-            workspaceType: DocumentWorkspace::WORKSPACE_TYPE
+            workspaceType: DocumentWorkspace::WORKSPACE_TYPE,
+            permissionType: $permissionType
         );
 
         $searchResult = $this->searchHelper->performSearch(
@@ -124,6 +129,6 @@ final readonly class DocumentSearchService implements DocumentSearchServiceInter
             $documentSearch->setUser($user);
         }
 
-        return $this->search($documentSearch)->getItems()[0] ?? null;
+        return $this->search($documentSearch, PermissionTypes::VIEW)->getItems()[0] ?? null;
     }
 }

--- a/src/Service/Search/SearchService/Document/DocumentSearchServiceInterface.php
+++ b/src/Service/Search/SearchService/Document/DocumentSearchServiceInterface.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DocumentSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult\DocumentSearchResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult\DocumentSearchResultItem;
@@ -27,7 +28,10 @@ interface DocumentSearchServiceInterface
     /**
      * @throws DocumentSearchException
      */
-    public function search(SearchInterface $documentSearch): DocumentSearchResult;
+    public function search(
+        SearchInterface $documentSearch,
+        PermissionTypes $permissionType = PermissionTypes::LIST
+    ): DocumentSearchResult;
 
     /**
      * @throws DocumentSearchException

--- a/src/Service/Search/SearchService/Element/ElementSearchHelperInterface.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchHelperInterface.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
@@ -25,7 +26,10 @@ use Pimcore\Model\User;
  */
 interface ElementSearchHelperInterface
 {
-    public function addSearchRestrictions(SearchInterface $search): SearchInterface;
+    public function addSearchRestrictions(
+        SearchInterface $search,
+        PermissionTypes $permissionType = PermissionTypes::LIST
+    ): SearchInterface;
 
     public function performSearch(SearchInterface $search, string $indexName): SearchResult;
 

--- a/src/Service/Search/SearchService/Element/ElementSearchService.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchService.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
 
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\ElementSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\SearchResult\ElementSearchResult;
@@ -44,9 +45,12 @@ final readonly class ElementSearchService implements ElementSearchServiceInterfa
     ) {
     }
 
-    public function search(SearchInterface $elementSearch): ElementSearchResult
+    public function search(
+        SearchInterface $elementSearch,
+        PermissionTypes $permissionType = PermissionTypes::LIST
+    ): ElementSearchResult
     {
-        $elementSearch = $this->searchHelper->addSearchRestrictions($elementSearch);
+        $elementSearch = $this->searchHelper->addSearchRestrictions($elementSearch, $permissionType);
 
         $searchResult = $this->searchHelper->performSearch(
             $elementSearch,

--- a/src/Service/Search/SearchService/Element/ElementSearchService.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchService.php
@@ -48,8 +48,7 @@ final readonly class ElementSearchService implements ElementSearchServiceInterfa
     public function search(
         SearchInterface $elementSearch,
         PermissionTypes $permissionType = PermissionTypes::LIST
-    ): ElementSearchResult
-    {
+    ): ElementSearchResult {
         $elementSearch = $this->searchHelper->addSearchRestrictions($elementSearch, $permissionType);
 
         $searchResult = $this->searchHelper->performSearch(

--- a/src/Service/Search/SearchService/Element/ElementSearchServiceInterface.php
+++ b/src/Service/Search/SearchService/Element/ElementSearchServiceInterface.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Element;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\ElementSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Element\SearchResult\ElementSearchResult;
@@ -28,7 +29,10 @@ interface ElementSearchServiceInterface
     /**
      * @throws ElementSearchException
      */
-    public function search(SearchInterface $elementSearch): ElementSearchResult;
+    public function search(
+        SearchInterface $elementSearch,
+        PermissionTypes $permissionType = PermissionTypes::LIST
+    ): ElementSearchResult;
 
     /**
      * @throws ElementSearchException

--- a/src/Service/Search/SearchService/Element/SearchHelper.php
+++ b/src/Service/Search/SearchService/Element/SearchHelper.php
@@ -45,7 +45,10 @@ final readonly class SearchHelper implements ElementSearchHelperInterface
     ) {
     }
 
-    public function addSearchRestrictions(SearchInterface $search): SearchInterface
+    public function addSearchRestrictions(
+        SearchInterface $search,
+        PermissionTypes $permissionType = PermissionTypes::LIST
+    ): SearchInterface
     {
         $user = $search->getUser();
         if (!$user) {
@@ -55,7 +58,7 @@ final readonly class SearchHelper implements ElementSearchHelperInterface
         if (!$user->isAdmin()) {
             $search->addModifier(new ElementWorkspacesQuery(
                 $user,
-                PermissionTypes::LIST->value
+                $permissionType->value
             ));
         }
 

--- a/src/Service/Search/SearchService/Element/SearchHelper.php
+++ b/src/Service/Search/SearchService/Element/SearchHelper.php
@@ -48,8 +48,7 @@ final readonly class SearchHelper implements ElementSearchHelperInterface
     public function addSearchRestrictions(
         SearchInterface $search,
         PermissionTypes $permissionType = PermissionTypes::LIST
-    ): SearchInterface
-    {
+    ): SearchInterface {
         $user = $search->getUser();
         if (!$user) {
             return $search;

--- a/src/Service/Search/SearchService/SearchHelperInterface.php
+++ b/src/Service/Search/SearchService/SearchHelperInterface.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
@@ -30,7 +31,8 @@ interface SearchHelperInterface
     public function addSearchRestrictions(
         SearchInterface $search,
         string $userPermission,
-        string $workspaceType
+        string $workspaceType,
+        PermissionTypes $permissionType
     ): SearchInterface;
 
     public function performSearch(SearchInterface $search, string $indexName): SearchResult;


### PR DESCRIPTION
## Changes in this pull request
Resolves #221 

## Additional info
Permission check for searchById is now `view` instead of `list`