### PR TITLE
[Modifiers]: Date filter wrong parameters

### DIFF
--- a/src/Model/DefaultSearch/Query/DateFilter.php
+++ b/src/Model/DefaultSearch/Query/DateFilter.php
@@ -98,24 +98,19 @@ final readonly class DateFilter implements QueryInterface
 
     public function getParams(): array
     {
-        $params = [
-            'format' => "yyyy-MM-dd'T'HH:mm:ssz",
-        ];
+        $params = ['format' => "yyyy-MM-dd'T'HH:mm:ssz"];
+
         if ($this->onDate) {
             $params['gte'] = $this->getStartOfDay($this->onDate)->format(DateTimeInterface::ATOM);
             $params['lte'] =  $this->getEndOfDay($this->onDate)->format(DateTimeInterface::ATOM);
-        } else {
-            if ($this->startDate) {
-                $params['gte'] = $this->getStartOfDay($this->startDate)->format(DateTimeInterface::ATOM);
-            }
-            if ($this->endDate) {
-                $params['lte'] = $this->getEndOfDay($this->endDate)->format(DateTimeInterface::ATOM);
-            }
+
+            return [$this->field => $params];
         }
 
-        return [
-            $this->field => $params,
-        ];
+        $params = $this->addStartParams($params);
+        $params = $this->addEndParams($params);
+
+        return [$this->field => $params];
     }
 
     public function toArray(bool $withType = false): array
@@ -160,6 +155,40 @@ final readonly class DateFilter implements QueryInterface
     public function getOnDate(): Carbon
     {
         return $this->onDate;
+    }
+
+    private function addStartParams(array $params): array
+    {
+        if (!$this->startDate) {
+            return $params;
+        }
+
+        if ($this->endDate) {
+            $params['gte'] = $this->getStartOfDay($this->startDate)->format(DateTimeInterface::ATOM);
+
+            return $params;
+        }
+
+        $params['gte'] = $this->getEndOfDay($this->startDate)->format(DateTimeInterface::ATOM);
+
+        return $params;
+    }
+
+    private function addEndParams(array $params): array
+    {
+        if (!$this->endDate) {
+            return $params;
+        }
+
+        if ($this->startDate) {
+            $params['lte'] = $this->getEndOfDay($this->endDate)->format(DateTimeInterface::ATOM);
+
+            return $params;
+        }
+
+        $params['lte'] = $this->getStartOfDay($this->endDate)->format(DateTimeInterface::ATOM);
+
+        return $params;
     }
 
     private function getStartOfDay(Carbon $date): Carbon

--- a/tests/Unit/Model/DefaultSearch/Query/DateFilterTest.php
+++ b/tests/Unit/Model/DefaultSearch/Query/DateFilterTest.php
@@ -58,7 +58,7 @@ final class DateFilterTest extends Unit
             'range' => [
                 'datefield' => [
                     'format' => "yyyy-MM-dd'T'HH:mm:ssz",
-                    'gte' => '2000-01-01T00:00:00+00:00',
+                    'gte' => '2000-01-01T23:59:59+00:00',
                 ],
             ],
         ], $dateFilter->toArray(true));
@@ -111,7 +111,7 @@ final class DateFilterTest extends Unit
         self::assertSame([
             'datefield' => [
                 'format' => "yyyy-MM-dd'T'HH:mm:ssz",
-                'gte' => '2000-01-01T00:00:00+00:00',
+                'gte' => '2000-01-01T23:59:59+00:00',
             ],
         ], $dateFilter->getParams());
 

--- a/tests/Unit/Model/DefaultSearch/Query/DateFilterTest.php
+++ b/tests/Unit/Model/DefaultSearch/Query/DateFilterTest.php
@@ -69,7 +69,7 @@ final class DateFilterTest extends Unit
             'range' => [
                 'datefield' => [
                     'format' => "yyyy-MM-dd'T'HH:mm:ssz",
-                    'lte' => '2000-01-01T23:59:59+00:00',
+                    'lte' => '2000-01-01T00:00:00+00:00',
                 ],
             ],
         ], $dateFilter->toArray(true));
@@ -120,7 +120,7 @@ final class DateFilterTest extends Unit
         self::assertSame([
             'datefield' => [
                 'format' => "yyyy-MM-dd'T'HH:mm:ssz",
-                'lte' => '2000-01-01T23:59:59+00:00',
+                'lte' => '2000-01-01T00:00:00+00:00',
             ],
         ], $dateFilter->getParams());
 

--- a/tests/Unit/SearchIndexAdapter/Asset/FieldDefinitionAdapter/DateAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/Asset/FieldDefinitionAdapter/DateAdapterTest.php
@@ -126,7 +126,7 @@ final class DateAdapterTest extends Unit
                 'range' => [
                     'standard_fields.test.en' => [
                         'format' => "yyyy-MM-dd'T'HH:mm:ssz",
-                        'gte' => '2000-01-01T00:00:00+00:00',
+                        'gte' => '2000-01-01T23:59:59+00:00',
                     ],
                 ],
             ],

--- a/tests/Unit/SearchIndexAdapter/Asset/FieldDefinitionAdapter/DateAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/Asset/FieldDefinitionAdapter/DateAdapterTest.php
@@ -141,7 +141,7 @@ final class DateAdapterTest extends Unit
                 'range' => [
                     'standard_fields.test.en' => [
                         'format' => "yyyy-MM-dd'T'HH:mm:ssz",
-                        'lte' => '2000-01-01T23:59:59+00:00',
+                        'lte' => '2000-01-01T00:00:00+00:00',
                     ],
                 ],
             ],


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-backend-bundle/issues/1315

## Additional info
- date filter should exclude selected dates for before/after filters - e.g. when choosing 16.09.2025, entries with this date should not be included anymore
- add support for "between" cases - these include the entered dates - e.g. between 16.09.2025 and 17.09.2025 includes items with these dates