### PR TITLE
PEES-831: Error in pimcore_generic_data_index Consumer: Unable to Parse Empty Time Fields During Indexing

### DIFF
--- a/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
+++ b/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
@@ -28,6 +28,7 @@ use Pimcore\Event\DataObjectEvents;
 use Pimcore\Event\Model\DataObjectEvent;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Service;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Time;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -104,6 +105,18 @@ final class DataObjectIndexUpdateSubscriber implements EventSubscriberInterface
         }
 
         $dataObject = $event->getObject();
+        $fields = $dataObject->getClass()->getFieldDefinitions();
+        foreach ($fields as $field) {
+            if ($field instanceof Time) {
+                $getter = 'get' . $field->getName();
+                $value = $dataObject->$getter();
+                if ($value === '') {
+                    $setter = 'set' . $field->getName();
+                    $dataObject->$setter(null);
+                }
+            }
+        }
+
         Service::useInheritedValues(true, fn () =>
         $this->indexQueueService
             ->updateIndexQueue(

--- a/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
+++ b/src/EventSubscriber/DataObjectIndexUpdateSubscriber.php
@@ -28,7 +28,6 @@ use Pimcore\Event\DataObjectEvents;
 use Pimcore\Event\Model\DataObjectEvent;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Service;
-use Pimcore\Model\DataObject\ClassDefinition\Data\Time;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -105,18 +104,6 @@ final class DataObjectIndexUpdateSubscriber implements EventSubscriberInterface
         }
 
         $dataObject = $event->getObject();
-        $fields = $dataObject->getClass()->getFieldDefinitions();
-        foreach ($fields as $field) {
-            if ($field instanceof Time) {
-                $getter = 'get' . $field->getName();
-                $value = $dataObject->$getter();
-                if ($value === '') {
-                    $setter = 'set' . $field->getName();
-                    $dataObject->$setter(null);
-                }
-            }
-        }
-
         Service::useInheritedValues(true, fn () =>
         $this->indexQueueService
             ->updateIndexQueue(

--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/TimeAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/TimeAdapter.php
@@ -27,4 +27,13 @@ final class TimeAdapter extends AbstractAdapter
             'format' => 'strict_hour_minute',
         ];
     }
+
+    public function normalize(mixed $value): mixed
+    {
+        if ($value === '') {
+            return null;
+        }
+        
+        return parent::normalize($value);
+    }
 }


### PR DESCRIPTION
resolves https://github.com/pimcore/service-operations/issues/293

map timefield from empty string to null to prevent indexing errors