### PR TITLE
[Bug] Wring index name passed for data objects deletion

### DIFF
--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -163,22 +163,21 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
             return null;
         }
 
-        if ($operation === IndexQueueOperation::UPDATE->value) {
-            return $this->dbConnection->createQueryBuilder()
-                ->select($this->getSelectArrayByOperation($element, $operation, $operationTime))
-                ->setMaxResults(1)
-                ->from('objects')
-                ->where('id = :id')
-                ->setParameter('id', $element->getId());
+        $queryBuilder = $this->dbConnection->createQueryBuilder()
+            ->select($this->getSelectParametersByOperation($element, $operation, $operationTime))
+            ->setMaxResults(1);
+
+        if ($operation === IndexQueueOperation::DELETE->value) {
+            return $queryBuilder->from('DUAL');
         }
 
-        return $this->dbConnection->createQueryBuilder()
-            ->select($this->getSelectArrayByOperation($element, $operation, $operationTime))
-            ->setMaxResults(1)
-            ->from('DUAL');
+        return $queryBuilder
+            ->from('objects')
+            ->where('id = :id')
+            ->setParameter('id', $element->getId());
     }
 
-    private function getSelectArrayByOperation(Concrete $element, string $operation, int $operationTime): array
+    private function getSelectParametersByOperation(Concrete $element, string $operation, int $operationTime): array
     {
         $classId = 'className';
         if ($operation === IndexQueueOperation::DELETE->value) {

--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -158,8 +158,7 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
         string $operation,
         int $operationTime,
         bool $includeElement = false
-    ): ?QueryBuilder
-    {
+    ): ?QueryBuilder {
         if (!$includeElement) {
             return null;
         }

--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -22,6 +22,7 @@ use Exception;
 use InvalidArgumentException;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexQueueOperation;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\UpdateFolderIndexDataEvent;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\DataObject\UpdateIndexDataEvent;
 use Pimcore\Bundle\GenericDataIndexBundle\Event\UpdateIndexDataEventInterface;
@@ -105,22 +106,10 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
         }
 
         if (!$element->getClass()->getAllowInherit()) {
-            if ($includeElement) {
-                return $this->dbConnection->createQueryBuilder()
-                    ->select([
-                        $element->getId(),
-                        "'" . ElementType::DATA_OBJECT->value . "'",
-                        'className',
-                        "'$operation'",
-                        "'$operationTime'",
-                        '0',
-                    ])
-                    ->from('objects') // just a dummy query to fit into the query builder interface
-                    ->where('id = :id')
-                    ->setMaxResults(1)
-                    ->setParameter('id', $element->getId());
-            }
+            return $this->getRelatedItemsQueryBuilder($element, $operation, $operationTime, $includeElement);
+        }
 
+        if ($operation !== IndexQueueOperation::UPDATE->value) {
             return null;
         }
 
@@ -162,5 +151,48 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
         }
 
         throw new InvalidArgumentException('Element must be instance of ' . AbstractObject::class);
+    }
+
+    private function getRelatedItemsQueryBuilder(
+        Concrete $element,
+        string $operation,
+        int $operationTime,
+        bool $includeElement = false
+    ): ?QueryBuilder
+    {
+        if (!$includeElement) {
+            return null;
+        }
+
+        if ($operation === IndexQueueOperation::UPDATE->value) {
+            return $this->dbConnection->createQueryBuilder()
+                ->select($this->getSelectArrayByOperation($element, $operation, $operationTime))
+                ->setMaxResults(1)
+                ->from('objects')
+                ->where('id = :id')
+                ->setParameter('id', $element->getId());
+        }
+
+        return $this->dbConnection->createQueryBuilder()
+            ->select($this->getSelectArrayByOperation($element, $operation, $operationTime))
+            ->setMaxResults(1)
+            ->from('DUAL');
+    }
+
+    private function getSelectArrayByOperation(Concrete $element, string $operation, int $operationTime): array
+    {
+        $classId = 'className';
+        if ($operation === IndexQueueOperation::DELETE->value) {
+            $classId = "'" . $element->getClassId() . "'";
+        }
+
+        return [
+            $element->getId(),
+            "'" . ElementType::DATA_OBJECT->value . "'",
+            $classId,
+            "'$operation'",
+            "'$operationTime'",
+            '0',
+        ];
     }
 }

--- a/tests/Functional/SearchIndex/IndexQueueTest.php
+++ b/tests/Functional/SearchIndex/IndexQueueTest.php
@@ -133,6 +133,7 @@ class IndexQueueTest extends Unit
         $result = $this->tester->checkIndexEntry($asset->getId(), $indexName);
         $this->assertEquals($asset->getId(), $result['_source']['system_fields']['id']);
     }
+
     /**
      * @throws Exception
      */

--- a/tests/Functional/SearchIndex/IndexQueueTest.php
+++ b/tests/Functional/SearchIndex/IndexQueueTest.php
@@ -133,38 +133,55 @@ class IndexQueueTest extends Unit
         $result = $this->tester->checkIndexEntry($asset->getId(), $indexName);
         $this->assertEquals($asset->getId(), $result['_source']['system_fields']['id']);
     }
+    /**
+     * @throws Exception
+     */
+    public function testAssetDeleteWithQueue(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $assetIndex = $this->searchIndexConfigService->getIndexName(self::ASSET_INDEX_NAME);
+        $this->consume();
+
+        $this->checkAndDeleteElement($asset, $assetIndex);
+        $this->consume();
+
+        $this->tester->checkDeletedIndexEntry($asset->getId(), $assetIndex);
+    }
 
     /**
      * @throws Exception
      */
-    public function testElementDeleteWithQueue(): void
+    public function testDocumentDeleteWithQueue(): void
     {
-        $this->checkAndDeleteElement(
-            TestHelper::createImageAsset(),
-            $this->searchIndexConfigService->getIndexName(self::ASSET_INDEX_NAME)
-        );
+        $document = TestHelper::createEmptyDocument();
+        $documentIndex = $this->searchIndexConfigService->getIndexName(self::DOCUMENT_INDEX_NAME);
+        $this->consume();
 
-        $this->checkAndDeleteElement(
-            TestHelper::createEmptyDocument(),
-            $this->searchIndexConfigService->getIndexName(self::DOCUMENT_INDEX_NAME)
-        );
+        $this->checkAndDeleteElement($document, $documentIndex);
+        $this->consume();
 
-        $object = TestHelper::createEmptyObject('', false);
-        $this->checkAndDeleteElement(
-            $object,
-            $this->searchIndexConfigService->getIndexName($object->getClassName())
-        );
+        $this->tester->checkDeletedIndexEntry($document->getId(), $documentIndex);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testDataObjectDeleteWithQueue(): void
+    {
+        $object = TestHelper::createEmptyObject();
+        $objectIndex = $this->searchIndexConfigService->getIndexName($object->getClassName());
+        $this->consume();
+
+        $this->checkAndDeleteElement($object, $objectIndex);
+        $this->consume();
+
+        $this->tester->checkDeletedIndexEntry($object->getId(), $objectIndex);
     }
 
     private function checkAndDeleteElement(ElementInterface $element, string $indexName): void
     {
-        $this->consume();
         $this->tester->checkIndexEntry($element->getId(), $indexName);
-
         $element->delete();
-        $this->consume();
-        $this->expectException(Missing404Exception::class);
-        $this->tester->checkIndexEntry($element->getId(), $indexName);
     }
 
     private function consume(): void

--- a/tests/Support/Helper/GenericDataIndex.php
+++ b/tests/Support/Helper/GenericDataIndex.php
@@ -147,6 +147,24 @@ class GenericDataIndex extends \Codeception\Module
         return $response;
     }
 
+    public function checkDeletedIndexEntry(string $id, string $index): void
+    {
+        $client = $this->getIndexSearchClient();
+        $response = $client->get([
+            'id' => $id,
+            'index' => $index,
+            'client' => ['ignore' => [404]],
+        ]);
+
+        if (isset($response['found'])) {
+            $this->assertFalse($response['found'], 'Check OpenSearch document id of element');
+
+            return;
+        }
+
+        $this->assertNotContains($id, $response);
+    }
+
     public function flushIndex()
     {
         $client = $this->getIndexSearchClient();


### PR DESCRIPTION
## Changes in this pull request
. on data object deletion correct class name should be passed to enqueue item
