### PR TITLE
[Bug] Add missing normalize methods to containers

### DIFF
--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/BlockAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/BlockAdapter.php
@@ -59,21 +59,20 @@ final class BlockAdapter extends AbstractAdapter
             throw new InvalidArgumentException('FieldDefinition must be an instance of ' . Block::class);
         }
         $fieldDefinitions = $fieldDefinition->getFieldDefinitions();
-            foreach ($value as $block) {
-                $resultItem = [];
+        foreach ($value as $block) {
+            $resultItem = [];
 
-                /** @var BlockElement $fieldValue */
-                foreach ($block as $key => $fieldValue) {
-                    $blockDefinition = $fieldDefinitions[$key];
-                    $resultItems[$key] = $this->fieldDefinitionService->normalizeValue(
-                        $blockDefinition,
-                        $fieldValue->getData()
-                    );
-                }
-
-                $resultItems[] = $resultItem;
+            /** @var BlockElement $fieldValue */
+            foreach ($block as $key => $fieldValue) {
+                $blockDefinition = $fieldDefinitions[$key];
+                $resultItems[$key] = $this->fieldDefinitionService->normalizeValue(
+                    $blockDefinition,
+                    $fieldValue->getData()
+                );
             }
 
+            $resultItems[] = $resultItem;
+        }
 
         return $resultItems;
     }

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/BlockAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/BlockAdapter.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Da
 
 use InvalidArgumentException;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Block;
+use Pimcore\Model\DataObject\Data\BlockElement;
 
 /**
  * @internal
@@ -44,5 +45,36 @@ final class BlockAdapter extends AbstractAdapter
             'type' => 'nested',
             'properties' => $properties,
         ];
+    }
+
+    public function normalize(mixed $value): ?array
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+
+        $resultItems = [];
+        $fieldDefinition = $this->getFieldDefinition();
+        if (!$fieldDefinition instanceof Block) {
+            throw new InvalidArgumentException('FieldDefinition must be an instance of ' . Block::class);
+        }
+        $fieldDefinitions = $fieldDefinition->getFieldDefinitions();
+            foreach ($value as $block) {
+                $resultItem = [];
+
+                /** @var BlockElement $fieldValue */
+                foreach ($block as $key => $fieldValue) {
+                    $blockDefinition = $fieldDefinitions[$key];
+                    $resultItems[$key] = $this->fieldDefinitionService->normalizeValue(
+                        $blockDefinition,
+                        $fieldValue->getData()
+                    );
+                }
+
+                $resultItems[] = $resultItem;
+            }
+
+
+        return $resultItems;
     }
 }

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapter.php
@@ -179,8 +179,8 @@ final class ClassificationStoreAdapter extends AbstractAdapter
                 $key->getKeyId(),
                 $language,
                 true,
-                true)
-            ;
+                true
+            );
         } catch (Exception $exception) {
             $this->logger->warning(sprintf(
                 'Could not get localized value for key %s in group %s: %s',

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapter.php
@@ -19,10 +19,14 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Da
 use Exception;
 use InvalidArgumentException;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\OpenSearch\AttributeType;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\MappingProperty;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\LanguageServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Traits\LoggerAwareTrait;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassificationStore\ServiceResolverInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore;
+use Pimcore\Model\DataObject\Classificationstore as ClassificationstoreModel;
+use Pimcore\Model\DataObject\Classificationstore\DefinitionCache;
 use Pimcore\Model\DataObject\Classificationstore\GroupConfig;
 use Pimcore\Model\DataObject\Classificationstore\GroupConfig\Listing as GroupListing;
 use Pimcore\Model\DataObject\Classificationstore\KeyGroupRelation;
@@ -37,6 +41,7 @@ final class ClassificationStoreAdapter extends AbstractAdapter
     use LoggerAwareTrait;
 
     private ServiceResolverInterface $classificationService;
+    private LanguageServiceInterface $languageService;
 
     #[Required]
     public function setClassificationService(ServiceResolverInterface $serviceResolver): void
@@ -64,6 +69,50 @@ final class ClassificationStoreAdapter extends AbstractAdapter
             'type' => AttributeType::NESTED,
             'properties' => $mapping,
         ];
+    }
+
+    public function normalize(mixed $value): ?array
+    {
+        if (!$value instanceof ClassificationstoreModel) {
+            return null;
+        }
+
+        $validLanguages = $this->getValidLanguages();
+        $resultItems = [];
+
+        foreach ($this->getActiveGroups($value) as $groupId => $groupConfig) {
+            $resultItems[$groupConfig->getName()] = [];
+            $keys = $this->getClassificationStoreKeysFromGroup($groupConfig);
+            foreach ($validLanguages as $validLanguage) {
+                foreach ($keys as $key) {
+                    $normalizedValue = $this->getNormalizedValue($value, $groupId, $key, $validLanguage);
+
+                    if ($normalizedValue !== null) {
+                        $resultItems[$groupConfig->getName()][$validLanguage][$key->getName()] = $normalizedValue;
+                    }
+                }
+            }
+        }
+
+        return $resultItems;
+    }
+
+    /**
+     * @return GroupConfig[]
+     */
+    private function getActiveGroups(ClassificationstoreModel $value): array
+    {
+        $groups = [];
+        foreach ($value->getActiveGroups() as $groupId => $active) {
+            if ($active) {
+                $groupConfig = GroupConfig::getById($groupId);
+                if ($groupConfig) {
+                    $groups[$groupId] = $groupConfig;
+                }
+            }
+        }
+
+        return $groups;
     }
 
     /**
@@ -115,5 +164,50 @@ final class ClassificationStoreAdapter extends AbstractAdapter
         $listing->addConditionParam('groupId = ?', $groupConfig->getId());
 
         return $listing->getList();
+    }
+
+    private function getNormalizedValue(
+        ClassificationstoreModel $classificationstore,
+        int $groupId,
+        KeyGroupRelation $key,
+        string $language
+    ): mixed {
+        try {
+            $value = $classificationstore->getLocalizedKeyValue(
+                $groupId,
+                $key->getKeyId(),
+                $language,
+                true,
+                true)
+            ;
+        } catch (Exception $exception) {
+            $this->logger->warning(sprintf(
+                'Could not get localized value for key %s in group %s: %s',
+                $key->getKeyId(),
+                $groupId,
+                $exception->getMessage()
+            ));
+            return null;
+        }
+
+        $keyConfig = DefinitionCache::get($key->getKeyId());
+        if ($keyConfig === null) {
+            return null;
+        }
+
+        $fieldDefinition = $this->classificationService->getFieldDefinitionFromKeyConfig($keyConfig);
+
+        return $this->fieldDefinitionService->normalizeValue($fieldDefinition, $value);
+    }
+    
+    private function getValidLanguages(): array
+    {
+        return array_merge([MappingProperty::NOT_LOCALIZED_KEY], $this->languageService->getValidLanguages());
+    }
+
+    #[Required]
+    public function setLanguageService(LanguageServiceInterface $languageService): void
+    {
+        $this->languageService = $languageService;
     }
 }

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapter.php
@@ -41,6 +41,7 @@ final class ClassificationStoreAdapter extends AbstractAdapter
     use LoggerAwareTrait;
 
     private ServiceResolverInterface $classificationService;
+
     private LanguageServiceInterface $languageService;
 
     #[Required]
@@ -187,6 +188,7 @@ final class ClassificationStoreAdapter extends AbstractAdapter
                 $groupId,
                 $exception->getMessage()
             ));
+
             return null;
         }
 
@@ -199,7 +201,7 @@ final class ClassificationStoreAdapter extends AbstractAdapter
 
         return $this->fieldDefinitionService->normalizeValue($fieldDefinition, $value);
     }
-    
+
     private function getValidLanguages(): array
     {
         return array_merge([MappingProperty::NOT_LOCALIZED_KEY], $this->languageService->getValidLanguages());

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/ObjectBrickAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/ObjectBrickAdapter.php
@@ -17,14 +17,19 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\DataObject\FieldDefinitionAdapter;
 
 use InvalidArgumentException;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\Objectbrick\DefinitionResolverInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks;
 use Pimcore\Model\DataObject\Objectbrick;
+use Pimcore\Model\DataObject\Objectbrick\Data\AbstractData;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @internal
  */
 final class ObjectBrickAdapter extends AbstractAdapter
 {
+    private DefinitionResolverInterface $objectBrickDefinition;
+    
     public function getIndexMapping(): array
     {
         $objectBricks = $this->getFieldDefinition();
@@ -44,9 +49,43 @@ final class ObjectBrickAdapter extends AbstractAdapter
         ];
     }
 
+    public function normalize(mixed $value): ?array
+    {
+        if (!$value instanceof Objectbrick) {
+            return null;
+        }
+
+        $resultItems = [];
+        $items = $value->getObjectVars();
+        foreach ($items as $item) {
+            if (!$item instanceof AbstractData) {
+                continue;
+            }
+
+            $type = $item->getType();
+            $resultItems[$type] = [];
+            $definition = $this->objectBrickDefinition->getByKey($type);
+            if ($definition === null) {
+                continue;
+            }
+
+            $resultItems[$type] = [];
+            foreach ($definition->getFieldDefinitions() as $fieldDefinition) {
+                $getter = 'get' . ucfirst($fieldDefinition->getName());
+                $value = $item->$getter();
+                $resultItems[$fieldDefinition->getName()] = $this->fieldDefinitionService->normalizeValue(
+                    $fieldDefinition,
+                    $value
+                );
+            }
+        }
+
+        return $resultItems;
+    }
+
     private function getMappingForObjectBrick(string $objectBrickType): array
     {
-        $fieldDefinitions = Objectbrick\Definition::getByKey($objectBrickType)?->getFieldDefinitions();
+        $fieldDefinitions = $this->objectBrickDefinition->getByKey($objectBrickType)?->getFieldDefinitions();
         $mapping = [];
         foreach ($fieldDefinitions as $fieldDefinition) {
             $adapter = $this->getFieldDefinitionService()->getFieldDefinitionAdapter($fieldDefinition);
@@ -56,5 +95,11 @@ final class ObjectBrickAdapter extends AbstractAdapter
         }
 
         return $mapping;
+    }
+
+    #[Required]
+    public function setObjectBrickDefinition(DefinitionResolverInterface $definitionResolver): void
+    {
+        $this->objectBrickDefinition = $definitionResolver;
     }
 }

--- a/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/ObjectBrickAdapter.php
+++ b/src/SearchIndexAdapter/OpenSearch/DataObject/FieldDefinitionAdapter/ObjectBrickAdapter.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 final class ObjectBrickAdapter extends AbstractAdapter
 {
     private DefinitionResolverInterface $objectBrickDefinition;
-    
+
     public function getIndexMapping(): array
     {
         $objectBricks = $this->getFieldDefinition();


### PR DESCRIPTION
## Changes in this pull request
Resolves #233

## Additional info
Add custom normalizer to some of the containers:

- object bricks
- blocks
- classification store

follow up after: 
https://github.com/pimcore/generic-data-index-bundle/pull/228