### PR TITLE
feat(cli): add --all-classes to generic-data-index:deployment:reindex

### DIFF
--- a/doc/02_Configuration/03_Index_Management.md
+++ b/doc/02_Configuration/03_Index_Management.md
@@ -180,3 +180,18 @@ php bin/console generic-data-index:deployment:reindex
 ```
 
 This command will update the index structure for all data object classes which were created/updated since the last deployment and reindex all data objects for relevant classes.
+
+If you need to force reindexing of all class definitions, use:
+
+```
+php bin/console generic-data-index:deployment:reindex --all-classes
+```
+
+Use `--all-classes` as a recovery/consistency option when checksum-based change detection may be out of sync and you want a full class-level pass without recreating indices.
+
+Compared to `php bin/console generic-data-index:update:index -r`:
+
+- `deployment:reindex --all-classes` keeps existing indices and forces reindexing for all class definitions.
+- `update:index -r` deletes and recreates indices before reindexing.
+
+Prefer `deployment:reindex --all-classes` first when a forced class-level refresh is needed. Use `update:index -r` when a hard rebuild is required (for example after incompatible mapping/state issues).

--- a/src/Command/DeploymentReindexCommand.php
+++ b/src/Command/DeploymentReindexCommand.php
@@ -21,6 +21,7 @@ use Pimcore\Console\AbstractCommand;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -29,6 +30,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class DeploymentReindexCommand extends AbstractCommand
 {
     use LockableTrait;
+
+    private const OPTION_ALL_CLASSES = 'all-classes';
 
     public function __construct(
         private readonly EnqueueServiceInterface $enqueueService,
@@ -42,6 +45,12 @@ final class DeploymentReindexCommand extends AbstractCommand
     {
         $this
             ->setName('generic-data-index:deployment:reindex')
+            ->addOption(
+                self::OPTION_ALL_CLASSES,
+                null,
+                InputOption::VALUE_NONE,
+                'Reindex all class definitions, even if the mapping checksum has not changed.'
+            )
             ->setDescription(
                 'Updates index/mapping for all classDefinitions which changed without' .
                 'deleting them. Afterwards are affected items added into the index queue.'
@@ -62,12 +71,13 @@ final class DeploymentReindexCommand extends AbstractCommand
 
         try {
             $updatedIds = [];
+            $forceAllClasses = (bool) $input->getOption(self::OPTION_ALL_CLASSES);
             $classesList = new ClassDefinition\Listing();
             $classes = $classesList->load();
 
             foreach ($classes as $classDefinition) {
                 $updated = $this->classDefinitionReindexService
-                    ->reindexClassDefinition($classDefinition, true, true)
+                    ->reindexClassDefinition($classDefinition, !$forceAllClasses, true)
                 ;
 
                 if ($updated) {


### PR DESCRIPTION
- add --all-classes option to force reindexing all class definitions
- bypass checksum-based skip logic when the flag is provided
- enqueue affected class items after forced reindex pass

## Changes in this pull request
Resolves #

## Additional info
TBD if this is useful
