### PR TITLE
Remove base64 asset data when indexing wysiwyg fields

### DIFF
--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/TextKeywordAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/TextKeywordAdapter.php
@@ -46,7 +46,7 @@ final class TextKeywordAdapter extends AbstractAdapter
     public function normalize(mixed $value): ?string
     {
         if ($value) {
-            return preg_replace("/src=('|\")data:[^;]+;base64,.+?('|\")/", '', $value);
+            return preg_replace("/src=['\"]data:[^;]+;base64,.+?['\"]/", '', $value);
         }
 
         return null;

--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/TextKeywordAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/TextKeywordAdapter.php
@@ -42,4 +42,13 @@ final class TextKeywordAdapter extends AbstractAdapter
             $this->searchIndexConfigService->getSearchAnalyzerAttributes()
         );
     }
+
+    public function normalize(mixed $value): ?string
+    {
+        if ($value) {
+            return preg_replace("/src=('|\")data:[^;]+;base64,.+('|\")/", '', $value);
+        }
+
+        return null;
+    }
 }

--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/TextKeywordAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/TextKeywordAdapter.php
@@ -46,7 +46,7 @@ final class TextKeywordAdapter extends AbstractAdapter
     public function normalize(mixed $value): ?string
     {
         if ($value) {
-            return preg_replace("/src=('|\")data:[^;]+;base64,.+('|\")/", '', $value);
+            return preg_replace("/src=('|\")data:[^;]+;base64,.+?('|\")/", '', $value);
         }
 
         return null;


### PR DESCRIPTION
If you have a wysiwyg field in a data object, it can have HTML content like 
```
<p>Some text</p>
<p><img src="blob:https://www.igp-powder.com/80000760-05b3-4ee8-aad8-2a263cd65829" alt=""></p>
<p>Some other text</p>
```

In the corresponding database table the image gets saved base64-encoded:
```
<p>Some text</p>
<p><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ..."
<p>Some other text</p>
```

In our case this was a huge original image, so the base64 was > 50 MB.

When the object with this data is tried to be indexed, open search throws an error
```
symfony-messenger    14:11:47 WARNING   [pimcore.opensearch] Request Failure: ["method" => "POST","uri" => "https://opensearch-1.opensearch:9200/_bulk?refresh=wait_for","port" => 9200,"headers" => ["Host" => ["opensearch-1.opensearch"],"Content-Type" => ["application/json"],"Accept" => ["application/json"],"User-Agent" => ["opensearch-php/2.3.1 (Linux 6.1.124; PHP 8.2.27)"]],"HTTP code" => 413,"duration" => 0.001124,"error" => "Unknown 413 error from OpenSearch """]
```
HTTP 413 means "Content too large".

As the generic data index is used for searching, imho it does not make sense to store base64 information there. So this PR removes the base64 data from the Wysiwyg HTML.