### PR TITLE
feat(search-index): add command to clean up unused indices

### DIFF
--- a/config/services/search/index.yaml
+++ b/config/services/search/index.yaml
@@ -85,3 +85,5 @@ services:
 
     Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\ClassDefinition\ClassDefinitionReindexServiceInterface:
         class: Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\ClassDefinition\ClassDefinitionReindexService
+
+    Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\UnusedIndexCleanupService: ~

--- a/doc/01_Installation/02_Upgrade.md
+++ b/doc/01_Installation/02_Upgrade.md
@@ -5,6 +5,11 @@ description: Version-specific upgrade instructions and breaking changes for the 
 
 # Upgrade Information
 
+## Upgrade to 2026.3.0
+
+- Added command `generic-data-index:cleanup:unused-indices` to delete managed indices not referenced by any alias.
+ 
+
 ## Upgrade to 2026.1.0
 
 ### PHP and Dependency Requirements

--- a/doc/02_Configuration/03_Index_Management.md
+++ b/doc/02_Configuration/03_Index_Management.md
@@ -207,9 +207,17 @@ To preview deletions without making changes, use `--dry-run`:
 bin/console generic-data-index:cleanup:unused-indices --dry-run
 ```
 
-> **Warning:** Do not run this command while a reindex is in progress. During a reindex the
-> new `-odd`/`-even` index is created and populated before it is attached to its alias, so for
-> the duration of that window it carries the configured prefix and suffix but is not referenced
-> by any alias. This command would classify such an index as unused and delete the index that is
-> actively being built. Run a `--dry-run` first and make sure no reindex (e.g.
-> `generic-data-index:reindex` or `generic-data-index:deployment:reindex`) is running.
+During a reindex the new `-odd`/`-even` index is created and populated before it is attached
+to its alias, so for the duration of that window it carries the configured prefix and suffix
+but is not referenced by any alias. To avoid deleting an index that is actively being built,
+indices younger than `--min-age` seconds (default: `86400`, i.e. 24 hours) are never
+considered unused. Indices whose creation date cannot be determined are also skipped.
+
+```bash
+bin/console generic-data-index:cleanup:unused-indices --min-age=3600
+```
+
+> **Warning:** Only lower `--min-age` or disable the guard entirely (`--min-age=0`) when you
+> are sure no reindex (e.g. `generic-data-index:reindex` or
+> `generic-data-index:deployment:reindex`) is currently running or expected to take longer
+> than the chosen threshold. Run a `--dry-run` first to review what would be deleted.

--- a/doc/02_Configuration/03_Index_Management.md
+++ b/doc/02_Configuration/03_Index_Management.md
@@ -180,3 +180,17 @@ php bin/console generic-data-index:deployment:reindex
 ```
 
 This command will update the index structure for all data object classes which were created/updated since the last deployment and reindex all data objects for relevant classes.
+
+### Cleaning Up Unused Indices
+
+To clean up old indices that are not referenced by any alias, use the following command:
+
+```
+php bin/console generic-data-index:cleanup:unused-indices
+```
+
+To preview what would be deleted without performing any changes, run:
+
+```
+php bin/console generic-data-index:cleanup:unused-indices --dry-run
+```

--- a/doc/02_Configuration/03_Index_Management.md
+++ b/doc/02_Configuration/03_Index_Management.md
@@ -16,6 +16,7 @@ to power search and listing features in Pimcore.
 | `generic-data-index:update:index -r` | Delete and recreate indices, then queue all elements |
 | `generic-data-index:reindex` | Native search engine reindex (reorganizes data within existing indices, no database read) |
 | `generic-data-index:deployment:reindex` | Update indices only for class definitions changed since the last deployment |
+| `generic-data-index:cleanup:unused-indices` | Delete managed indices not referenced by any alias (`-odd`/`-even` suffixes only) |
 
 ## Index Prefix
 
@@ -190,3 +191,18 @@ bin/console generic-data-index:deployment:reindex
 
 This updates the index structure for all class definitions modified since the last
 deployment and reindexes data objects for affected classes.
+
+### Cleaning Up Unused Indices
+
+To clean up managed indices that are no longer referenced by any alias, run:
+
+```bash
+bin/console generic-data-index:cleanup:unused-indices
+```
+
+This only targets indices with the configured prefix and a `-odd` or `-even` suffix.
+To preview deletions without making changes, use `--dry-run`:
+
+```bash
+bin/console generic-data-index:cleanup:unused-indices --dry-run
+```

--- a/doc/02_Configuration/03_Index_Management.md
+++ b/doc/02_Configuration/03_Index_Management.md
@@ -206,3 +206,10 @@ To preview deletions without making changes, use `--dry-run`:
 ```bash
 bin/console generic-data-index:cleanup:unused-indices --dry-run
 ```
+
+> **Warning:** Do not run this command while a reindex is in progress. During a reindex the
+> new `-odd`/`-even` index is created and populated before it is attached to its alias, so for
+> the duration of that window it carries the configured prefix and suffix but is not referenced
+> by any alias. This command would classify such an index as unused and delete the index that is
+> actively being built. Run a `--dry-run` first and make sure no reindex (e.g.
+> `generic-data-index:reindex` or `generic-data-index:deployment:reindex`) is running.

--- a/src/Command/CleanupUnusedIndicesCommand.php
+++ b/src/Command/CleanupUnusedIndicesCommand.php
@@ -31,6 +31,8 @@ final class CleanupUnusedIndicesCommand extends AbstractCommand
 
     private const OPTION_DRY_RUN = 'dry-run';
 
+    private const OPTION_MIN_AGE = 'min-age';
+
     public function __construct(
         private readonly UnusedIndexCleanupService $unusedIndexCleanupService,
         ?string $name = null
@@ -48,12 +50,19 @@ final class CleanupUnusedIndicesCommand extends AbstractCommand
                 InputOption::VALUE_NONE,
                 'List unused indices without deleting them.'
             )
+            ->addOption(
+                self::OPTION_MIN_AGE,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Minimum age in seconds an index must have before it is considered unused. Set to 0 to disable the age guard.',
+                (string) UnusedIndexCleanupService::DEFAULT_MIN_AGE_SECONDS
+            )
             ->setDescription(
                 'Deletes managed Generic Data Index indices with the configured index prefix and a -odd/-even suffix that are not referenced by any alias.'
             )
             ->setHelp(
                 'This command only targets managed Generic Data Index indices that use the configured index prefix and end with -odd or -even. It does not consider other indices.' . PHP_EOL .
-                'Warning: do not run this command while a reindex is in progress. A reindex creates and populates the new -odd/-even index before attaching it to its alias, so during that window the new index is not referenced by any alias and would be deleted by this command.'
+                'A reindex creates and populates the new -odd/-even index before attaching it to its alias, so during that window the new index is not referenced by any alias. To avoid deleting an index that is actively being built, indices younger than --min-age seconds (default: 86400) are never deleted. Only lower this threshold or disable it (--min-age=0) when no reindex is or was recently running.'
             );
     }
 
@@ -70,7 +79,15 @@ final class CleanupUnusedIndicesCommand extends AbstractCommand
 
         try {
             $dryRun = (bool) $input->getOption(self::OPTION_DRY_RUN);
-            $unusedIndices = $this->unusedIndexCleanupService->cleanupUnusedIndices($dryRun);
+
+            $minAge = $input->getOption(self::OPTION_MIN_AGE);
+            if (!is_numeric($minAge) || (int) $minAge < 0) {
+                $output->writeln('<error>The --min-age option must be a non-negative number of seconds.</error>');
+
+                return self::FAILURE;
+            }
+
+            $unusedIndices = $this->unusedIndexCleanupService->cleanupUnusedIndices($dryRun, (int) $minAge);
 
             if (empty($unusedIndices)) {
                 $output->writeln('<info>No unused indices found.</info>');

--- a/src/Command/CleanupUnusedIndicesCommand.php
+++ b/src/Command/CleanupUnusedIndicesCommand.php
@@ -49,7 +49,10 @@ final class CleanupUnusedIndicesCommand extends AbstractCommand
                 'List unused indices without deleting them.'
             )
             ->setDescription(
-                'Deletes Generic Data Index indices that are not referenced by any alias.'
+                'Deletes managed Generic Data Index indices with the configured index prefix and a -odd/-even suffix that are not referenced by any alias.'
+            )
+            ->setHelp(
+                'This command only targets managed Generic Data Index indices that use the configured index prefix and end with -odd or -even. It does not consider other indices.'
             );
     }
 

--- a/src/Command/CleanupUnusedIndicesCommand.php
+++ b/src/Command/CleanupUnusedIndicesCommand.php
@@ -93,6 +93,7 @@ final class CleanupUnusedIndicesCommand extends AbstractCommand
             }
         } catch (Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return self::FAILURE;
         } finally {
             $this->release();
         }

--- a/src/Command/CleanupUnusedIndicesCommand.php
+++ b/src/Command/CleanupUnusedIndicesCommand.php
@@ -54,15 +54,23 @@ final class CleanupUnusedIndicesCommand extends AbstractCommand
                 self::OPTION_MIN_AGE,
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Minimum age in seconds an index must have before it is considered unused. Set to 0 to disable the age guard.',
+                'Minimum age in seconds an index must have before it is considered unused. '
+                . 'Set to 0 to disable the age guard.',
                 (string) UnusedIndexCleanupService::DEFAULT_MIN_AGE_SECONDS
             )
             ->setDescription(
-                'Deletes managed Generic Data Index indices with the configured index prefix and a -odd/-even suffix that are not referenced by any alias.'
+                'Deletes managed Generic Data Index indices with the configured index prefix '
+                . 'and a -odd/-even suffix that are not referenced by any alias.'
             )
             ->setHelp(
-                'This command only targets managed Generic Data Index indices that use the configured index prefix and end with -odd or -even. It does not consider other indices.' . PHP_EOL .
-                'A reindex creates and populates the new -odd/-even index before attaching it to its alias, so during that window the new index is not referenced by any alias. To avoid deleting an index that is actively being built, indices younger than --min-age seconds (default: 86400) are never deleted. Only lower this threshold or disable it (--min-age=0) when no reindex is or was recently running.'
+                'This command only targets managed Generic Data Index indices that use the '
+                . 'configured index prefix and end with -odd or -even. It does not consider other indices.'
+                . PHP_EOL
+                . 'A reindex creates and populates the new -odd/-even index before attaching it to its '
+                . 'alias, so during that window the new index is not referenced by any alias. To avoid '
+                . 'deleting an index that is actively being built, indices younger than --min-age seconds '
+                . '(default: 86400) are never deleted. Only lower this threshold or disable it '
+                . '(--min-age=0) when no reindex is or was recently running.'
             );
     }
 

--- a/src/Command/CleanupUnusedIndicesCommand.php
+++ b/src/Command/CleanupUnusedIndicesCommand.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Command;
+
+use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\CommandAlreadyRunningException;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\UnusedIndexCleanupService;
+use Pimcore\Console\AbstractCommand;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final class CleanupUnusedIndicesCommand extends AbstractCommand
+{
+    use LockableTrait;
+
+    private const OPTION_DRY_RUN = 'dry-run';
+
+    public function __construct(
+        private readonly UnusedIndexCleanupService $unusedIndexCleanupService,
+        ?string $name = null
+    ) {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('generic-data-index:cleanup:unused-indices')
+            ->addOption(
+                self::OPTION_DRY_RUN,
+                null,
+                InputOption::VALUE_NONE,
+                'List unused indices without deleting them.'
+            )
+            ->setDescription(
+                'Deletes Generic Data Index indices that are not referenced by any alias.'
+            );
+    }
+
+    /**
+     * @throws CommandAlreadyRunningException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            throw new CommandAlreadyRunningException(
+                'The command is already running in another process.'
+            );
+        }
+
+        try {
+            $dryRun = (bool) $input->getOption(self::OPTION_DRY_RUN);
+            $unusedIndices = $this->unusedIndexCleanupService->cleanupUnusedIndices($dryRun);
+
+            if (empty($unusedIndices)) {
+                $output->writeln('<info>No unused indices found.</info>');
+
+                return self::SUCCESS;
+            }
+
+            $output->writeln('<info>Unused indices:</info>');
+            foreach ($unusedIndices as $indexName) {
+                $output->writeln(sprintf(' - %s', $indexName));
+            }
+
+            if ($dryRun) {
+                $output->writeln(
+                    sprintf('<comment>Dry run: %d indices would be deleted.</comment>', count($unusedIndices))
+                );
+            } else {
+                $output->writeln(
+                    sprintf('<info>Deleted %d unused indices.</info>', count($unusedIndices))
+                );
+            }
+        } catch (Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+        } finally {
+            $this->release();
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Command/CleanupUnusedIndicesCommand.php
+++ b/src/Command/CleanupUnusedIndicesCommand.php
@@ -52,7 +52,8 @@ final class CleanupUnusedIndicesCommand extends AbstractCommand
                 'Deletes managed Generic Data Index indices with the configured index prefix and a -odd/-even suffix that are not referenced by any alias.'
             )
             ->setHelp(
-                'This command only targets managed Generic Data Index indices that use the configured index prefix and end with -odd or -even. It does not consider other indices.'
+                'This command only targets managed Generic Data Index indices that use the configured index prefix and end with -odd or -even. It does not consider other indices.' . PHP_EOL .
+                'Warning: do not run this command while a reindex is in progress. A reindex creates and populates the new -odd/-even index before attaching it to its alias, so during that window the new index is not referenced by any alias and would be deleted by this command.'
             );
     }
 
@@ -93,6 +94,7 @@ final class CleanupUnusedIndicesCommand extends AbstractCommand
             }
         } catch (Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+
             return self::FAILURE;
         } finally {
             $this->release();

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -366,6 +366,11 @@ final class DefaultSearchService implements SearchIndexServiceInterface
         return $this->client->getIndexStats(['index' => $indexName]);
     }
 
+    public function getIndexSettings(string $indexName): array
+    {
+        return $this->client->getIndexSettings(['index' => $indexName]);
+    }
+
     public function getCount(AdapterSearchInterface $search, string $indexName): int
     {
         $body = $search->toArray();

--- a/src/SearchIndexAdapter/SearchIndexServiceInterface.php
+++ b/src/SearchIndexAdapter/SearchIndexServiceInterface.php
@@ -68,5 +68,7 @@ interface SearchIndexServiceInterface
 
     public function getStats(string $indexName): array;
 
+    public function getIndexSettings(string $indexName): array;
+
     public function getCount(AdapterSearchInterface $search, string $indexName): int;
 }

--- a/src/Service/SearchIndex/UnusedIndexCleanupService.php
+++ b/src/Service/SearchIndex/UnusedIndexCleanupService.php
@@ -72,6 +72,9 @@ final readonly class UnusedIndexCleanupService
     private function getAllManagedIndices(): array
     {
         $indexPrefix = $this->searchIndexConfigService->getIndexPrefix();
+        if ($indexPrefix === '') {
+            return [];
+        }
 
         try {
             $stats = $this->searchIndexService->getStats($indexPrefix . '*');

--- a/src/Service/SearchIndex/UnusedIndexCleanupService.php
+++ b/src/Service/SearchIndex/UnusedIndexCleanupService.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
 
-use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 
@@ -76,11 +75,7 @@ final readonly class UnusedIndexCleanupService
             return [];
         }
 
-        try {
-            $stats = $this->searchIndexService->getStats($indexPrefix . '*');
-        } catch (Exception) {
-            return [];
-        }
+        $stats = $this->searchIndexService->getStats($indexPrefix . '*');
 
         $indices = $stats['indices'] ?? null;
         if (!is_array($indices)) {

--- a/src/Service/SearchIndex/UnusedIndexCleanupService.php
+++ b/src/Service/SearchIndex/UnusedIndexCleanupService.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
+
+use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+
+/**
+ * @internal
+ */
+final readonly class UnusedIndexCleanupService
+{
+    private const INDEX_SUFFIX_PATTERN = '/-(odd|even)$/';
+
+    public function __construct(
+        private SearchIndexServiceInterface $searchIndexService,
+        private IndexAliasServiceInterface $indexAliasService,
+        private SearchIndexConfigServiceInterface $searchIndexConfigService,
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function findUnusedIndices(): array
+    {
+        $allManagedIndices = $this->getAllManagedIndices();
+        if (empty($allManagedIndices)) {
+            return [];
+        }
+
+        $aliasedIndices = $this->getAliasedIndices();
+        $unusedIndices = array_values(array_diff($allManagedIndices, $aliasedIndices));
+        sort($unusedIndices);
+
+        return $unusedIndices;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function cleanupUnusedIndices(bool $dryRun = false): array
+    {
+        $unusedIndices = $this->findUnusedIndices();
+
+        if ($dryRun) {
+            return $unusedIndices;
+        }
+
+        foreach ($unusedIndices as $indexName) {
+            $this->searchIndexService->deleteIndex($indexName);
+        }
+
+        return $unusedIndices;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAllManagedIndices(): array
+    {
+        $indexPrefix = $this->searchIndexConfigService->getIndexPrefix();
+
+        try {
+            $stats = $this->searchIndexService->getStats($indexPrefix . '*');
+        } catch (Exception) {
+            return [];
+        }
+
+        $indices = $stats['indices'] ?? null;
+        if (!is_array($indices)) {
+            return [];
+        }
+
+        $indexNames = array_keys($indices);
+
+        return array_values(array_filter(
+            $indexNames,
+            static fn (string $indexName): bool => str_starts_with($indexName, $indexPrefix)
+                && preg_match(self::INDEX_SUFFIX_PATTERN, $indexName) === 1
+        ));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAliasedIndices(): array
+    {
+        $indexPrefix = $this->searchIndexConfigService->getIndexPrefix();
+        $aliases = $this->indexAliasService->getAllAliases();
+
+        $aliasedIndexMap = [];
+        foreach ($aliases as $aliasData) {
+            if (!is_array($aliasData)) {
+                continue;
+            }
+
+            $indexName = $aliasData['index'] ?? null;
+            if (!is_string($indexName) || !str_starts_with($indexName, $indexPrefix)) {
+                continue;
+            }
+
+            $aliasedIndexMap[$indexName] = true;
+        }
+
+        return array_keys($aliasedIndexMap);
+    }
+}

--- a/src/Service/SearchIndex/UnusedIndexCleanupService.php
+++ b/src/Service/SearchIndex/UnusedIndexCleanupService.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex;
 
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DefaultSearchService;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 
@@ -21,7 +22,13 @@ use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceI
  */
 final readonly class UnusedIndexCleanupService
 {
-    private const INDEX_SUFFIX_PATTERN = '/-(odd|even)$/';
+    public const DEFAULT_MIN_AGE_SECONDS = 86400;
+
+    private const INDEX_SUFFIX_PATTERN = '/-('
+        . DefaultSearchService::INDEX_VERSION_ODD
+        . '|'
+        . DefaultSearchService::INDEX_VERSION_EVEN
+        . ')$/';
 
     public function __construct(
         private SearchIndexServiceInterface $searchIndexService,
@@ -33,9 +40,9 @@ final readonly class UnusedIndexCleanupService
     /**
      * @return string[]
      */
-    public function findUnusedIndices(): array
+    public function findUnusedIndices(int $minAgeSeconds = self::DEFAULT_MIN_AGE_SECONDS): array
     {
-        $allManagedIndices = $this->getAllManagedIndices();
+        $allManagedIndices = $this->getAllManagedIndices($minAgeSeconds);
         if (empty($allManagedIndices)) {
             return [];
         }
@@ -50,9 +57,11 @@ final readonly class UnusedIndexCleanupService
     /**
      * @return string[]
      */
-    public function cleanupUnusedIndices(bool $dryRun = false): array
-    {
-        $unusedIndices = $this->findUnusedIndices();
+    public function cleanupUnusedIndices(
+        bool $dryRun = false,
+        int $minAgeSeconds = self::DEFAULT_MIN_AGE_SECONDS
+    ): array {
+        $unusedIndices = $this->findUnusedIndices($minAgeSeconds);
 
         if ($dryRun) {
             return $unusedIndices;
@@ -68,27 +77,51 @@ final readonly class UnusedIndexCleanupService
     /**
      * @return string[]
      */
-    private function getAllManagedIndices(): array
+    private function getAllManagedIndices(int $minAgeSeconds): array
     {
         $indexPrefix = $this->searchIndexConfigService->getIndexPrefix();
         if ($indexPrefix === '') {
             return [];
         }
 
-        $stats = $this->searchIndexService->getStats($indexPrefix . '*');
+        $settingsByIndex = $this->searchIndexService->getIndexSettings($indexPrefix . '*');
 
-        $indices = $stats['indices'] ?? null;
-        if (!is_array($indices)) {
-            return [];
+        $indexNames = [];
+        foreach ($settingsByIndex as $indexName => $indexSettings) {
+            if (!is_string($indexName)
+                || !str_starts_with($indexName, $indexPrefix)
+                || preg_match(self::INDEX_SUFFIX_PATTERN, $indexName) !== 1
+                || !$this->isOldEnough($indexSettings, $minAgeSeconds)
+            ) {
+                continue;
+            }
+
+            $indexNames[] = $indexName;
         }
 
-        $indexNames = array_keys($indices);
+        return $indexNames;
+    }
 
-        return array_values(array_filter(
-            $indexNames,
-            static fn (string $indexName): bool => str_starts_with($indexName, $indexPrefix)
-                && preg_match(self::INDEX_SUFFIX_PATTERN, $indexName) === 1
-        ));
+    /**
+     * A reindex creates and populates the new -odd/-even index before attaching it to its
+     * alias, so a recently created index without an alias may still be in that window.
+     * Indices with an unknown creation date never qualify for deletion unless the guard
+     * is disabled ($minAgeSeconds <= 0).
+     */
+    private function isOldEnough(mixed $indexSettings, int $minAgeSeconds): bool
+    {
+        if ($minAgeSeconds <= 0) {
+            return true;
+        }
+
+        $creationDate = $indexSettings['settings']['index']['creation_date'] ?? null;
+        if (!is_numeric($creationDate)) {
+            return false;
+        }
+
+        $creationTimestamp = (int) ((float) $creationDate / 1000);
+
+        return time() - $creationTimestamp >= $minAgeSeconds;
     }
 
     /**

--- a/tests/Unit/Service/SearchIndex/UnusedIndexCleanupServiceTest.php
+++ b/tests/Unit/Service/SearchIndex/UnusedIndexCleanupServiceTest.php
@@ -1,0 +1,146 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Service\SearchIndex;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\UnusedIndexCleanupService;
+
+/**
+ * @internal
+ */
+final class UnusedIndexCleanupServiceTest extends Unit
+{
+    public function testFindUnusedIndicesReturnsOnlyUnaliasedManagedIndices(): void
+    {
+        $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
+        $searchIndexService
+            ->method('getStats')
+            ->with('pimcore_*')
+            ->willReturn([
+                'indices' => [
+                    'pimcore_asset-odd' => [],
+                    'pimcore_asset-even' => [],
+                    'pimcore_document-even' => [],
+                    'pimcore_custom' => [],
+                    'other_prefix_asset-odd' => [],
+                ],
+            ])
+        ;
+        $searchIndexService->expects($this->never())->method('deleteIndex');
+
+        $indexAliasService = $this->createMock(IndexAliasServiceInterface::class);
+        $indexAliasService
+            ->method('getAllAliases')
+            ->willReturn([
+                ['alias' => 'pimcore_asset', 'index' => 'pimcore_asset-even'],
+                ['alias' => 'pimcore_document', 'index' => 'pimcore_document-even'],
+            ])
+        ;
+
+        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
+        $searchIndexConfigService
+            ->method('getIndexPrefix')
+            ->willReturn('pimcore_')
+        ;
+
+        $service = new UnusedIndexCleanupService(
+            $searchIndexService,
+            $indexAliasService,
+            $searchIndexConfigService
+        );
+
+        $this->assertSame(['pimcore_asset-odd'], $service->findUnusedIndices());
+    }
+
+    public function testDryRunDoesNotDeleteIndices(): void
+    {
+        $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
+        $searchIndexService
+            ->method('getStats')
+            ->willReturn([
+                'indices' => [
+                    'pimcore_asset-odd' => [],
+                    'pimcore_asset-even' => [],
+                ],
+            ])
+        ;
+        $searchIndexService->expects($this->never())->method('deleteIndex');
+
+        $indexAliasService = $this->createMock(IndexAliasServiceInterface::class);
+        $indexAliasService
+            ->method('getAllAliases')
+            ->willReturn([
+                ['alias' => 'pimcore_asset', 'index' => 'pimcore_asset-even'],
+            ])
+        ;
+
+        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
+        $searchIndexConfigService
+            ->method('getIndexPrefix')
+            ->willReturn('pimcore_')
+        ;
+
+        $service = new UnusedIndexCleanupService(
+            $searchIndexService,
+            $indexAliasService,
+            $searchIndexConfigService
+        );
+
+        $this->assertSame(['pimcore_asset-odd'], $service->cleanupUnusedIndices(true));
+    }
+
+    public function testExecuteDeletesUnusedIndices(): void
+    {
+        $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
+        $searchIndexService
+            ->method('getStats')
+            ->willReturn([
+                'indices' => [
+                    'pimcore_asset-odd' => [],
+                    'pimcore_asset-even' => [],
+                ],
+            ])
+        ;
+        $searchIndexService
+            ->expects($this->once())
+            ->method('deleteIndex')
+            ->with('pimcore_asset-odd')
+        ;
+
+        $indexAliasService = $this->createMock(IndexAliasServiceInterface::class);
+        $indexAliasService
+            ->method('getAllAliases')
+            ->willReturn([
+                ['alias' => 'pimcore_asset', 'index' => 'pimcore_asset-even'],
+            ])
+        ;
+
+        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
+        $searchIndexConfigService
+            ->method('getIndexPrefix')
+            ->willReturn('pimcore_')
+        ;
+
+        $service = new UnusedIndexCleanupService(
+            $searchIndexService,
+            $indexAliasService,
+            $searchIndexConfigService
+        );
+
+        $this->assertSame(['pimcore_asset-odd'], $service->cleanupUnusedIndices());
+    }
+}

--- a/tests/Unit/Service/SearchIndex/UnusedIndexCleanupServiceTest.php
+++ b/tests/Unit/Service/SearchIndex/UnusedIndexCleanupServiceTest.php
@@ -29,16 +29,14 @@ final class UnusedIndexCleanupServiceTest extends Unit
     {
         $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
         $searchIndexService
-            ->method('getStats')
+            ->method('getIndexSettings')
             ->with('pimcore_*')
             ->willReturn([
-                'indices' => [
-                    'pimcore_asset-odd' => [],
-                    'pimcore_asset-even' => [],
-                    'pimcore_document-even' => [],
-                    'pimcore_custom' => [],
-                    'other_prefix_asset-odd' => [],
-                ],
+                'pimcore_asset-odd' => $this->indexSettings('-2 days'),
+                'pimcore_asset-even' => $this->indexSettings('-2 days'),
+                'pimcore_document-even' => $this->indexSettings('-2 days'),
+                'pimcore_custom' => $this->indexSettings('-2 days'),
+                'other_prefix_asset-odd' => $this->indexSettings('-2 days'),
             ])
         ;
         $searchIndexService->expects($this->never())->method('deleteIndex');
@@ -52,31 +50,24 @@ final class UnusedIndexCleanupServiceTest extends Unit
             ])
         ;
 
-        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
-        $searchIndexConfigService
-            ->method('getIndexPrefix')
-            ->willReturn('pimcore_')
-        ;
-
         $service = new UnusedIndexCleanupService(
             $searchIndexService,
             $indexAliasService,
-            $searchIndexConfigService
+            $this->mockConfigService('pimcore_')
         );
 
         $this->assertSame(['pimcore_asset-odd'], $service->findUnusedIndices());
     }
 
-    public function testDryRunDoesNotDeleteIndices(): void
+    public function testRecentlyCreatedIndicesAreProtectedByMinAge(): void
     {
         $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
         $searchIndexService
-            ->method('getStats')
+            ->method('getIndexSettings')
             ->willReturn([
-                'indices' => [
-                    'pimcore_asset-odd' => [],
-                    'pimcore_asset-even' => [],
-                ],
+                'pimcore_asset-odd' => $this->indexSettings('-10 minutes'),
+                'pimcore_asset-even' => $this->indexSettings('-2 days'),
+                'pimcore_document-odd' => [], // creation date unknown
             ])
         ;
         $searchIndexService->expects($this->never())->method('deleteIndex');
@@ -89,16 +80,46 @@ final class UnusedIndexCleanupServiceTest extends Unit
             ])
         ;
 
-        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
-        $searchIndexConfigService
-            ->method('getIndexPrefix')
-            ->willReturn('pimcore_')
+        $service = new UnusedIndexCleanupService(
+            $searchIndexService,
+            $indexAliasService,
+            $this->mockConfigService('pimcore_')
+        );
+
+        // The fresh index and the index with unknown creation date are not considered unused.
+        $this->assertSame([], $service->findUnusedIndices());
+
+        // Disabling the age guard includes both.
+        $this->assertSame(
+            ['pimcore_asset-odd', 'pimcore_document-odd'],
+            $service->findUnusedIndices(0)
+        );
+    }
+
+    public function testDryRunDoesNotDeleteIndices(): void
+    {
+        $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
+        $searchIndexService
+            ->method('getIndexSettings')
+            ->willReturn([
+                'pimcore_asset-odd' => $this->indexSettings('-2 days'),
+                'pimcore_asset-even' => $this->indexSettings('-2 days'),
+            ])
+        ;
+        $searchIndexService->expects($this->never())->method('deleteIndex');
+
+        $indexAliasService = $this->createMock(IndexAliasServiceInterface::class);
+        $indexAliasService
+            ->method('getAllAliases')
+            ->willReturn([
+                ['alias' => 'pimcore_asset', 'index' => 'pimcore_asset-even'],
+            ])
         ;
 
         $service = new UnusedIndexCleanupService(
             $searchIndexService,
             $indexAliasService,
-            $searchIndexConfigService
+            $this->mockConfigService('pimcore_')
         );
 
         $this->assertSame(['pimcore_asset-odd'], $service->cleanupUnusedIndices(true));
@@ -108,12 +129,10 @@ final class UnusedIndexCleanupServiceTest extends Unit
     {
         $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
         $searchIndexService
-            ->method('getStats')
+            ->method('getIndexSettings')
             ->willReturn([
-                'indices' => [
-                    'pimcore_asset-odd' => [],
-                    'pimcore_asset-even' => [],
-                ],
+                'pimcore_asset-odd' => $this->indexSettings('-2 days'),
+                'pimcore_asset-even' => $this->indexSettings('-2 days'),
             ])
         ;
         $searchIndexService
@@ -130,42 +149,30 @@ final class UnusedIndexCleanupServiceTest extends Unit
             ])
         ;
 
-        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
-        $searchIndexConfigService
-            ->method('getIndexPrefix')
-            ->willReturn('pimcore_')
-        ;
-
         $service = new UnusedIndexCleanupService(
             $searchIndexService,
             $indexAliasService,
-            $searchIndexConfigService
+            $this->mockConfigService('pimcore_')
         );
 
         $this->assertSame(['pimcore_asset-odd'], $service->cleanupUnusedIndices());
     }
 
-    public function testGetStatsExceptionIsNotSwallowed(): void
+    public function testGetIndexSettingsExceptionIsNotSwallowed(): void
     {
         $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
         $searchIndexService
-            ->method('getStats')
+            ->method('getIndexSettings')
             ->willThrowException(new RuntimeException('search engine unavailable'))
         ;
         $searchIndexService->expects($this->never())->method('deleteIndex');
 
         $indexAliasService = $this->createMock(IndexAliasServiceInterface::class);
 
-        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
-        $searchIndexConfigService
-            ->method('getIndexPrefix')
-            ->willReturn('pimcore_')
-        ;
-
         $service = new UnusedIndexCleanupService(
             $searchIndexService,
             $indexAliasService,
-            $searchIndexConfigService
+            $this->mockConfigService('pimcore_')
         );
 
         $this->expectException(RuntimeException::class);
@@ -177,23 +184,39 @@ final class UnusedIndexCleanupServiceTest extends Unit
     public function testEmptyPrefixReturnsNoIndices(): void
     {
         $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
-        $searchIndexService->expects($this->never())->method('getStats');
+        $searchIndexService->expects($this->never())->method('getIndexSettings');
         $searchIndexService->expects($this->never())->method('deleteIndex');
 
         $indexAliasService = $this->createMock(IndexAliasServiceInterface::class);
 
-        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
-        $searchIndexConfigService
-            ->method('getIndexPrefix')
-            ->willReturn('')
-        ;
-
         $service = new UnusedIndexCleanupService(
             $searchIndexService,
             $indexAliasService,
-            $searchIndexConfigService
+            $this->mockConfigService('')
         );
 
         $this->assertSame([], $service->findUnusedIndices());
+    }
+
+    private function mockConfigService(string $indexPrefix): SearchIndexConfigServiceInterface
+    {
+        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
+        $searchIndexConfigService
+            ->method('getIndexPrefix')
+            ->willReturn($indexPrefix)
+        ;
+
+        return $searchIndexConfigService;
+    }
+
+    private function indexSettings(string $createdAt): array
+    {
+        return [
+            'settings' => [
+                'index' => [
+                    'creation_date' => (string) (strtotime($createdAt) * 1000),
+                ],
+            ],
+        ];
     }
 }

--- a/tests/Unit/Service/SearchIndex/UnusedIndexCleanupServiceTest.php
+++ b/tests/Unit/Service/SearchIndex/UnusedIndexCleanupServiceTest.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceIn
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\UnusedIndexCleanupService;
+use RuntimeException;
 
 /**
  * @internal
@@ -142,5 +143,57 @@ final class UnusedIndexCleanupServiceTest extends Unit
         );
 
         $this->assertSame(['pimcore_asset-odd'], $service->cleanupUnusedIndices());
+    }
+
+    public function testGetStatsExceptionIsNotSwallowed(): void
+    {
+        $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
+        $searchIndexService
+            ->method('getStats')
+            ->willThrowException(new RuntimeException('search engine unavailable'))
+        ;
+        $searchIndexService->expects($this->never())->method('deleteIndex');
+
+        $indexAliasService = $this->createMock(IndexAliasServiceInterface::class);
+
+        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
+        $searchIndexConfigService
+            ->method('getIndexPrefix')
+            ->willReturn('pimcore_')
+        ;
+
+        $service = new UnusedIndexCleanupService(
+            $searchIndexService,
+            $indexAliasService,
+            $searchIndexConfigService
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('search engine unavailable');
+
+        $service->cleanupUnusedIndices();
+    }
+
+    public function testEmptyPrefixReturnsNoIndices(): void
+    {
+        $searchIndexService = $this->createMock(SearchIndexServiceInterface::class);
+        $searchIndexService->expects($this->never())->method('getStats');
+        $searchIndexService->expects($this->never())->method('deleteIndex');
+
+        $indexAliasService = $this->createMock(IndexAliasServiceInterface::class);
+
+        $searchIndexConfigService = $this->createMock(SearchIndexConfigServiceInterface::class);
+        $searchIndexConfigService
+            ->method('getIndexPrefix')
+            ->willReturn('')
+        ;
+
+        $service = new UnusedIndexCleanupService(
+            $searchIndexService,
+            $indexAliasService,
+            $searchIndexConfigService
+        );
+
+        $this->assertSame([], $service->findUnusedIndices());
     }
 }


### PR DESCRIPTION
- add generic-data-index:cleanup:unused-indices command
- default behavior deletes unmanaged stale -odd/-even indices not referenced by aliases
- add --dry-run option to preview deletions without changes
- implement UnusedIndexCleanupService to detect candidates via prefix + alias diff
- add unit tests for selection, dry-run, and execute behavior
- document new cleanup command in index management docs

## Changes in this pull request
Resolves #382

## Additional info
