### PR TITLE
Symfony 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": "~8.3.0 || ~8.4.0 ",
     "nesbot/carbon": "^3.8.4",
-    "pimcore/pimcore": "^12.0",
+    "pimcore/pimcore": "^12.3",
     "pimcore/static-resolver-bundle": "^3.0",
     "pimcore/opensearch-client": "^2.0",
     "pimcore/elasticsearch-client": "^2.0",

--- a/src/EventSubscriber/DebugSubscriber.php
+++ b/src/EventSubscriber/DebugSubscriber.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\EventSubscriber;
 
+use Pimcore\Helper\ParameterBagHelper;
 use Pimcore;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Debug\SearchInformation;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DefaultSearchService;
@@ -48,7 +49,7 @@ final class DebugSubscriber implements EventSubscriberInterface
         if (!Pimcore::inDebugMode() || empty($event->getRequest()->query->get(self::DEBUG_SEARCH_PARAM))) {
             return;
         }
-        $verbosity = $event->getRequest()->query->getInt(self::DEBUG_SEARCH_PARAM);
+        $verbosity = ParameterBagHelper::getInt($event->getRequest()->query, self::DEBUG_SEARCH_PARAM);
         $event->setResponse(new JsonResponse($this->getNormalizedSearches($verbosity)));
     }
 

--- a/src/EventSubscriber/DebugSubscriber.php
+++ b/src/EventSubscriber/DebugSubscriber.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\EventSubscriber;
 
-use Pimcore\Helper\ParameterBagHelper;
 use Pimcore;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Debug\SearchInformation;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DefaultSearchService;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+use Pimcore\Helper\ParameterBagHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;


### PR DESCRIPTION
This pull request refactors how the verbosity parameter is retrieved in the `DebugSubscriber` to improve code consistency and reliability. The change replaces the direct usage of Symfony's `ParameterBag::getInt` with the more robust `ParameterBagHelper::getInt` method.

Improvements to parameter handling:

* Updated the import statements in `src/EventSubscriber/DebugSubscriber.php` to include `ParameterBagHelper`, enabling the use of its helper methods.
* Changed the retrieval of the verbosity parameter in `onKernelResponse` to use `ParameterBagHelper::getInt`, ensuring consistent and safer parameter extraction.
