### PR TITLE
Add class_alias for asset field definition adapters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "symfony/messenger": "^6.4"
   },
   "require-dev": {
+    "roave/security-advisories": "dev-latest",
     "codeception/codeception": "^5.0.10",
     "codeception/phpunit-wrapper": "^9",
     "codeception/module-asserts": "^2",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "symfony/messenger": "^6.4"
   },
   "require-dev": {
-    "roave/security-advisories": "dev-latest",
     "codeception/codeception": "^5.0.10",
     "codeception/phpunit-wrapper": "^9",
     "codeception/module-asserts": "^2",

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -77,7 +77,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DataO
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Asset\FieldDefinitionAdapter\AbstractAdapter as OpenSearchAssetAbstractAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\DataObject\FieldDefinitionAdapter\AbstractAdapter as OpenSearchDataObjectAbstractAdapter;
 
-const ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE = 'Pimcore\\Bundle\GenericDataIndexBundle\\SearchIndexAdapter\\DefaultSearch\\Asset\\FieldDefinitionAdapter\\';
+const ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE = 'Pimcore\\Bundle\GenericDataIndexBundle\\SearchIndexAdapter\\OpenSearch\\Asset\\FieldDefinitionAdapter\\';
 
 $classesToAlias = [
     AttributeType::class => OpenSearchAttributeType::class,

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -68,9 +68,16 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Sort\FieldSortList as
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Traits\QueryObjectsToArrayTrait as OpenSearchQueryObjectsToArrayTrait;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\OpenSearch\Traits\SimplifySingleTypesTrait as OpenSearchSimplifySingleTypesTrait;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Asset\FieldDefinitionAdapter\AbstractAdapter as AssetAbstractAdapter;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Asset\FieldDefinitionAdapter\BooleanAdapter;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Asset\FieldDefinitionAdapter\DateAdapter;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Asset\FieldDefinitionAdapter\KeywordAdapter;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Asset\FieldDefinitionAdapter\RelationAdapter;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Asset\FieldDefinitionAdapter\TextKeywordAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DataObject\FieldDefinitionAdapter\AbstractAdapter as DataObjectAbstractAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Asset\FieldDefinitionAdapter\AbstractAdapter as OpenSearchAssetAbstractAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\DataObject\FieldDefinitionAdapter\AbstractAdapter as OpenSearchDataObjectAbstractAdapter;
+
+const ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE = 'Pimcore\\Bundle\GenericDataIndexBundle\\SearchIndexAdapter\\DefaultSearch\\Asset\\FieldDefinitionAdapter';
 
 $classesToAlias = [
     AttributeType::class => OpenSearchAttributeType::class,
@@ -101,6 +108,11 @@ $classesToAlias = [
     DefaultSearchInterface::class => OpenSearchSearchInterface::class,
     AssetAbstractAdapter::class => OpenSearchAssetAbstractAdapter::class,
     DataObjectAbstractAdapter::class => OpenSearchDataObjectAbstractAdapter::class,
+    ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'BooleanAdapter' => BooleanAdapter::class,
+    ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'DateAdapter' => DateAdapter::class,
+    ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'KeywordAdapter' => KeywordAdapter::class,
+    ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'RelationAdapter' => RelationAdapter::class,
+    ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'TextKeywordAdapter' => TextKeywordAdapter::class,
 ];
 
 foreach ($classesToAlias as $originalClass => $aliasClass) {

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -108,11 +108,11 @@ $classesToAlias = [
     DefaultSearchInterface::class => OpenSearchSearchInterface::class,
     AssetAbstractAdapter::class => OpenSearchAssetAbstractAdapter::class,
     DataObjectAbstractAdapter::class => OpenSearchDataObjectAbstractAdapter::class,
-    ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'BooleanAdapter' => BooleanAdapter::class,
-    ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'DateAdapter' => DateAdapter::class,
-    ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'KeywordAdapter' => KeywordAdapter::class,
-    ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'RelationAdapter' => RelationAdapter::class,
-    ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'TextKeywordAdapter' => TextKeywordAdapter::class,
+    BooleanAdapter::class => ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'BooleanAdapter',
+    DateAdapter::class => ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'DateAdapter',
+    KeywordAdapter::class => ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'KeywordAdapter',
+    RelationAdapter::class => ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'RelationAdapter',
+    TextKeywordAdapter::class => ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE . 'TextKeywordAdapter',
 ];
 
 foreach ($classesToAlias as $originalClass => $aliasClass) {

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -77,7 +77,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DataO
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\Asset\FieldDefinitionAdapter\AbstractAdapter as OpenSearchAssetAbstractAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\OpenSearch\DataObject\FieldDefinitionAdapter\AbstractAdapter as OpenSearchDataObjectAbstractAdapter;
 
-const ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE = 'Pimcore\\Bundle\GenericDataIndexBundle\\SearchIndexAdapter\\DefaultSearch\\Asset\\FieldDefinitionAdapter';
+const ASSET_FIELD_DEFINITION_ADAPTER_NAMESPACE = 'Pimcore\\Bundle\GenericDataIndexBundle\\SearchIndexAdapter\\DefaultSearch\\Asset\\FieldDefinitionAdapter\\';
 
 $classesToAlias = [
     AttributeType::class => OpenSearchAttributeType::class,


### PR DESCRIPTION
Those classes are internal but it's needed to add aliases to be compatible with the asset metadata class definitions bundle (^2.2.0)