### PR TITLE
[Bug] Add missing type in normalize method of object brick adapter

### DIFF
--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/ObjectBrickAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/ObjectBrickAdapter.php
@@ -69,11 +69,10 @@ final class ObjectBrickAdapter extends AbstractAdapter
                 continue;
             }
 
-            $resultItems[$type] = [];
             foreach ($definition->getFieldDefinitions() as $fieldDefinition) {
                 $getter = 'get' . ucfirst($fieldDefinition->getName());
                 $value = $item->$getter();
-                $resultItems[$fieldDefinition->getName()] = $this->fieldDefinitionService->normalizeValue(
+                $resultItems[$type][$fieldDefinition->getName()] = $this->fieldDefinitionService->normalizeValue(
                     $fieldDefinition,
                     $value
                 );


### PR DESCRIPTION
## Changes in this pull request
Normalize method in the ObjectBrickAdapter was missing a $type key
