### PR TITLE
[Fix][Queue]: Data object folders are not indexed in async mode

### DIFF
--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -101,11 +101,11 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
         int $operationTime,
         bool $includeElement = false
     ): ?QueryBuilder {
-        if (!$element instanceof Concrete) {
+        if (!$element instanceof AbstractObject) {
             return null;
         }
 
-        if (!$element->getClass()->getAllowInherit()) {
+        if (!$element instanceof Concrete || !$element->getClass()->getAllowInherit()) {
             return $this->getRelatedItemsQueryBuilder($element, $operation, $operationTime, $includeElement);
         }
 
@@ -154,7 +154,7 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
     }
 
     private function getRelatedItemsQueryBuilder(
-        Concrete $element,
+        AbstractObject $element,
         string $operation,
         int $operationTime,
         bool $includeElement = false
@@ -177,20 +177,30 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
             ->setParameter('id', $element->getId());
     }
 
-    private function getSelectParametersByOperation(Concrete $element, string $operation, int $operationTime): array
+    private function getSelectParametersByOperation(
+        AbstractObject $element,
+        string $operation,
+        int $operationTime
+    ): array
     {
-        $classId = 'className';
-        if ($operation === IndexQueueOperation::DELETE->value) {
-            $classId = "'" . $element->getClassId() . "'";
-        }
-
         return [
             $element->getId(),
             "'" . ElementType::DATA_OBJECT->value . "'",
-            $classId,
+            $this->getIndexName($element, $operation),
             "'$operation'",
             "'$operationTime'",
             '0',
         ];
+    }
+
+    private function getIndexName(AbstractObject $element, string $operation): string
+    {
+        if ($element instanceof Concrete) {
+            return $operation === IndexQueueOperation::DELETE->value
+                ? "'{$element->getClassName()}'"
+                : 'className';
+        }
+
+        return "'" . IndexName::DATA_OBJECT_FOLDER->value . "'";
     }
 }

--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -181,8 +181,7 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
         AbstractObject $element,
         string $operation,
         int $operationTime
-    ): array
-    {
+    ): array {
         return [
             $element->getId(),
             "'" . ElementType::DATA_OBJECT->value . "'",

--- a/tests/Functional/SearchIndex/AssetBasicTest.php
+++ b/tests/Functional/SearchIndex/AssetBasicTest.php
@@ -15,6 +15,7 @@
 
 namespace Functional\SearchIndex;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\SearchResultItem\Document;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\SearchResultItem\Folder;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\SearchResultItem\Image;
@@ -22,6 +23,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\SearchResult\Search
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\AssetSearchServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\Db;
 use Pimcore\Tests\Support\Util\TestHelper;
 
 class AssetBasicTest extends \Codeception\Test\Unit
@@ -70,6 +72,33 @@ class AssetBasicTest extends \Codeception\Test\Unit
         $asset->delete();
         $this->tester->checkDeletedIndexEntry($asset->getId(), $indexName);
 
+    }
+
+    public function testFolderIndexingAsynchronous()
+    {
+        $this->tester->disableSynchronousProcessing();
+        $searchIndexConfigService = $this->tester->grabService(SearchIndexConfigServiceInterface::class);
+        $indexName = $searchIndexConfigService->getIndexName(IndexName::ASSET->value);
+        $folder = TestHelper::createAssetFolder();
+
+        $folder->setKey('my-test-folder');
+        $folder->save();
+
+        $this->assertGreaterThan(
+            0,
+            Db::get()->fetchOne(
+                'select count(elementId) from generic_data_index_queue where elementId = ? and elementType="asset"',
+                [$folder->getId()]
+            )
+        );
+        $this->tester->consume();
+
+        $response = $this->tester->checkIndexEntry($folder->getId(), $indexName);
+        $this->assertEquals('my-test-folder', $response['_source']['system_fields']['key']);
+
+        $folder->delete();
+        $this->tester->consume();
+        $this->tester->checkDeletedIndexEntry($folder->getId(), $indexName);
     }
 
     public function testAssetSearch()

--- a/tests/Functional/SearchIndex/DataObjectBasicTest.php
+++ b/tests/Functional/SearchIndex/DataObjectBasicTest.php
@@ -87,7 +87,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
                 [$object->getId()]
             )
         );
-        $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
+        $this->tester->consume();
         $response = $this->tester->checkIndexEntry($object->getId(), $indexName);
         $this->assertEquals($object->getKey(), $response['_source']['system_fields']['key']);
     }
@@ -126,9 +126,35 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
                 [$object->getId()]
             )
         );
-        $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
+        $this->tester->consume();
         $response = $this->tester->checkIndexEntry($object->getId(), $indexName);
         $this->assertEquals($object->getKey(), $response['_source']['system_fields']['key']);
+    }
+
+    public function testFolderIndexingAsynchronous()
+    {
+        $this->tester->disableSynchronousProcessing();
+        $object = TestHelper::createObjectFolder();
+        $indexName = $this->searchIndexConfigService->getIndexName(IndexName::DATA_OBJECT_FOLDER->value);
+
+        $object->setKey('my-test-folder');
+        $object->save();
+
+        $this->assertGreaterThan(
+            0,
+            Db::get()->fetchOne(
+                'select count(elementId) from generic_data_index_queue where elementId = ? and elementType="dataObject"',
+                [$object->getId()]
+            )
+        );
+        $this->tester->consume();
+
+        $response = $this->tester->checkIndexEntry($object->getId(), $indexName);
+        $this->assertEquals('my-test-folder', $response['_source']['system_fields']['key']);
+
+        $object->delete();
+        $this->tester->consume();
+        $this->tester->checkDeletedIndexEntry($object->getId(), $indexName);
     }
 
     public function testFolderIndexing()
@@ -189,19 +215,19 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
         $this->assertNull($settingsStoreService->getClassMappingCheckSum($classId));
 
         $class->save();
-        $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
+        $this->tester->consume();
         $checkSum = $settingsStoreService->getClassMappingCheckSum($classId);
         $this->assertNotNull($checkSum);
 
         $class->save();
-        $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
+        $this->tester->consume();
         $this->assertEquals($checkSum, $settingsStoreService->getClassMappingCheckSum($classId));
 
         $input = new Input();
         $input->setName('settingsTest');
         $class->addFieldDefinition('settingsTest', $input);
         $class->save();
-        $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
+        $this->tester->consume();
         $this->assertNotEquals($checkSum, $settingsStoreService->getClassMappingCheckSum($classId));
     }
 
@@ -216,7 +242,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
         $input->setName('mappingTest');
         $class->addFieldDefinition('mappingTest', $input);
         $class->save();
-        $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
+        $this->tester->consume();
 
         $indexName = $this->tester->getIndexName($object->getClassName());
         $mapping = $this->tester->getIndexMapping($index);
@@ -225,7 +251,7 @@ class DataObjectBasicTest extends \Codeception\Test\Unit
 
         $class->setFieldDefinitions($originalFields);
         $class->save();
-        $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
+        $this->tester->consume();
 
         $indexName = $this->tester->getIndexName($object->getClassName());
         $mapping = $this->tester->getIndexMapping($index);

--- a/tests/Functional/SearchIndex/DocumentBasicTest.php
+++ b/tests/Functional/SearchIndex/DocumentBasicTest.php
@@ -18,6 +18,7 @@ namespace Functional\SearchIndex;
 
 use Codeception\Test\Unit;
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult\SearchResultItem\Email;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult\SearchResultItem\Folder;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Document\SearchResult\SearchResultItem\HardLink;
@@ -28,6 +29,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Document\
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Tests\IndexTester;
+use Pimcore\Db;
 use Pimcore\Tests\Support\Util\TestHelper;
 
 /**
@@ -58,7 +60,7 @@ final class DocumentBasicTest extends Unit
         $indexName = $searchIndexConfigService->getIndexName('document');
 
         $document = TestHelper::createEmptyDocument();
-        $documentId = (string)$document->getId();
+        $documentId = $document->getId();
 
         // check indexed
         $response = $this->tester->checkIndexEntry($documentId, $indexName);
@@ -73,6 +75,35 @@ final class DocumentBasicTest extends Unit
         $document->delete();
         $this->tester->checkDeletedIndexEntry($documentId, $indexName);
     }
+
+
+    public function testFolderIndexingAsynchronous()
+    {
+        $this->tester->disableSynchronousProcessing();
+        $searchIndexConfigService = $this->tester->grabService(SearchIndexConfigServiceInterface::class);
+        $indexName = $searchIndexConfigService->getIndexName(IndexName::DOCUMENT->value);
+        $folder = TestHelper::createDocumentFolder();
+
+        $folder->setKey('my-test-folder');
+        $folder->save();
+
+        $this->assertGreaterThan(
+            0,
+            Db::get()->fetchOne(
+                'select count(elementId) from generic_data_index_queue where elementId = ? and elementType="document"',
+                [$folder->getId()]
+            )
+        );
+        $this->tester->consume();
+
+        $response = $this->tester->checkIndexEntry($folder->getId(), $indexName);
+        $this->assertEquals('my-test-folder', $response['_source']['system_fields']['key']);
+
+        $folder->delete();
+        $this->tester->consume();
+        $this->tester->checkDeletedIndexEntry($folder->getId(), $indexName);
+    }
+
 
     /**
      * @throws Exception

--- a/tests/Functional/SearchIndex/DocumentBasicTest.php
+++ b/tests/Functional/SearchIndex/DocumentBasicTest.php
@@ -76,7 +76,6 @@ final class DocumentBasicTest extends Unit
         $this->tester->checkDeletedIndexEntry($documentId, $indexName);
     }
 
-
     public function testFolderIndexingAsynchronous()
     {
         $this->tester->disableSynchronousProcessing();
@@ -103,7 +102,6 @@ final class DocumentBasicTest extends Unit
         $this->tester->consume();
         $this->tester->checkDeletedIndexEntry($folder->getId(), $indexName);
     }
-
 
     /**
      * @throws Exception

--- a/tests/Functional/SearchIndex/IndexQueueTest.php
+++ b/tests/Functional/SearchIndex/IndexQueueTest.php
@@ -127,7 +127,7 @@ class IndexQueueTest extends Unit
             )
         );
 
-        $this->consume();
+        $this->tester->consume();
         $result = $this->tester->checkIndexEntry($asset->getId(), $indexName);
         $this->assertEquals($asset->getId(), $result['_source']['system_fields']['id']);
     }
@@ -139,10 +139,10 @@ class IndexQueueTest extends Unit
     {
         $asset = TestHelper::createImageAsset();
         $assetIndex = $this->searchIndexConfigService->getIndexName(self::ASSET_INDEX_NAME);
-        $this->consume();
+        $this->tester->consume();
 
         $this->checkAndDeleteElement($asset, $assetIndex);
-        $this->consume();
+        $this->tester->consume();
 
         $this->tester->checkDeletedIndexEntry($asset->getId(), $assetIndex);
     }
@@ -154,10 +154,10 @@ class IndexQueueTest extends Unit
     {
         $document = TestHelper::createEmptyDocument();
         $documentIndex = $this->searchIndexConfigService->getIndexName(self::DOCUMENT_INDEX_NAME);
-        $this->consume();
+        $this->tester->consume();
 
         $this->checkAndDeleteElement($document, $documentIndex);
-        $this->consume();
+        $this->tester->consume();
 
         $this->tester->checkDeletedIndexEntry($document->getId(), $documentIndex);
     }
@@ -169,10 +169,10 @@ class IndexQueueTest extends Unit
     {
         $object = TestHelper::createEmptyObject();
         $objectIndex = $this->searchIndexConfigService->getIndexName($object->getClassName());
-        $this->consume();
+        $this->tester->consume();
 
         $this->checkAndDeleteElement($object, $objectIndex);
-        $this->consume();
+        $this->tester->consume();
 
         $this->tester->checkDeletedIndexEntry($object->getId(), $objectIndex);
     }
@@ -181,10 +181,5 @@ class IndexQueueTest extends Unit
     {
         $this->tester->checkIndexEntry($element->getId(), $indexName);
         $element->delete();
-    }
-
-    private function consume(): void
-    {
-        $this->tester->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
     }
 }

--- a/tests/Support/Helper/GenericDataIndex.php
+++ b/tests/Support/Helper/GenericDataIndex.php
@@ -132,7 +132,7 @@ class GenericDataIndex extends \Codeception\Module
         return $this->grabService('generic-data-index.search-client');
     }
 
-    public function checkIndexEntry(string $id, string $index): array
+    public function checkIndexEntry(int|string $id, string $index): array
     {
         /** @var SearchClientInterface $client */
         $client = $this->getIndexSearchClient();
@@ -146,7 +146,7 @@ class GenericDataIndex extends \Codeception\Module
         return $response;
     }
 
-    public function checkDeletedIndexEntry(string $id, string $index): void
+    public function checkDeletedIndexEntry(int|string $id, string $index): void
     {
         /** @var SearchClientInterface $client */
         $client = $this->getIndexSearchClient();
@@ -248,5 +248,10 @@ class GenericDataIndex extends \Codeception\Module
         $client = $this->getIndexSearchClient();
 
         return $client->getIndexMapping(['index' => $indexName]);
+    }
+
+    public function consume(): void
+    {
+        $this->runCommand('messenger:consume', ['--limit'=>2], ['pimcore_generic_data_index_queue']);
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Resolves #293
Resolves #https://github.com/pimcore/studio-backend-bundle/issues/764

## Additional info
- add missing data object folders handling
- in the queue the class name should used