### PR TITLE
Runner to ubuntu-latest

### DIFF
--- a/.github/workflows/elastic-search-codeception.yaml
+++ b/.github/workflows/elastic-search-codeception.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
     codeception-tests:
         name: "Codeception tests"
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-latest"
         continue-on-error: ${{ matrix.experimental }}
         strategy:
             matrix:

--- a/.github/workflows/open-search-codeception.yaml
+++ b/.github/workflows/open-search-codeception.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
     codeception-tests:
         name: "Codeception tests"
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-latest"
         continue-on-error: ${{ matrix.experimental }}
         strategy:
             matrix:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
     static-analysis-phpstan:
         name: "Static Analysis with PHPStan"
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-latest"
         strategy:
             matrix:
                 include:


### PR DESCRIPTION
This pull request updates the operating system used in several GitHub Actions workflows from `ubuntu-20.04` to `ubuntu-latest`. This change ensures that CI jobs run on the most up-to-date Ubuntu environment, which can provide improved security, newer tools, and better compatibility.

**CI/CD Workflow Updates:**

* Updated the runner for the `codeception-tests` job in `.github/workflows/elastic-search-codeception.yaml` to use `ubuntu-latest` instead of `ubuntu-20.04`.
* Updated the runner for the `codeception-tests` job in `.github/workflows/open-search-codeception.yaml` to use `ubuntu-latest` instead of `ubuntu-20.04`.
* Updated the runner for the `static-analysis-phpstan` job in `.github/workflows/static-analysis.yaml` to use `ubuntu-latest` instead of `ubuntu-20.04`.## Changes in this pull request
Resolves #

## Additional info
