### PR TITLE
[Improvement] Refactor IndexQueueRepository to use named column aliases and simplify deleteQueueEntries

### DIFF
--- a/doc/01_Installation/02_Upgrade.md
+++ b/doc/01_Installation/02_Upgrade.md
@@ -8,8 +8,7 @@ Following steps are necessary during updating to newer versions.
 - The messenger transport DSN is now configurable via the `%pimcore.messenger.transport_dsn_prefix%` container parameter instead of being hardcoded to `doctrine://default`. This allows the installer to wire the transport DSN from environment variables (e.g. `PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX`).
 - Added support to `PHP` `8.5`.
 - Removed support to `PHP` `8.3` and Symfony `v6`.
-- [Indexing] Refactored `IndexQueueRepository::generateSelectQuery()` to use named column aliases instead of positional field arrays. The method now accepts an associative `$columnAliases` array (`alias => expression`) instead of the previous positional `$fields` array with a separate `$idField` parameter. All enqueue methods in `EnqueueService` and the element type adapters (`AssetTypeAdapter`, `DocumentTypeAdapter`, `DataObjectTypeAdapter`) have been updated accordingly. The `quoteParameters()` helper method has been removed.
-- [Indexing] Refactored `IndexQueueRepository::getValuesFromSqlResult()` to extract values by named column alias (`elementId`, `elementType`, `elementIndexName`, `operation`, `operationTime`) instead of fragile positional index access.
+- [Indexing] **BC Break**: `IndexQueueRepository::generateSelectQuery()` signature changed. The method now accepts an associative `$columnAliases` array (`alias => expression`) instead of the previous positional `$fields` array with a separate `$idField` parameter. Passing a numerically-indexed array will throw an `InvalidArgumentException`. All enqueue methods in `EnqueueService` and the element type adapters (`AssetTypeAdapter`, `DocumentTypeAdapter`, `DataObjectTypeAdapter`) have been updated accordingly. The `quoteParameters()` helper method has been removed.
 
 ## Upgrade to 2.2.0
 - [Indexing] Added `id` column as new primary key to `generic_data_index_queue`. Please make sure to execute migrations.

--- a/doc/01_Installation/02_Upgrade.md
+++ b/doc/01_Installation/02_Upgrade.md
@@ -8,6 +8,8 @@ Following steps are necessary during updating to newer versions.
 - The messenger transport DSN is now configurable via the `%pimcore.messenger.transport_dsn_prefix%` container parameter instead of being hardcoded to `doctrine://default`. This allows the installer to wire the transport DSN from environment variables (e.g. `PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX`).
 - Added support to `PHP` `8.5`.
 - Removed support to `PHP` `8.3` and Symfony `v6`.
+- [Indexing] Refactored `IndexQueueRepository::generateSelectQuery()` to use named column aliases instead of positional field arrays. The method now accepts an associative `$columnAliases` array (`alias => expression`) instead of the previous positional `$fields` array with a separate `$idField` parameter. All enqueue methods in `EnqueueService` and the element type adapters (`AssetTypeAdapter`, `DocumentTypeAdapter`, `DataObjectTypeAdapter`) have been updated accordingly. The `quoteParameters()` helper method has been removed.
+- [Indexing] Refactored `IndexQueueRepository::getValuesFromSqlResult()` to extract values by named column alias (`elementId`, `elementType`, `elementIndexName`, `operation`, `operationTime`) instead of fragile positional index access.
 
 ## Upgrade to 2.2.0
 - [Indexing] Added `id` column as new primary key to `generic_data_index_queue`. Please make sure to execute migrations.

--- a/src/Repository/IndexQueueRepository.php
+++ b/src/Repository/IndexQueueRepository.php
@@ -174,6 +174,15 @@ final class IndexQueueRepository
     ): DBALQueryBuilder {
         $selectExpressions = [];
         foreach ($columnAliases as $alias => $expression) {
+            if (is_int($alias)) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Column aliases must be an associative array with string keys (alias => expression), got numeric key %d for expression "%s".',
+                        $alias,
+                        $expression
+                    )
+                );
+            }
             $selectExpressions[] = $expression . ' AS ' . $alias;
         }
 

--- a/src/Repository/IndexQueueRepository.php
+++ b/src/Repository/IndexQueueRepository.php
@@ -124,27 +124,19 @@ final class IndexQueueRepository
     {
         $chunks = array_chunk($entries, self::BATCH_SIZE);
         foreach ($chunks as $chunk) {
-            $condition = [];
-
-            /** @var IndexQueue $entry */
-            foreach ($chunk as $entry) {
-                $condition[] = sprintf(
-                    '(%s, %s)',
-                    $this->connection->quote((string)$entry->getId()),
-                    $this->connection->quote($entry->getOperationTime())
-                );
-            }
-
-            $condition = sprintf('(%s, %s) IN (%s) ORDER BY %s ASC LIMIT %s',
-                $this->connection->quoteIdentifier('id'),
-                $this->connection->quoteIdentifier('operationTime'),
-                implode(',', $condition),
-                $this->connection->quoteIdentifier('id'),
-                self::BATCH_SIZE
+            $ids = array_map(
+                fn (IndexQueue $entry) => $this->connection->quote((string)$entry->getId()),
+                $chunk
             );
 
-            //delete handled entry from queue table
-            $this->connection->executeQuery('DELETE FROM ' . IndexQueue::TABLE . ' WHERE ' . $condition);
+            $this->connection->executeQuery(
+                sprintf(
+                    'DELETE FROM %s WHERE %s IN (%s)',
+                    $this->connection->quoteIdentifier(IndexQueue::TABLE),
+                    $this->connection->quoteIdentifier('id'),
+                    implode(',', $ids)
+                )
+            );
         }
     }
 
@@ -161,24 +153,29 @@ final class IndexQueueRepository
         return $this->denormalizer->denormalize($entry, IndexQueue::class);
     }
 
+    /**
+     * @param array<string, string> $columnAliases Associative array mapping alias names to SQL expressions
+     * @param array<string, mixed>  $params        Query parameters for setParameters()
+     * @param array<string>         $whereParameters Column names for WHERE clauses
+     */
     public function generateSelectQuery(
         string $tableName,
-        array $fields,
-        string $idField = 'id',
+        array $columnAliases,
         array $params = [],
         array $whereParameters = []
     ): DBALQueryBuilder {
-        $fields = $this->quoteParameters($fields);
-        array_unshift($fields, $idField);
+        $selectExpressions = [];
+        foreach ($columnAliases as $alias => $expression) {
+            $selectExpressions[] = $expression . ' AS ' . $alias;
+        }
 
         $qb = $this->connection->createQueryBuilder()
-            ->addSelect(...$fields)
+            ->addSelect(...$selectExpressions)
             ->from($tableName);
 
         $this->addWhereStatements($qb, $whereParameters);
 
         if (!empty($params)) {
-            $params = $this->quoteParameters($params);
             $qb->setParameters($params);
         }
 
@@ -315,20 +312,6 @@ final class IndexQueueRepository
             ->createQueryBuilder($alias);
     }
 
-    private function quoteParameters(array $parameters): array
-    {
-        return array_map(
-            function ($parameter) {
-                if (is_string($parameter)) {
-                    return $this->connection->quote($parameter);
-                }
-
-                return $parameter;
-            },
-            $parameters
-        );
-    }
-
     private function addWhereStatements(DBALQueryBuilder $queryBuilder, array $whereParameters): DBALQueryBuilder
     {
         foreach ($whereParameters as $operator => $parameter) {
@@ -412,10 +395,10 @@ final class IndexQueueRepository
         return $this->connection->executeStatement($insertSql, $insertParams);
     }
 
-    /*
-    * @TODO: Refactor to avoid that all values have to be in a specific order. Either use aliases or pass the keys as parameters.
-    * Both things can be considered breaking changes.
-    */
+    /**
+     * Extracts values from SQL result rows that use named column aliases.
+     * Expected aliases: elementId, elementType, elementIndexName, operation, operationTime.
+     */
     private function getValuesFromSqlResult(array $result): array
     {
         if (empty($result)) {
@@ -423,40 +406,13 @@ final class IndexQueueRepository
         }
 
         $firstRow = $result[0];
-        $keys = array_keys($firstRow);
-        $columnCount = count($keys);
-
-        $ids = array_column($result, $keys[0]);
-        $elementType = $firstRow[$keys[1]];
-
-        $elementIndexName = match ($elementType) {
-            ElementType::ASSET->value, ElementType::DOCUMENT->value => $elementType,
-            ElementType::DATA_OBJECT->value => $firstRow['className'] ??
-            $firstRow[
-                $keys[2]
-            ] ??
-            null,
-            default => null,
-        };
-
-        $operation = $firstRow[
-            $keys[
-                    $columnCount > 5 ? 3 : 2
-            ]
-        ];
-
-        $operationTime = (int)$firstRow[
-            $keys[
-                $columnCount > 5 ? 4 : 3
-            ]
-        ];
 
         return [
-            $ids,
-            $elementType,
-            $operation,
-            $operationTime,
-            $elementIndexName,
+            array_column($result, 'elementId'),
+            $firstRow['elementType'],
+            $firstRow['operation'],
+            (int)$firstRow['operationTime'],
+            $firstRow['elementIndexName'],
         ];
     }
 }

--- a/src/Repository/IndexQueueRepository.php
+++ b/src/Repository/IndexQueueRepository.php
@@ -163,7 +163,8 @@ final class IndexQueueRepository
     /**
      * @param array<string, string> $columnAliases Associative array mapping alias names to SQL expressions
      * @param array<string, mixed>  $params        Query parameters for setParameters()
-     * @param array<string>         $whereParameters Column names for WHERE clauses
+     * @param array<int|string, string> $whereParameters Column names for WHERE clauses; keys may be numeric
+     *                                                   or operator constants (AND_OPERATOR, OR_OPERATOR)
      */
     public function generateSelectQuery(
         string $tableName,

--- a/src/Repository/IndexQueueRepository.php
+++ b/src/Repository/IndexQueueRepository.php
@@ -174,7 +174,7 @@ final class IndexQueueRepository
     ): DBALQueryBuilder {
         $selectExpressions = [];
         foreach ($columnAliases as $alias => $expression) {
-            if (is_int($alias)) {
+            if (is_int($alias)) { // @phpstan-ignore function.impossibleType (runtime guard for callers without static analysis)
                 throw new \InvalidArgumentException(
                     sprintf(
                         'Column aliases must be an associative array with string keys (alias => expression), got numeric key %d for expression "%s".',

--- a/src/Repository/IndexQueueRepository.php
+++ b/src/Repository/IndexQueueRepository.php
@@ -174,10 +174,12 @@ final class IndexQueueRepository
     ): DBALQueryBuilder {
         $selectExpressions = [];
         foreach ($columnAliases as $alias => $expression) {
-            if (is_int($alias)) { // @phpstan-ignore function.impossibleType (runtime guard for callers without static analysis)
+            /** @phpstan-ignore function.impossibleType (runtime guard for callers without static analysis) */
+            if (is_int($alias)) {
                 throw new \InvalidArgumentException(
                     sprintf(
-                        'Column aliases must be an associative array with string keys (alias => expression), got numeric key %d for expression "%s".',
+                        'Column aliases must be an associative array with string keys '
+                        . '(alias => expression), got numeric key %d for expression "%s".',
                         $alias,
                         $expression
                     )

--- a/src/Repository/IndexQueueRepository.php
+++ b/src/Repository/IndexQueueRepository.php
@@ -124,17 +124,24 @@ final class IndexQueueRepository
     {
         $chunks = array_chunk($entries, self::BATCH_SIZE);
         foreach ($chunks as $chunk) {
-            $ids = array_map(
-                fn (IndexQueue $entry) => $this->connection->quote((string)$entry->getId()),
+            $tuples = array_map(
+                fn (IndexQueue $entry) => sprintf(
+                    '(%s, %s)',
+                    $this->connection->quote((string)$entry->getId()),
+                    $this->connection->quote($entry->getOperationTime())
+                ),
                 $chunk
             );
 
             $this->connection->executeQuery(
                 sprintf(
-                    'DELETE FROM %s WHERE %s IN (%s)',
+                    'DELETE FROM %s WHERE (%s, %s) IN (%s) ORDER BY %s ASC LIMIT %d',
                     $this->connection->quoteIdentifier(IndexQueue::TABLE),
                     $this->connection->quoteIdentifier('id'),
-                    implode(',', $ids)
+                    $this->connection->quoteIdentifier('operationTime'),
+                    implode(',', $tuples),
+                    $this->connection->quoteIdentifier('id'),
+                    self::BATCH_SIZE
                 )
             );
         }

--- a/src/Service/SearchIndex/IndexQueue/EnqueueService.php
+++ b/src/Service/SearchIndex/IndexQueue/EnqueueService.php
@@ -49,8 +49,9 @@ final readonly class EnqueueService implements EnqueueServiceInterface
     {
         $tagCondition = $this->indexQueueRepository->generateSelectQuery(
             'tags_assignment',
-            [],
-            'cid',
+            [
+                'elementId' => 'cid',
+            ],
             [],
             ['ctype', IndexQueueRepository::AND_OPERATOR => 'tagid']
         );
@@ -59,13 +60,13 @@ final readonly class EnqueueService implements EnqueueServiceInterface
         $assetQuery = $this->indexQueueRepository->generateSelectQuery(
             'assets',
             [
-                ElementType::ASSET->value,
-                IndexName::ASSET->value,
-                IndexQueueOperation::UPDATE->value,
-                (string)$this->timeService->getCurrentMillisecondTimestamp(),
-                '0',
+                'elementId' => 'id',
+                'elementType' => "'" . ElementType::ASSET->value . "'",
+                'elementIndexName' => "'" . IndexName::ASSET->value . "'",
+                'operation' => "'" . IndexQueueOperation::UPDATE->value . "'",
+                'operationTime' => "'" . (string)$this->timeService->getCurrentMillisecondTimestamp() . "'",
+                'dispatched' => '0',
             ],
-            'id',
             ['ctype' => ElementType::ASSET->value, 'tagid' => $tag->getId()],
         );
         $assetQuery->where($assetQuery->expr()->in('id', $tagCondition->getSQL()));
@@ -75,12 +76,13 @@ final readonly class EnqueueService implements EnqueueServiceInterface
         $dataObjectQuery = $this->indexQueueRepository->generateSelectQuery(
             'objects',
             [
-                ElementType::DATA_OBJECT->value,
-                IndexQueueOperation::UPDATE->value,
-                (string)$this->timeService->getCurrentMillisecondTimestamp(),
-                '0',
+                'elementId' => 'id',
+                'elementType' => "'" . ElementType::DATA_OBJECT->value . "'",
+                'elementIndexName' => 'className',
+                'operation' => "'" . IndexQueueOperation::UPDATE->value . "'",
+                'operationTime' => "'" . (string)$this->timeService->getCurrentMillisecondTimestamp() . "'",
+                'dispatched' => '0',
             ],
-            'id, className',
             ['ctype' => ElementType::DATA_OBJECT->value, 'tagid' => $tag->getId()],
         );
         $dataObjectQuery->where($dataObjectQuery->expr()->in('id', $tagCondition->getSQL()));
@@ -98,13 +100,13 @@ final readonly class EnqueueService implements EnqueueServiceInterface
         $selectQuery = $this->indexQueueRepository->generateSelectQuery(
             $dataObjectTableName,
             [
-                ElementType::DATA_OBJECT->value,
-                $classDefinition->getName(),
-                IndexQueueOperation::UPDATE->value,
-                (string)$this->timeService->getCurrentMillisecondTimestamp(),
-                '0',
-            ],
-            'oo_id'
+                'elementId' => 'oo_id',
+                'elementType' => "'" . ElementType::DATA_OBJECT->value . "'",
+                'elementIndexName' => "'" . $classDefinition->getName() . "'",
+                'operation' => "'" . IndexQueueOperation::UPDATE->value . "'",
+                'operationTime' => "'" . (string)$this->timeService->getCurrentMillisecondTimestamp() . "'",
+                'dispatched' => '0',
+            ]
         );
         $this->indexQueueRepository->enqueueBySelectQuery(
             $selectQuery
@@ -119,11 +121,12 @@ final readonly class EnqueueService implements EnqueueServiceInterface
             $selectQuery = $this->indexQueueRepository->generateSelectQuery(
                 'objects',
                 [
-                    ElementType::DATA_OBJECT->value,
-                    IndexName::DATA_OBJECT_FOLDER->value,
-                    IndexQueueOperation::UPDATE->value,
-                    (string)$this->timeService->getCurrentMillisecondTimestamp(),
-                    '0',
+                    'elementId' => 'id',
+                    'elementType' => "'" . ElementType::DATA_OBJECT->value . "'",
+                    'elementIndexName' => "'" . IndexName::DATA_OBJECT_FOLDER->value . "'",
+                    'operation' => "'" . IndexQueueOperation::UPDATE->value . "'",
+                    'operationTime' => "'" . (string)$this->timeService->getCurrentMillisecondTimestamp() . "'",
+                    'dispatched' => '0',
                 ],
             )->where('type = "folder"');
             $this->indexQueueRepository->enqueueBySelectQuery($selectQuery);
@@ -145,11 +148,12 @@ final readonly class EnqueueService implements EnqueueServiceInterface
             $selectQuery = $this->indexQueueRepository->generateSelectQuery(
                 'assets',
                 [
-                    ElementType::ASSET->value,
-                    IndexName::ASSET->value,
-                    IndexQueueOperation::UPDATE->value,
-                    (string)$this->timeService->getCurrentMillisecondTimestamp(),
-                    '0',
+                    'elementId' => 'id',
+                    'elementType' => "'" . ElementType::ASSET->value . "'",
+                    'elementIndexName' => "'" . IndexName::ASSET->value . "'",
+                    'operation' => "'" . IndexQueueOperation::UPDATE->value . "'",
+                    'operationTime' => "'" . (string)$this->timeService->getCurrentMillisecondTimestamp() . "'",
+                    'dispatched' => '0',
                 ]
             );
             $this->indexQueueRepository->enqueueBySelectQuery($selectQuery);
@@ -171,11 +175,12 @@ final readonly class EnqueueService implements EnqueueServiceInterface
             $selectQuery = $this->indexQueueRepository->generateSelectQuery(
                 'documents',
                 [
-                    ElementType::DOCUMENT->value,
-                    IndexName::DOCUMENT->value,
-                    IndexQueueOperation::UPDATE->value,
-                    (string)$this->timeService->getCurrentMillisecondTimestamp(),
-                    '0',
+                    'elementId' => 'id',
+                    'elementType' => "'" . ElementType::DOCUMENT->value . "'",
+                    'elementIndexName' => "'" . IndexName::DOCUMENT->value . "'",
+                    'operation' => "'" . IndexQueueOperation::UPDATE->value . "'",
+                    'operationTime' => "'" . (string)$this->timeService->getCurrentMillisecondTimestamp() . "'",
+                    'dispatched' => '0',
                 ]
             );
             $this->indexQueueRepository->enqueueBySelectQuery($selectQuery);

--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/AssetTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/AssetTypeAdapter.php
@@ -85,12 +85,12 @@ final class AssetTypeAdapter extends AbstractElementTypeAdapter
     ): QueryBuilder {
 
         $selects = [
-            (string)$element->getId(),
-            "'" . ElementType::ASSET->value . "'",
-            "'" . IndexName::ASSET->value . "'",
-            "'$operation'",
-            "'$operationTime'",
-            '0',
+            (string)$element->getId() . ' AS elementId',
+            "'" . ElementType::ASSET->value . "' AS elementType",
+            "'" . IndexName::ASSET->value . "' AS elementIndexName",
+            "'$operation' AS operation",
+            "'$operationTime' AS operationTime",
+            '0 AS dispatched',
         ];
 
         return $this->dbConnection->createQueryBuilder()

--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DataObjectTypeAdapter.php
@@ -115,12 +115,12 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
         }
 
         $selects = [
-            'id',
-            "'" . ElementType::DATA_OBJECT->value . "'",
-            'className',
-            "'$operation'",
-            "'$operationTime'",
-            '0',
+            'id AS elementId',
+            "'" . ElementType::DATA_OBJECT->value . "' AS elementType",
+            'className AS elementIndexName',
+            "'$operation' AS operation",
+            "'$operationTime' AS operationTime",
+            '0 AS dispatched',
         ];
 
         $select = $this->dbConnection->createQueryBuilder()
@@ -188,12 +188,12 @@ final class DataObjectTypeAdapter extends AbstractElementTypeAdapter
         int $operationTime
     ): array {
         return [
-            (string)$element->getId(),
-            "'" . ElementType::DATA_OBJECT->value . "'",
-            $this->getIndexName($element, $operation),
-            "'$operation'",
-            "'$operationTime'",
-            '0',
+            (string)$element->getId() . ' AS elementId',
+            "'" . ElementType::DATA_OBJECT->value . "' AS elementType",
+            $this->getIndexName($element, $operation) . ' AS elementIndexName',
+            "'$operation' AS operation",
+            "'$operationTime' AS operationTime",
+            '0 AS dispatched',
         ];
     }
 

--- a/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DocumentTypeAdapter.php
+++ b/src/Service/SearchIndex/IndexService/ElementTypeAdapter/DocumentTypeAdapter.php
@@ -84,12 +84,12 @@ final class DocumentTypeAdapter extends AbstractElementTypeAdapter
         bool $includeElement = false
     ): QueryBuilder {
         $selects = [
-            (string)$element->getId(),
-            "'" . ElementType::DOCUMENT->value . "'",
-            "'" . IndexName::DOCUMENT->value . "'",
-            "'$operation'",
-            "'$operationTime'",
-            '0',
+            (string)$element->getId() . ' AS elementId',
+            "'" . ElementType::DOCUMENT->value . "' AS elementType",
+            "'" . IndexName::DOCUMENT->value . "' AS elementIndexName",
+            "'$operation' AS operation",
+            "'$operationTime' AS operationTime",
+            '0 AS dispatched',
         ];
 
         return $this->dbConnection->createQueryBuilder()

--- a/tests/Functional/SearchIndex/IndexQueueTest.php
+++ b/tests/Functional/SearchIndex/IndexQueueTest.php
@@ -92,11 +92,12 @@ class IndexQueueTest extends Unit
 
         $indexQueueRepository->enqueueBySelectQuery(
             $indexQueueRepository->generateSelectQuery('assets', [
-                ElementType::ASSET->value,
-                IndexName::ASSET->value,
-                IndexQueueOperation::UPDATE->value,
-                '1234',
-                '0',
+                'elementId' => 'id',
+                'elementType' => "'" . ElementType::ASSET->value . "'",
+                'elementIndexName' => "'" . IndexName::ASSET->value . "'",
+                'operation' => "'" . IndexQueueOperation::UPDATE->value . "'",
+                'operationTime' => "'1234'",
+                'dispatched' => '0',
             ])
         );
         $this->assertEquals(

--- a/tests/Unit/Repository/IndexQueueRepositoryTest.php
+++ b/tests/Unit/Repository/IndexQueueRepositoryTest.php
@@ -17,6 +17,7 @@ use Codeception\Test\Unit;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Entity\IndexQueue;
 use Pimcore\Bundle\GenericDataIndexBundle\Repository\IndexQueueRepository;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\TimeServiceInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -290,6 +291,88 @@ final class IndexQueueRepositoryTest extends Unit
 
         // Verify element type
         $this->assertContains('data_object', $insertParams);
+    }
+
+    public function testDeleteQueueEntriesMatchesOnIdAndOperationTime(): void
+    {
+        $executedQueries = [];
+
+        $connection = $this->makeEmpty(Connection::class, [
+            'quote' => function (string $value) {
+                return "'" . $value . "'";
+            },
+            'quoteIdentifier' => function (string $identifier) {
+                return '`' . $identifier . '`';
+            },
+            'executeQuery' => function (string $sql) use (&$executedQueries) {
+                $executedQueries[] = $sql;
+
+                return $this->makeEmpty(\Doctrine\DBAL\Result::class);
+            },
+        ]);
+
+        $repository = $this->createRepository($connection);
+
+        $entry1 = new IndexQueue();
+        $entry1->setId(42);
+        $entry1->setOperationTime('1711800000000');
+
+        $entry2 = new IndexQueue();
+        $entry2->setId(99);
+        $entry2->setOperationTime('1711800001000');
+
+        $repository->deleteQueueEntries([$entry1, $entry2]);
+
+        $this->assertCount(1, $executedQueries);
+        $sql = $executedQueries[0];
+
+        // Must match on BOTH id AND operationTime to prevent race condition
+        $this->assertStringContainsString('(`id`, `operationTime`) IN', $sql);
+        $this->assertStringContainsString("('42', '1711800000000')", $sql);
+        $this->assertStringContainsString("('99', '1711800001000')", $sql);
+    }
+
+    public function testDeleteQueueEntriesDoesNotDeleteRequeuedEntries(): void
+    {
+        // This test documents WHY the operationTime guard exists:
+        // If an element is re-queued (e.g., saved again) while being processed,
+        // the ON DUPLICATE KEY UPDATE changes the operationTime on the existing row.
+        // The DELETE must NOT match the re-queued entry because the operationTime
+        // no longer matches what was fetched during processing.
+
+        $executedQueries = [];
+
+        $connection = $this->makeEmpty(Connection::class, [
+            'quote' => function (string $value) {
+                return "'" . $value . "'";
+            },
+            'quoteIdentifier' => function (string $identifier) {
+                return '`' . $identifier . '`';
+            },
+            'executeQuery' => function (string $sql) use (&$executedQueries) {
+                $executedQueries[] = $sql;
+
+                return $this->makeEmpty(\Doctrine\DBAL\Result::class);
+            },
+        ]);
+
+        $repository = $this->createRepository($connection);
+
+        // Simulate an entry that was fetched with operationTime=1000
+        // but has since been re-queued with operationTime=2000
+        $entry = new IndexQueue();
+        $entry->setId(42);
+        $entry->setOperationTime('1000'); // original time when fetched
+
+        $repository->deleteQueueEntries([$entry]);
+
+        $sql = $executedQueries[0];
+
+        // The DELETE uses the ORIGINAL operationTime ('1000'), not the new one ('2000').
+        // In the database, the row now has operationTime=2000, so the tuple (42, '1000')
+        // will NOT match, and the re-queued entry will survive.
+        $this->assertStringContainsString("('42', '1000')", $sql);
+        $this->assertStringNotContainsString('WHERE `id` IN', $sql, 'Must not use id-only matching');
     }
 
     private function createRepository(Connection $connection): IndexQueueRepository

--- a/tests/Unit/Repository/IndexQueueRepositoryTest.php
+++ b/tests/Unit/Repository/IndexQueueRepositoryTest.php
@@ -1,0 +1,304 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Repository;
+
+use Codeception\Test\Unit;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Repository\IndexQueueRepository;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\TimeServiceInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * @internal
+ */
+final class IndexQueueRepositoryTest extends Unit
+{
+    private Connection $realConnection;
+
+    public function _before(): void
+    {
+        $this->realConnection = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
+        ]);
+    }
+
+    public function testGenerateSelectQueryProducesNamedAliases(): void
+    {
+        $repository = $this->createRepository($this->realConnection);
+
+        $qb = $repository->generateSelectQuery('assets', [
+            'elementId' => 'id',
+            'elementType' => "'asset'",
+            'elementIndexName' => "'asset'",
+            'operation' => "'update'",
+            'operationTime' => "'1234'",
+            'dispatched' => '0',
+        ]);
+
+        $sql = $qb->getSQL();
+
+        $this->assertStringContainsString('id AS elementId', $sql);
+        $this->assertStringContainsString("'asset' AS elementType", $sql);
+        $this->assertStringContainsString("'asset' AS elementIndexName", $sql);
+        $this->assertStringContainsString("'update' AS operation", $sql);
+        $this->assertStringContainsString("'1234' AS operationTime", $sql);
+        $this->assertStringContainsString('0 AS dispatched', $sql);
+        $this->assertStringContainsString('FROM assets', $sql);
+    }
+
+    public function testGenerateSelectQueryWithColumnReference(): void
+    {
+        $repository = $this->createRepository($this->realConnection);
+
+        $qb = $repository->generateSelectQuery('objects', [
+            'elementId' => 'id',
+            'elementType' => "'data_object'",
+            'elementIndexName' => 'className',
+            'operation' => "'update'",
+            'operationTime' => "'5678'",
+            'dispatched' => '0',
+        ]);
+
+        $sql = $qb->getSQL();
+
+        $this->assertStringContainsString('className AS elementIndexName', $sql);
+    }
+
+    public function testGenerateSelectQueryWithCustomIdColumn(): void
+    {
+        $repository = $this->createRepository($this->realConnection);
+
+        $qb = $repository->generateSelectQuery('object_1', [
+            'elementId' => 'oo_id',
+            'elementType' => "'data_object'",
+            'elementIndexName' => "'MyClass'",
+            'operation' => "'update'",
+            'operationTime' => "'9999'",
+            'dispatched' => '0',
+        ]);
+
+        $sql = $qb->getSQL();
+
+        $this->assertStringContainsString('oo_id AS elementId', $sql);
+        $this->assertStringContainsString('FROM object_1', $sql);
+    }
+
+    public function testGenerateSelectQueryWithWhereParameters(): void
+    {
+        $repository = $this->createRepository($this->realConnection);
+
+        $qb = $repository->generateSelectQuery(
+            'tags_assignment',
+            [
+                'elementId' => 'cid',
+            ],
+            [],
+            ['ctype', IndexQueueRepository::AND_OPERATOR => 'tagid']
+        );
+
+        $sql = $qb->getSQL();
+
+        $this->assertStringContainsString('cid AS elementId', $sql);
+        $this->assertStringContainsString('ctype = :ctype', $sql);
+        $this->assertStringContainsString('tagid = :tagid', $sql);
+    }
+
+    public function testGenerateSelectQueryWithParams(): void
+    {
+        $repository = $this->createRepository($this->realConnection);
+
+        $qb = $repository->generateSelectQuery(
+            'assets',
+            [
+                'elementId' => 'id',
+                'elementType' => "'asset'",
+                'elementIndexName' => "'asset'",
+                'operation' => "'update'",
+                'operationTime' => "'1234'",
+                'dispatched' => '0',
+            ],
+            ['ctype' => 'asset', 'tagid' => 42],
+        );
+
+        $params = $qb->getParameters();
+
+        $this->assertSame('asset', $params['ctype']);
+        $this->assertSame(42, $params['tagid']);
+    }
+
+    public function testGenerateSelectQueryWithSubsetOfAliases(): void
+    {
+        $repository = $this->createRepository($this->realConnection);
+
+        $qb = $repository->generateSelectQuery('tags_assignment', [
+            'elementId' => 'cid',
+        ]);
+
+        $sql = $qb->getSQL();
+
+        $this->assertStringContainsString('cid AS elementId', $sql);
+        $this->assertStringNotContainsString('elementType', $sql);
+        $this->assertStringNotContainsString('elementIndexName', $sql);
+    }
+
+    public function testEnqueueBySelectQueryWithEmptyResult(): void
+    {
+        $connection = $this->makeEmpty(Connection::class, [
+            'fetchAllAssociative' => [],
+        ]);
+
+        $repository = $this->createRepository($connection);
+
+        $qb = $this->makeEmpty(\Doctrine\DBAL\Query\QueryBuilder::class, [
+            'getSQL' => 'SELECT 1',
+            'getParameters' => [],
+        ]);
+
+        // Should not throw -- empty result is a no-op
+        $repository->enqueueBySelectQuery($qb);
+
+        // If we get here without exception, the test passes
+        $this->assertTrue(true);
+    }
+
+    public function testEnqueueBySelectQueryExtractsNamedColumns(): void
+    {
+        $insertStatements = [];
+
+        $connection = $this->makeEmpty(Connection::class, [
+            'fetchAllAssociative' => [
+                [
+                    'elementId' => '10',
+                    'elementType' => 'asset',
+                    'elementIndexName' => 'asset',
+                    'operation' => 'update',
+                    'operationTime' => '1711800000000',
+                    'dispatched' => '0',
+                ],
+                [
+                    'elementId' => '20',
+                    'elementType' => 'asset',
+                    'elementIndexName' => 'asset',
+                    'operation' => 'update',
+                    'operationTime' => '1711800000000',
+                    'dispatched' => '0',
+                ],
+            ],
+            'beginTransaction' => null,
+            'commit' => null,
+            'quoteIdentifier' => function (string $identifier) {
+                return '`' . $identifier . '`';
+            },
+            'executeStatement' => function (string $sql, array $params) use (&$insertStatements) {
+                $insertStatements[] = ['sql' => $sql, 'params' => $params];
+
+                return count($params) > 0 ? 2 : 0;
+            },
+        ]);
+
+        $repository = $this->createRepository($connection);
+
+        $qb = $this->makeEmpty(\Doctrine\DBAL\Query\QueryBuilder::class, [
+            'getSQL' => 'SELECT 1',
+            'getParameters' => [],
+        ]);
+
+        $repository->enqueueBySelectQuery($qb);
+
+        $this->assertNotEmpty($insertStatements, 'Expected at least one INSERT statement');
+
+        $insertSql = $insertStatements[0]['sql'];
+        $insertParams = $insertStatements[0]['params'];
+
+        // Verify the INSERT uses the correct column names
+        $this->assertStringContainsString('`elementId`', $insertSql);
+        $this->assertStringContainsString('`elementType`', $insertSql);
+        $this->assertStringContainsString('`elementIndexName`', $insertSql);
+        $this->assertStringContainsString('`operation`', $insertSql);
+        $this->assertStringContainsString('`operationTime`', $insertSql);
+
+        // Verify both element IDs are included in the params
+        $this->assertContains('10', $insertParams);
+        $this->assertContains('20', $insertParams);
+
+        // Verify the element type is passed correctly
+        $this->assertContains('asset', $insertParams);
+
+        // Verify the operation is passed correctly
+        $this->assertContains('update', $insertParams);
+    }
+
+    public function testEnqueueBySelectQueryExtractsDataObjectNamedColumns(): void
+    {
+        $insertStatements = [];
+
+        $connection = $this->makeEmpty(Connection::class, [
+            'fetchAllAssociative' => [
+                [
+                    'elementId' => '100',
+                    'elementType' => 'data_object',
+                    'elementIndexName' => 'Product',
+                    'operation' => 'update',
+                    'operationTime' => '1711800000000',
+                    'dispatched' => '0',
+                ],
+            ],
+            'beginTransaction' => null,
+            'commit' => null,
+            'quoteIdentifier' => function (string $identifier) {
+                return '`' . $identifier . '`';
+            },
+            'executeStatement' => function (string $sql, array $params) use (&$insertStatements) {
+                $insertStatements[] = ['sql' => $sql, 'params' => $params];
+
+                return 1;
+            },
+        ]);
+
+        $repository = $this->createRepository($connection);
+
+        $qb = $this->makeEmpty(\Doctrine\DBAL\Query\QueryBuilder::class, [
+            'getSQL' => 'SELECT 1',
+            'getParameters' => [],
+        ]);
+
+        $repository->enqueueBySelectQuery($qb);
+
+        $this->assertNotEmpty($insertStatements);
+
+        $insertParams = $insertStatements[0]['params'];
+
+        // Verify the element ID is extracted correctly
+        $this->assertContains('100', $insertParams);
+
+        // Verify the elementIndexName (class name) is extracted correctly
+        $this->assertContains('Product', $insertParams);
+
+        // Verify element type
+        $this->assertContains('data_object', $insertParams);
+    }
+
+    private function createRepository(Connection $connection): IndexQueueRepository
+    {
+        return new IndexQueueRepository(
+            $this->makeEmpty(EntityManagerInterface::class),
+            $this->makeEmpty(TimeServiceInterface::class),
+            $connection,
+            $this->makeEmpty(DenormalizerInterface::class)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Refactors `generateSelectQuery` to accept an associative `columnAliases` array (`alias => expression`) instead of positional `$selects`, producing named SQL aliases (e.g. `id AS elementId`) for robust, position-independent result extraction
- Refactors `getValuesFromSqlResult` to extract values by column alias name instead of fragile positional index access
- Updates all `EnqueueService` callers and type adapters (`Asset`, `Document`, `DataObject`) to use the new associative alias format
- Cleans up `deleteQueueEntries`: improved code structure and quoting while preserving the `(id, operationTime)` tuple matching that guards against race conditions
- Removes the unused `quoteParameters` method
- Adds 11 unit tests covering `generateSelectQuery`, `enqueueBySelectQuery`, and `deleteQueueEntries`

## Motivation

The previous implementation used positional array indices (`$result[0]`, `$result[1]`, etc.) to extract values from SQL query results. This was fragile — any change to column order in the SELECT statement would silently break the mapping. Named column aliases make the code self-documenting and resilient to column reordering.

## deleteQueueEntries — operationTime guard

The `deleteQueueEntries` method matches on `WHERE (id, operationTime) IN (...)` rather than just `WHERE id IN (...)`. This is intentional — it acts as an optimistic-concurrency guard:

1. The queue table has a **unique index on `(elementId, elementType)`**, so only one queue entry per element can exist
2. Re-queueing (e.g., element saved again during processing) uses `ON DUPLICATE KEY UPDATE`, which updates the existing row **in-place** — same `id`, but new `operationTime`
3. If `deleteQueueEntries` matched only on `id`, it would delete the re-queued entry, losing the pending update
4. By matching on `(id, operationTime)`, the DELETE becomes a no-op when `operationTime` has changed, and the re-queued entry survives for the next processing cycle

Two dedicated unit tests document and verify this behavior.