### PR TITLE
Update `supportsNormalization` and switch to POCL license

### DIFF
--- a/src/Service/Serializer/Normalizer/AssetNormalizer.php
+++ b/src/Service/Serializer/Normalizer/AssetNormalizer.php
@@ -60,7 +60,7 @@ final class AssetNormalizer implements NormalizerInterface
         return [];
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Asset;
     }

--- a/src/Service/Serializer/Normalizer/DataObjectNormalizer.php
+++ b/src/Service/Serializer/Normalizer/DataObjectNormalizer.php
@@ -66,7 +66,7 @@ final class DataObjectNormalizer implements NormalizerInterface
         return [];
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof AbstractObject;
     }

--- a/src/Service/Serializer/Normalizer/DocumentNormalizer.php
+++ b/src/Service/Serializer/Normalizer/DocumentNormalizer.php
@@ -56,7 +56,7 @@ final class DocumentNormalizer implements NormalizerInterface
         return [];
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Document;
     }


### PR DESCRIPTION
## Changes in this pull request

- Added `$context` parameter to `supportsNormalization` in `DataObjectNormalizer`, `DocumentNormalizer`, and `AssetNormalizer` for enhanced flexibility.
