### PR TITLE
[Bug] Add prefixes for class definition indexes

### DIFF
--- a/src/Service/SearchIndex/GlobalIndexAliasService.php
+++ b/src/Service/SearchIndex/GlobalIndexAliasService.php
@@ -140,7 +140,7 @@ final readonly class GlobalIndexAliasService implements GlobalIndexAliasServiceI
         $classes = $this->connection->fetchFirstColumn('select name from classes');
 
         return array_map(function (string $class) {
-            return $this->searchIndexConfigService->getIndexName($class);
+            return $this->searchIndexConfigService->getIndexName($class, true);
         }, $classes);
     }
 

--- a/src/Service/SearchIndex/IndexEntityService.php
+++ b/src/Service/SearchIndex/IndexEntityService.php
@@ -34,10 +34,17 @@ final readonly class IndexEntityService implements IndexEntityServiceInterface
 
     public function getByEntityName(string $entityName): IndexEntity
     {
+        $isClass = false;
+        $indexType = $this->getIndexType($entityName);
+
+        if ($indexType === IndexType::DATA_OBJECT) {
+            $isClass = $this->elementService->classDefinitionExists($entityName);
+        }
+
         return new IndexEntity(
             $entityName,
-            $this->searchIndexConfigService->getIndexName($entityName),
-            $this->getIndexType($entityName)
+            $this->searchIndexConfigService->getIndexName($entityName, $isClass),
+            $indexType
         );
     }
 

--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -25,6 +25,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\UpdateFolderIndexDataEvent;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\UpdateIndexDataEvent;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\UpdateIndexDataEventInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigService;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Serializer\Normalizer\DataObjectNormalizer;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\ClassDefinition;
@@ -38,8 +39,6 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
 {
-    private const CLASS_INDEX_PREFIX = 'data-object_';
-
     public function __construct(
         private readonly DataObjectNormalizer $normalizer,
         private readonly Connection $dbConnection,
@@ -67,7 +66,7 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
     public function getIndexNameShort(mixed $context): string
     {
         return match (true) {
-            $context instanceof ClassDefinition => self::CLASS_INDEX_PREFIX . $context->getName(),
+            $context instanceof ClassDefinition => SearchIndexConfigService::CLASS_INDEX_PREFIX . $context->getName(),
             $context === IndexName::DATA_OBJECT->value => $context,
             default => IndexName::DATA_OBJECT_FOLDER->value,
         };
@@ -76,7 +75,7 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
     public function getIndexNameByClassDefinition(ClassDefinition $classDefinition): string
     {
         return $this->searchIndexConfigService->getIndexName(
-            self::CLASS_INDEX_PREFIX . $classDefinition->getName()
+            SearchIndexConfigService::CLASS_INDEX_PREFIX . $classDefinition->getName()
         );
     }
 

--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -38,6 +38,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
 {
+    private const CLASS_INDEX_PREFIX = 'data-object_';
+
     public function __construct(
         private readonly DataObjectNormalizer $normalizer,
         private readonly Connection $dbConnection,
@@ -65,7 +67,7 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
     public function getIndexNameShort(mixed $context): string
     {
         return match (true) {
-            $context instanceof ClassDefinition => $context->getName(),
+            $context instanceof ClassDefinition => self::CLASS_INDEX_PREFIX . $context->getName(),
             $context === IndexName::DATA_OBJECT->value => $context,
             default => IndexName::DATA_OBJECT_FOLDER->value,
         };
@@ -73,7 +75,9 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
 
     public function getIndexNameByClassDefinition(ClassDefinition $classDefinition): string
     {
-        return $this->searchIndexConfigService->getIndexName($classDefinition->getName());
+        return $this->searchIndexConfigService->getIndexName(
+            self::CLASS_INDEX_PREFIX . $classDefinition->getName()
+        );
     }
 
     public function getElementType(): string

--- a/src/Service/SearchIndex/SearchIndexConfigService.php
+++ b/src/Service/SearchIndex/SearchIndexConfigService.php
@@ -33,6 +33,8 @@ final class SearchIndexConfigService implements SearchIndexConfigServiceInterfac
 
     public const SYSTEM_FIELD_DATA_OBJECT = 'data_object';
 
+    public const CLASS_INDEX_PREFIX = 'data-object_';
+
     public function __construct(
         private readonly string $indexPrefix,
         private readonly array $indexSettings,
@@ -44,8 +46,12 @@ final class SearchIndexConfigService implements SearchIndexConfigServiceInterfac
     /**
      * returns index name for given class name
      */
-    public function getIndexName(string $name): string
+    public function getIndexName(string $name, bool $isClass = false): string
     {
+        if ($isClass) {
+            return $this->getIndexPrefix() . self::CLASS_INDEX_PREFIX . strtolower($name);
+        }
+
         return $this->getIndexPrefix() . strtolower($name);
     }
 

--- a/src/Service/SearchIndex/SearchIndexConfigServiceInterface.php
+++ b/src/Service/SearchIndex/SearchIndexConfigServiceInterface.php
@@ -24,7 +24,7 @@ interface SearchIndexConfigServiceInterface
     /**
      * returns index name for given class name
      */
-    public function getIndexName(string $name): string;
+    public function getIndexName(string $name, bool $isClass = false): string;
 
     public function prefixIndexName(string $indexName): string;
 

--- a/tests/Functional/SearchIndex/DataObjectBasicTest.php
+++ b/tests/Functional/SearchIndex/DataObjectBasicTest.php
@@ -17,11 +17,9 @@ namespace Functional\SearchIndex;
 
 use Exception;
 use OpenSearch\Common\Exceptions\Missing404Exception;
-use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\DataObjectSearchServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\ElementTypeAdapter\DataObjectTypeAdapter;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SettingsStoreServiceInterface;
 use Pimcore\Db;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Input;

--- a/tests/Functional/SearchIndex/DataObjectBasicTest.php
+++ b/tests/Functional/SearchIndex/DataObjectBasicTest.php
@@ -15,10 +15,12 @@
 
 namespace Functional\SearchIndex;
 
+use Exception;
 use OpenSearch\Common\Exceptions\Missing404Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\DataObjectSearchServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\ElementTypeAdapter\DataObjectTypeAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SettingsStoreServiceInterface;
 use Pimcore\Db;
@@ -34,13 +36,11 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
      */
     protected $tester;
 
-    private SearchIndexConfigServiceInterface $searchIndexConfigService;
+    private DataObjectTypeAdapter $dataObjectTypeAdapter;
 
     protected function _before()
     {
-        $this->searchIndexConfigService = $this->tester->grabService(
-            SearchIndexConfigServiceInterface::class
-        );
+        $this->dataObjectTypeAdapter = $this->tester->grabService(DataObjectTypeAdapter::class);
         $this->tester->enableSynchronousProcessing();
         $this->tester->clearQueue();
     }
@@ -55,10 +55,14 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
     }
 
     // tests
+
+    /**
+     * @throws Exception
+     */
     public function testIndexingWithInheritanceSynchronous()
     {
         $object = $this->createObjectWithInheritance();
-        $indexName = $this->searchIndexConfigService->getIndexName($object->getClassName());
+        $indexName = $this->dataObjectTypeAdapter->getAliasIndexName($object->getClass());
 
         // check indexed
         $response = $this->tester->checkIndexEntry($object->getId(), $indexName);
@@ -81,7 +85,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
         $this->tester->disableSynchronousProcessing();
         // create object
         $object = $this->createObjectWithInheritance();
-        $indexName = $this->searchIndexConfigService->getIndexName($object->getClassName());
+        $indexName = $this->dataObjectTypeAdapter->getAliasIndexName($object->getClass());
 
         // check indexed
         $this->expectException(Missing404Exception::class);
@@ -102,7 +106,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
     {
         $object = TestHelper::createEmptyObject();
         $this->assertFalse($object->getClass()->getAllowInherit());
-        $indexName = $this->searchIndexConfigService->getIndexName($object->getClassName());
+        $indexName = $this->dataObjectTypeAdapter->getAliasIndexName($object->getClass());
 
         // check indexed
         $response = $this->tester->checkIndexEntry($object->getId(), $indexName);
@@ -126,7 +130,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
         // create object
         $object = TestHelper::createEmptyObject();
         $this->assertFalse($object->getClass()->getAllowInherit());
-        $indexName = $this->searchIndexConfigService->getIndexName($object->getClassName());
+        $indexName = $this->dataObjectTypeAdapter->getAliasIndexName($object->getClass());
 
         // check indexed
         $this->expectException(Missing404Exception::class);
@@ -146,7 +150,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
     public function testFolderIndexing()
     {
         $object = TestHelper::createObjectFolder();
-        $indexName = $this->searchIndexConfigService->getIndexName(IndexName::DATA_OBJECT_FOLDER->value);
+        $indexName = $this->dataObjectTypeAdapter->getAliasIndexName();
 
         // check indexed
         $response = $this->tester->checkIndexEntry($object->getId(), $indexName);
@@ -155,7 +159,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
         $object->setKey('my-test-folder');
         $object->save();
 
-        $indexName = $this->searchIndexConfigService->getIndexName(IndexName::DATA_OBJECT_FOLDER->value);
+        $indexName = $this->dataObjectTypeAdapter->getAliasIndexName();
         $response = $this->tester->checkIndexEntry($object->getId(), $indexName);
         $this->assertEquals('my-test-folder', $response['_source']['system_fields']['key']);
 
@@ -222,8 +226,8 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
     public function testClassDefinitionMapping(): void
     {
         $object = TestHelper::createEmptyObject('', true, true, MappingTest::class);
-        $index = $this->searchIndexConfigService->getIndexName($object->getClassName());
         $class = $object->getClass();
+        $index = $this->dataObjectTypeAdapter->getAliasIndexName($class);
         $originalFields = $class->getFieldDefinitions();
 
         $input = new Input();
@@ -232,8 +236,9 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
         $class->save();
         $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
 
-        $indexName = $this->tester->getIndexName($object->getClassName());
+        $indexName = $this->tester->getIndexName($class->getName(), true);
         $mapping = $this->tester->getIndexMapping($index);
+
         $standardFields = $mapping[$indexName]['mappings']['properties']['standard_fields']['properties'];
         $this->assertArrayHasKey('mappingTest', $standardFields);
 
@@ -241,7 +246,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
         $class->save();
         $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
 
-        $indexName = $this->tester->getIndexName($object->getClassName());
+        $indexName = $this->tester->getIndexName($class->getName(), true);
         $mapping = $this->tester->getIndexMapping($index);
         $standardFields = $mapping[$indexName]['mappings']['properties']['standard_fields']['properties'];
         $this->assertArrayNotHasKey('mappingTest', $standardFields);
@@ -265,7 +270,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
 
         $this->tester->runCommand('messenger:consume', ['--limit'=>1], ['pimcore_generic_data_index_queue']);
 
-        $indexName = $this->tester->getIndexName($object->getClassName());
+        $indexName = $this->dataObjectTypeAdapter->getAliasIndexName($class);
         $response = $this->tester->checkIndexEntry($object->getId(), $indexName);
         $updatedIcon = $response['_source']['system_fields']['classDefinitionIcon'];
 
@@ -291,7 +296,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
         $class->save();
         $object->save();
 
-        $this->assertTrue($object->getClass()->getAllowInherit());
+        $this->assertTrue($class->getAllowInherit());
 
         return $object;
     }

--- a/tests/Functional/SearchIndex/IndexQueueTest.php
+++ b/tests/Functional/SearchIndex/IndexQueueTest.php
@@ -152,7 +152,7 @@ class IndexQueueTest extends Unit
         $object = TestHelper::createEmptyObject('', false);
         $this->checkAndDeleteElement(
             $object,
-            $this->searchIndexConfigService->getIndexName($object->getClassName())
+            $this->searchIndexConfigService->getIndexName($object->getClassName(), true)
         );
     }
 

--- a/tests/Support/Helper/GenericDataIndex.php
+++ b/tests/Support/Helper/GenericDataIndex.php
@@ -209,10 +209,10 @@ class GenericDataIndex extends \Codeception\Module
         );
     }
 
-    public function getIndexName(string $name): string
+    public function getIndexName(string $name, bool $isClass = false): string
     {
         $searchIndexConfigService = $this->grabService(SearchIndexConfigServiceInterface::class);
-        $indexName = $searchIndexConfigService->getIndexName($name);
+        $indexName = $searchIndexConfigService->getIndexName($name, $isClass);
         $client = $this->getIndexSearchClient();
         $alias = $client->indices()->getAlias([
             'name' => $indexName,


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/generic-data-index-bundle/issues/216

## Additional info
Add prefix for indexes of class definitions to avoid collisions with other indexes which have share the class definition name

