### PR TITLE
remove 404 ignore for index/alias check

### DIFF
--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -169,9 +169,6 @@ final class DefaultSearchService implements SearchIndexServiceInterface
     {
         return $this->client->existsIndex([
             'index' => $indexName,
-            'client' => [
-                'ignore' => [404],
-            ],
         ]);
     }
 

--- a/src/SearchIndexAdapter/DefaultSearch/IndexAliasService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/IndexAliasService.php
@@ -52,9 +52,6 @@ final class IndexAliasService implements IndexAliasServiceInterface
         return $this->client->existsIndexAlias([
             'name' => $aliasName,
             'index' => $indexName,
-            'client' => [
-                'ignore' => [404],
-            ],
         ]);
     }
 


### PR DESCRIPTION
I'm really not sure about this, since no one else came up with this... however: if i'm executing

`bin/console generic-data-index:update:index -r` 

I'm receiving several exceptions:

- `Failed to get an Alias: {"error":"alias [generic_data_index_dev_data-object-folder] missing","status":404}`
- `Failed to delete an index: {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [generic_data_index_dev_data-object-folder-odd]"`

I don't know why you're omitting the `404` inside a `existsIndex|existsAlias` method. But I'm also curious since this is so crucial and never happened to anyone else - so maybe I'm missing something important here. If so, feel free to close this PR.

Used Opensearch Version 2.11.1 (`action.auto_create_index=false`).