### PR TITLE
[Bug]: Fix missing index settings default config values

### DIFF
--- a/config/pimcore/config.yaml
+++ b/config/pimcore/config.yaml
@@ -17,8 +17,6 @@ pimcore_generic_data_index:
               type: text
               analyzer: standard
               search_analyzer: generic_data_index_whitespace_analyzer
-
-    index_settings: []
     system_fields_settings:
       general:
         id:

--- a/config/pimcore/config.yaml
+++ b/config/pimcore/config.yaml
@@ -18,55 +18,7 @@ pimcore_generic_data_index:
               analyzer: standard
               search_analyzer: generic_data_index_whitespace_analyzer
 
-    index_settings:
-      index:
-        mapping:
-          nested_fields:
-            limit: 200
-          total_fields:
-            limit: 100000
-      number_of_shards: 1
-      number_of_replicas: 0
-      max_ngram_diff: 30
-      max_result_window: 10000
-      analysis:
-        analyzer:
-          generic_data_index_ngram_analyzer:
-            tokenizer: generic_data_index_ngram_tokenzier
-            filter:
-              - lowercase
-          generic_data_index_whitespace_analyzer:
-            tokenizer: generic_data_index_whitespace_tokenzier
-            filter:
-              - lowercase
-          generic_data_index_path_analyzer:
-            tokenizer: generic_data_index_path_tokenizer
-        normalizer:
-          generic_data_index_sort_normalizer:
-            type: custom
-            filter:
-              - lowercase
-          generic_data_index_sort_truncate_normalizer:
-            type: custom
-            char_filter:
-              - generic_data_index_sort_truncate
-            filter:
-              - lowercase
-        tokenizer:
-          generic_data_index_ngram_tokenzier:
-            type: ngram
-            min_gram: 3
-            max_gram: 25
-            token_chars: [ letter, digit ]
-          generic_data_index_whitespace_tokenzier:
-            type: whitespace
-          generic_data_index_path_tokenizer:
-            type: "path_hierarchy"
-        char_filter:
-          generic_data_index_sort_truncate:
-            type: pattern_replace
-            pattern: ^(.{256})(.*)$
-            replacement: $1
+    index_settings: []
     system_fields_settings:
       general:
         id:

--- a/config/pimcore/default_index_settings.yaml
+++ b/config/pimcore/default_index_settings.yaml
@@ -1,0 +1,48 @@
+index:
+  mapping:
+    nested_fields:
+      limit: 200
+    total_fields:
+      limit: 100000
+number_of_shards: 1
+number_of_replicas: 0
+max_ngram_diff: 30
+max_result_window: 10000
+analysis:
+  analyzer:
+    generic_data_index_ngram_analyzer:
+      tokenizer: generic_data_index_ngram_tokenzier
+      filter:
+        - lowercase
+    generic_data_index_whitespace_analyzer:
+      tokenizer: generic_data_index_whitespace_tokenzier
+      filter:
+        - lowercase
+    generic_data_index_path_analyzer:
+      tokenizer: generic_data_index_path_tokenizer
+  normalizer:
+    generic_data_index_sort_normalizer:
+      type: custom
+      filter:
+        - lowercase
+    generic_data_index_sort_truncate_normalizer:
+      type: custom
+      char_filter:
+        - generic_data_index_sort_truncate
+      filter:
+        - lowercase
+  tokenizer:
+    generic_data_index_ngram_tokenzier:
+      type: ngram
+      min_gram: 3
+      max_gram: 25
+      token_chars: [ letter, digit ]
+    generic_data_index_whitespace_tokenzier:
+      type: whitespace
+    generic_data_index_path_tokenizer:
+      type: "path_hierarchy"
+  char_filter:
+    generic_data_index_sort_truncate:
+      type: pattern_replace
+      pattern: ^(.{256})(.*)$
+      replacement: $1

--- a/src/DependencyInjection/PimcoreGenericDataIndexExtension.php
+++ b/src/DependencyInjection/PimcoreGenericDataIndexExtension.php
@@ -135,7 +135,6 @@ class PimcoreGenericDataIndexExtension extends Extension implements PrependExten
         }
     }
 
-
     /**
      * @throws InvalidArgumentException
      */

--- a/src/DependencyInjection/PimcoreGenericDataIndexExtension.php
+++ b/src/DependencyInjection/PimcoreGenericDataIndexExtension.php
@@ -71,19 +71,14 @@ class PimcoreGenericDataIndexExtension extends Extension implements PrependExten
             $loader->load('doctrine_migrations.yaml');
         }
 
-        $filename = __DIR__ . '/../../config/doctrine.yaml';
-
-        try {
-            $config = Yaml::parseFile($filename);
-        } catch (ParseException $e) {
-            throw new InvalidArgumentException(sprintf('The file "%s" does not contain valid YAML.', $filename), 0, $e);
-        }
+        $config = $this->getParsedConfig(__DIR__ . '/../../config/doctrine.yaml');
 
         $container->prependExtensionConfig('doctrine', $config['doctrine']);
     }
 
     private function registerIndexServiceParams(ContainerBuilder $container, array $indexSettings): void
     {
+        $indexSettings['index_settings'] = $this->getIndexSettings($indexSettings['index_settings']);
         $definition = $container->getDefinition(SearchIndexConfigServiceInterface::class);
         $definition->setArgument('$clientType', $indexSettings['client_params']['client_type']);
         $definition->setArgument('$indexPrefix', $indexSettings['client_params']['index_prefix']);
@@ -108,6 +103,38 @@ class PimcoreGenericDataIndexExtension extends Extension implements PrependExten
         $definition = $container->getDefinition(DispatchQueueMessagesHandler::class);
         $definition->setArgument('$queueSettings', $indexSettings['queue_settings']);
     }
+
+    private function getIndexSettings(array $indexSettings): array
+    {
+        $defaultIndexSettings = $this->getParsedConfig(
+            __DIR__ . '/../../config/pimcore/default_index_settings.yaml'
+        );
+
+        return $this->mergeConfig($defaultIndexSettings, $indexSettings);
+    }
+
+    private function mergeConfig(array $default, array $custom): array
+    {
+        foreach ($custom as $key => $value) {
+            $default[$key] = is_array($value) && isset($default[$key]) && is_array($default[$key])
+                ? $this->mergeConfig($default[$key], $value)
+                : $value;
+        }
+
+        return $default;
+    }
+
+    private function getParsedConfig(string $fileLocation): array
+    {
+        try {
+            return Yaml::parseFile($fileLocation);
+        } catch (ParseException $e) {
+            throw new InvalidArgumentException(
+                sprintf('The file "%s" does not contain valid YAML.', $fileLocation), 0, $e
+            );
+        }
+    }
+
 
     /**
      * @throws InvalidArgumentException

--- a/src/DependencyInjection/PimcoreGenericDataIndexExtension.php
+++ b/src/DependencyInjection/PimcoreGenericDataIndexExtension.php
@@ -124,13 +124,18 @@ class PimcoreGenericDataIndexExtension extends Extension implements PrependExten
         return $default;
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     private function getParsedConfig(string $fileLocation): array
     {
         try {
             return Yaml::parseFile($fileLocation);
         } catch (ParseException $e) {
             throw new InvalidArgumentException(
-                sprintf('The file "%s" does not contain valid YAML.', $fileLocation), 0, $e
+                sprintf('The file "%s" does not contain valid YAML.', $fileLocation),
+                0,
+                $e
             );
         }
     }


### PR DESCRIPTION
## Changes in this pull request

Provide default index settings

## Additional info
Dynamic symfony config node loses default values when some of it gets overwritten. Now we store default values separately and merge them so the default values are always available.