### PR TITLE
[PQL]: Add new modifiers for PQL in the tree

### DIFF
--- a/doc/04_Searching_For_Data_In_Index/05_Search_Modifiers/README.md
+++ b/doc/04_Searching_For_Data_In_Index/05_Search_Modifiers/README.md
@@ -54,9 +54,10 @@ $search->addModifier(new ParentIdFilter(1))
 
 ### Query Language
 
-| Modifier                                                                                                                         | Modifier Category | Description                                                                               |
-|----------------------------------------------------------------------------------------------------------------------------------|-------------------|-------------------------------------------------------------------------------------------|
-| [PqlFilter](https://github.com/pimcore/generic-data-index-bundle/blob/2.0/src/Model/Search/Modifier/QueryLanguage/PqlFilter.php) | Query Language    | Apply a [Pimcore Query Language (PQL)](../09_Pimcore_Query_Language/README.md) condition. |
+| Modifier                                                                                                                                 | Modifier Category | Description                                                                               |
+|------------------------------------------------------------------------------------------------------------------------------------------|-------------------|-------------------------------------------------------------------------------------------|
+| [PqlFilter](https://github.com/pimcore/generic-data-index-bundle/blob/2.0/src/Model/Search/Modifier/QueryLanguage/PqlFilter.php)         | Query Language    | Apply a [Pimcore Query Language (PQL)](../09_Pimcore_Query_Language/README.md) condition. |
+| [TreePqlFilter](https://github.com/pimcore/generic-data-index-bundle/blob/2.5/src/Model/Search/Modifier/QueryLanguage/TreePqlFilter.php) | Query Language    | Apply a [Pimcore Query Language (PQL)](../09_Pimcore_Query_Language/README.md) condition in a tree context: shows folders containing matching descendants and non-folder items matching the PQL query. Requires pre-computed relevant folder keys. |
 
 ### Sort Modifiers
 
@@ -75,8 +76,9 @@ If multiple sort modifiers are added to the search, the order of the modifiers i
 | Modifier                                                                                                                                                           | Modifier Category        | Description                                                                                                                                                                                         |
 |--------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [ChildrenCountAggregation](https://github.com/pimcore/generic-data-index-bundle/blob/2.0/src/Model/Search/Modifier/Aggregation/Tree/ChildrenCountAggregation.php)  | Tree related aggregation | Get children counts for given element IDs.                                                                                                                                                          |
+| [ChildFolderAggregation](https://github.com/pimcore/generic-data-index-bundle/blob/2.5/src/Model/Search/Modifier/Aggregation/Tree/ChildFolderAggregation.php)      | Tree related aggregation | Get the keys (names) of child folders at a specific tree level that contain descendants matching a search. Used internally by TreePqlFilter to determine which folders to display in filtered trees. |
 | [AssetMetaDataAggregation](https://github.com/pimcore/generic-data-index-bundle/blob/2.0/src/Model/Search/Modifier/Aggregation/Asset/AssetMetaDataAggregation.php) | Assets                   | Used for the filters in the asset grid to aggregate the filter options for supported meta data types.                                                                                               |
-| [FileSizeSumAggregation](https://github.com/pimcore/generic-data-index-bundle/blob/2.0/src/Model/Search/Modifier/Aggregation/Asset/FileSizeSumAggregation.php) | Assets                   | Aggregates the sum of file sizes for all assets for a given search. The `FileSizeAggregationServiceInterface` internally uses this aggregation and provides an easy way to use this functionality. |
+| [FileSizeSumAggregation](https://github.com/pimcore/generic-data-index-bundle/blob/2.0/src/Model/Search/Modifier/Aggregation/Asset/FileSizeSumAggregation.php)     | Assets                   | Aggregates the sum of file sizes for all assets for a given search. The `FileSizeAggregationServiceInterface` internally uses this aggregation and provides an easy way to use this functionality. |
 
 ## Search Modifier Implementation Details
 

--- a/src/Model/Search/Modifier/Aggregation/Tree/ChildFolderAggregation.php
+++ b/src/Model/Search/Modifier/Aggregation/Tree/ChildFolderAggregation.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Aggregation\Tree;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierInterface;
+
+final readonly class ChildFolderAggregation implements SearchModifierInterface
+{
+    public const string AGGREGATION_NAME = 'child_folders_with_matches';
+
+    private const int DEFAULT_MAX_FOLDERS = 10000;
+
+    private int $childLevel;
+
+    public function __construct(
+        private string $parentPath,
+        private int $maxFolders = self::DEFAULT_MAX_FOLDERS,
+    ) {
+        $segments = array_filter(explode('/', $this->parentPath));
+        $this->childLevel = count($segments) + 1;
+    }
+
+    public function getParentPath(): string
+    {
+        return $this->parentPath;
+    }
+
+    public function getChildLevel(): int
+    {
+        return $this->childLevel;
+    }
+
+    public function getMaxFolders(): int
+    {
+        return $this->maxFolders;
+    }
+
+    public function getAggregationName(): string
+    {
+        return self::AGGREGATION_NAME;
+    }
+}

--- a/src/Model/Search/Modifier/QueryLanguage/TreePqlFilter.php
+++ b/src/Model/Search/Modifier/QueryLanguage/TreePqlFilter.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\QueryLanguage;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierInterface;
+
+final readonly class TreePqlFilter implements SearchModifierInterface
+{
+    public function __construct(
+        private string $query,
+        /** @var string[] */
+        private array $relevantFolderKeys,
+    ) {
+    }
+
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRelevantFolderKeys(): array
+    {
+        return $this->relevantFolderKeys;
+    }
+}

--- a/src/SearchIndexAdapter/DefaultSearch/Search/Modifier/Aggregation/TreeAggregations.php
+++ b/src/SearchIndexAdapter/DefaultSearch/Search/Modifier/Aggregation/TreeAggregations.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemF
 use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Aggregation\Aggregation;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Modifier\SearchModifierContextInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Query\TermsFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Aggregation\Tree\ChildFolderAggregation;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Aggregation\Tree\ChildrenCountAggregation;
 
 /**
@@ -46,6 +47,46 @@ final class TreeAggregations
                             'size' => count($aggregation->getParentIds()),
                         ],
                     ]
+                )
+            )
+            ->setSize(0)
+        ;
+    }
+
+    #[AsSearchModifierHandler]
+    public function handleChildFolderAggregation(
+        ChildFolderAggregation $aggregation,
+        SearchModifierContextInterface $context
+    ): void {
+        $context->getSearch()
+            ->addAggregation(
+                new Aggregation(
+                    name: $aggregation->getAggregationName(),
+                    params: [
+                        'nested' => [
+                            'path' => SystemField::PATH_LEVELS->getPath(),
+                        ],
+                        'aggs' => [
+                            'filtered_level' => [
+                                'filter' => [
+                                    'term' => [
+                                        SystemField::PATH_LEVELS->getPath()
+                                            . '.level'
+                                            => $aggregation->getChildLevel(),
+                                    ],
+                                ],
+                                'aggs' => [
+                                    'folder_names' => [
+                                        'terms' => [
+                                            'field' => SystemField::PATH_LEVELS->getPath()
+                                                . '.name',
+                                            'size' => $aggregation->getMaxFolders(),
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
                 )
             )
             ->setSize(0)

--- a/src/SearchIndexAdapter/DefaultSearch/Search/Modifier/QueryLanguage/QueryLanguageHandlers.php
+++ b/src/SearchIndexAdapter/DefaultSearch/Search/Modifier/QueryLanguage/QueryLanguageHandlers.php
@@ -15,13 +15,18 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch
 
 use Pimcore\Bundle\GenericDataIndexBundle\Attribute\Search\AsSearchModifierHandler;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\DefaultSearch\ConditionType;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\QueryLanguage\ParsingException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Modifier\SearchModifierContextInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Query\BoolQuery;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Query\TermFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Query\TermsFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\QueryLanguage\PqlFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\QueryLanguage\TreePqlFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\QueryLanguage\ProcessorInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\IndexNameResolverInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexEntityServiceInterface;
+use Pimcore\Model\DataObject\AbstractObject;
 
 /**
  * @internal
@@ -43,16 +48,88 @@ final readonly class QueryLanguageHandlers
         PqlFilter $pql,
         SearchModifierContextInterface $context
     ): void {
-
-        $query = $this->queryLanguageProcessor->process(
-            $pql->getQuery(),
-            $this->indexEntityService->getByIndexName(
-                $this->indexNameResolver->resolveIndexName($context->getOriginalSearch())
-            )
+        $context->getSearch()->addQuery(
+            new BoolQuery([
+                ConditionType::MUST->value => $this->processPql(
+                    $pql->getQuery(),
+                    $context,
+                ),
+            ])
         );
+    }
+
+    /**
+     * @throws ParsingException
+     */
+    #[AsSearchModifierHandler]
+    public function handleTreePqlFilter(
+        TreePqlFilter $treePqlFilter,
+        SearchModifierContextInterface $context
+    ): void {
+        $pqlConditions = $this->processPql($treePqlFilter->getQuery(), $context);
+        $folderKeys = $treePqlFilter->getRelevantFolderKeys();
+
+        // Branch B: non-folders matching the PQL query
+        $nonFolderBranch = new BoolQuery([
+            ConditionType::MUST_NOT->value => [
+                new TermFilter(
+                    field: SystemField::TYPE->getPath(),
+                    term: AbstractObject::OBJECT_TYPE_FOLDER,
+                ),
+            ],
+            ConditionType::MUST->value => $pqlConditions,
+        ]);
+
+        // If no relevant folders found, only show non-folder PQL matches
+        if (empty($folderKeys)) {
+            $context->getSearch()->addQuery(
+                new BoolQuery([ConditionType::MUST->value => [$nonFolderBranch]])
+            );
+
+            return;
+        }
+
+        // Branch A: folders whose key is in the relevant folder list
+        $folderBranch = new BoolQuery([
+            ConditionType::FILTER->value => [
+                new TermFilter(
+                    field: SystemField::TYPE->getPath(),
+                    term: AbstractObject::OBJECT_TYPE_FOLDER,
+                ),
+                new TermsFilter(
+                    field: SystemField::KEY->getPath(),
+                    terms: $folderKeys,
+                ),
+            ],
+        ]);
+
+        // Combine: at least one branch must match
+        $combinedQuery = new BoolQuery([
+            ConditionType::SHOULD->value => [
+                $folderBranch,
+                $nonFolderBranch,
+            ],
+        ]);
 
         $context->getSearch()->addQuery(
-            new BoolQuery([ConditionType::MUST->value => $query])
+            new BoolQuery([ConditionType::MUST->value => [$combinedQuery]])
+        );
+    }
+
+    /**
+     * @throws ParsingException
+     */
+    private function processPql(
+        string $query,
+        SearchModifierContextInterface $context,
+    ): array {
+        return $this->queryLanguageProcessor->process(
+            $query,
+            $this->indexEntityService->getByIndexName(
+                $this->indexNameResolver->resolveIndexName(
+                    $context->getOriginalSearch()
+                )
+            )
         );
     }
 }

--- a/tests/Functional/Search/Modifier/Aggregation/ChildFolderAggregationTest.php
+++ b/tests/Functional/Search/Modifier/Aggregation/ChildFolderAggregationTest.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Functional\Search\Modifier\Aggregation;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Aggregation\Tree\ChildFolderAggregation;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\ExcludeFoldersFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\PathFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\QueryLanguage\PqlFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\DataObjectSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
+use Pimcore\Model\DataObject\Unittest;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+final class ChildFolderAggregationTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \Pimcore\Bundle\GenericDataIndexBundle\Tests\IndexTester
+     */
+    protected $tester;
+
+    protected function _before()
+    {
+        $this->tester->enableSynchronousProcessing();
+    }
+
+    protected function _after()
+    {
+        TestHelper::cleanUp();
+        $this->tester->flushIndex();
+        $this->tester->cleanupIndex();
+        $this->tester->flushIndex();
+    }
+
+    public function testChildFolderAggregationReturnsChildFolderNames(): void
+    {
+        $folderA = TestHelper::createObjectFolder('cfaA_');
+        $folderB = TestHelper::createObjectFolder('cfaB_');
+
+        /** @var Unittest $object1 */
+        $object1 = TestHelper::createEmptyObject('obj1_', false);
+        $object1->setParent($folderA)->setInput('match')->setPublished(true)->save();
+
+        /** @var Unittest $object2 */
+        $object2 = TestHelper::createEmptyObject('obj2_', false);
+        $object2->setParent($folderB)->setInput('match')->setPublished(true)->save();
+
+        /** @var Unittest $object3 */
+        $object3 = TestHelper::createEmptyObject('obj3_');
+        $object3->setInput('match')->save();
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        // Simulate the real usage: PathFilter + ExcludeFoldersFilter + PqlFilter + ChildFolderAggregation
+        $aggregation = new ChildFolderAggregation('/');
+
+        $dataObjectSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier(new PathFilter('/'))
+            ->addModifier(new ExcludeFoldersFilter())
+            ->addModifier(new PqlFilter('input = "match"'))
+            ->addModifier($aggregation)
+            ->setClassDefinition($object1->getClass())
+        ;
+        $dataObjectSearch->setAggregationsOnly(true);
+
+        $searchResult = $searchService->search($dataObjectSearch);
+        $folderNames = $this->extractFolderNames($searchResult, $aggregation->getAggregationName());
+
+        sort($folderNames);
+        $expectedNames = [$folderA->getKey(), $folderB->getKey()];
+        sort($expectedNames);
+
+        $this->assertEquals(
+            $expectedNames,
+            $folderNames,
+            'Aggregation should return folder names of direct children containing matching objects'
+        );
+    }
+
+    public function testChildFolderAggregationNestedLevels()
+    {
+        $topFolder = TestHelper::createObjectFolder('cfaTop_');
+        $subFolderA = TestHelper::createObjectFolder('cfaSub1_', false);
+        $subFolderA->setParent($topFolder)->save();
+        $subFolderB = TestHelper::createObjectFolder('cfaSub2_', false);
+        $subFolderB->setParent($topFolder)->save();
+
+        /** @var Unittest $object1 */
+        $object1 = TestHelper::createEmptyObject('obj1_', false);
+        $object1->setParent($subFolderA)->setInput('deep')->setPublished(true)->save();
+
+        /** @var Unittest $object2 */
+        $object2 = TestHelper::createEmptyObject('obj2_', false);
+        $object2->setParent($subFolderB)->setInput('deep')->setPublished(true)->save();
+
+        /** @var Unittest $object3 */
+        $object3 = TestHelper::createEmptyObject('obj3_', false);
+        $object3->setParent($topFolder)->setInput('deep')->setPublished(true)->save();
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        // Query from root — should find topFolder at child level 1
+        $aggregationRoot = new ChildFolderAggregation('/');
+
+        $rootSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier(new PathFilter('/'))
+            ->addModifier(new ExcludeFoldersFilter())
+            ->addModifier(new PqlFilter('input = "deep"'))
+            ->addModifier($aggregationRoot)
+            ->setClassDefinition($object1->getClass())
+        ;
+        $rootSearch->setAggregationsOnly(true);
+
+        $rootResult = $searchService->search($rootSearch);
+        $rootFolderNames = $this->extractFolderNames($rootResult, $aggregationRoot->getAggregationName());
+
+        $this->assertEquals(
+            [$topFolder->getKey()],
+            $rootFolderNames,
+            'At root level, only topFolder should appear (not subFolders)'
+        );
+
+        // Query from topFolder — should find subFolderA and subFolderB at child level 2
+        $aggregationTop = new ChildFolderAggregation($topFolder->getRealFullPath());
+
+        $topSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier(new PathFilter($topFolder->getRealFullPath()))
+            ->addModifier(new ExcludeFoldersFilter())
+            ->addModifier(new PqlFilter('input = "deep"'))
+            ->addModifier($aggregationTop)
+            ->setClassDefinition($object1->getClass())
+        ;
+        $topSearch->setAggregationsOnly(true);
+
+        $topResult = $searchService->search($topSearch);
+        $topFolderNames = $this->extractFolderNames($topResult, $aggregationTop->getAggregationName());
+
+        sort($topFolderNames);
+        $expectedSubNames = [$subFolderA->getKey(), $subFolderB->getKey()];
+        sort($expectedSubNames);
+
+        $this->assertEquals(
+            $expectedSubNames,
+            $topFolderNames,
+            'At topFolder level, subFolderA and subFolderB should appear'
+        );
+    }
+
+    public function testChildFolderAggregationNoMatches()
+    {
+        $folder = TestHelper::createObjectFolder('cfaEmpty_');
+
+        /** @var Unittest $object */
+        $object = TestHelper::createEmptyObject('obj_', false);
+        $object->setParent($folder)->setInput('something')->setPublished(true)->save();
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        $aggregation = new ChildFolderAggregation('/');
+
+        $dataObjectSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier(new PathFilter('/'))
+            ->addModifier(new ExcludeFoldersFilter())
+            ->addModifier(new PqlFilter('input = "nonexistent_value"'))
+            ->addModifier($aggregation)
+            ->setClassDefinition($object->getClass())
+        ;
+        $dataObjectSearch->setAggregationsOnly(true);
+
+        $searchResult = $searchService->search($dataObjectSearch);
+        $folderNames = $this->extractFolderNames($searchResult, $aggregation->getAggregationName());
+
+        $this->assertEmpty($folderNames, 'No folder names when PQL matches nothing');
+    }
+
+    public function testChildFolderAggregationOnlyMatchingFolders()
+    {
+        $folderWithMatch = TestHelper::createObjectFolder('cfaWith_');
+        $folderWithoutMatch = TestHelper::createObjectFolder('cfaWithout_');
+
+        /** @var Unittest $object1 */
+        $object1 = TestHelper::createEmptyObject('obj1_', false);
+        $object1->setParent($folderWithMatch)->setInput('target')->setPublished(true)->save();
+
+        /** @var Unittest $object2 */
+        $object2 = TestHelper::createEmptyObject('obj2_', false);
+        $object2->setParent($folderWithoutMatch)->setInput('other')->setPublished(true)->save();
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        $aggregation = new ChildFolderAggregation('/');
+
+        $dataObjectSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier(new PathFilter('/'))
+            ->addModifier(new ExcludeFoldersFilter())
+            ->addModifier(new PqlFilter('input = "target"'))
+            ->addModifier($aggregation)
+            ->setClassDefinition($object1->getClass())
+        ;
+        $dataObjectSearch->setAggregationsOnly(true);
+
+        $searchResult = $searchService->search($dataObjectSearch);
+        $folderNames = $this->extractFolderNames($searchResult, $aggregation->getAggregationName());
+
+        $this->assertEquals(
+            [$folderWithMatch->getKey()],
+            $folderNames,
+            'Only folders containing PQL-matching objects should appear in aggregation'
+        );
+
+        $this->assertNotContains(
+            $folderWithoutMatch->getKey(),
+            $folderNames,
+            'Folders without matching content must not appear'
+        );
+    }
+
+    private function extractFolderNames($searchResult, string $aggregationName): array
+    {
+        $aggregation = $searchResult->getAggregation($aggregationName);
+        if ($aggregation === null) {
+            return [];
+        }
+
+        $result = $aggregation->getAggregationResult();
+        $buckets = $result['filtered_level']['folder_names']['buckets'] ?? [];
+
+        return array_map(
+            static fn (array $bucket): string => (string) $bucket['key'],
+            $buckets,
+        );
+    }
+}

--- a/tests/Functional/Search/Modifier/QueryLanguage/TreePqlFilterTest.php
+++ b/tests/Functional/Search/Modifier/QueryLanguage/TreePqlFilterTest.php
@@ -1,0 +1,351 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Functional\Search\Modifier\QueryLanguage;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\ParentIdFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\QueryLanguage\TreePqlFilter;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\DataObjectSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchProviderInterface;
+use Pimcore\Model\DataObject\Unittest;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+class TreePqlFilterTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \Pimcore\Bundle\GenericDataIndexBundle\Tests\IndexTester
+     */
+    protected $tester;
+
+    protected function _before()
+    {
+        $this->tester->enableSynchronousProcessing();
+    }
+
+    protected function _after()
+    {
+        TestHelper::cleanUp();
+        $this->tester->flushIndex();
+        $this->tester->cleanupIndex();
+        $this->tester->flushIndex();
+    }
+
+    public function testTreePqlFilterWithRelevantFolderKeys(): void
+    {
+        $folderA = TestHelper::createObjectFolder('treeA_');
+        $folderB = TestHelper::createObjectFolder('treeB_');
+
+        /** @var Unittest $object1 */
+        $object1 = TestHelper::createEmptyObject('obj1_', false);
+        $object1->setParent($folderA)->setPublished(true)->save();
+
+        /** @var Unittest $object2 */
+        $object2 = TestHelper::createEmptyObject('obj2_', false);
+        $object2->setParent($folderB)->setPublished(true)->save();
+
+        /** @var Unittest $object3 */
+        $object3 = TestHelper::createEmptyObject('obj3_');
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        // PQL matches only object1 (inside folderA).
+        // Relevant folder keys: only folderA.
+        // At root with ParentIdFilter(1): folderA appears as a matching folder.
+        // object3 is at root but does NOT match PQL (different path), so excluded.
+        $pqlQuery = 'fullPath LIKE "' . $folderA->getRealFullPath() . '/*"';
+
+        $treePqlFilter = new TreePqlFilter(
+            $pqlQuery,
+            [$folderA->getKey()]
+        );
+
+        $dataObjectSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier($treePqlFilter)
+            ->addModifier(new ParentIdFilter(1))
+        ;
+        $searchResult = $searchService->search($dataObjectSearch);
+
+        $this->assertIdArrayEquals(
+            [$folderA->getId()],
+            $searchResult->getIds(),
+            'TreePqlFilter should return relevant folder at root level'
+        );
+    }
+
+    public function testTreePqlFilterWithEmptyFolderKeys(): void
+    {
+        $folder = TestHelper::createObjectFolder('emptyKeys_');
+
+        /** @var Unittest $object1 */
+        $object1 = TestHelper::createEmptyObject('obj1_', false);
+        $object1->setParent($folder)->setPublished(true)->save();
+
+        /** @var Unittest $object2 */
+        $object2 = TestHelper::createEmptyObject('obj2_', false);
+        $object2->setParent($folder)->setPublished(true)->save();
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        // Empty folder keys + ParentIdFilter on folder: only non-folder PQL matches inside
+        $pqlQuery = 'fullPath LIKE "' . $folder->getRealFullPath() . '/*"';
+        $treePqlFilter = new TreePqlFilter($pqlQuery, []);
+
+        $dataObjectSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier($treePqlFilter)
+            ->addModifier(new ParentIdFilter($folder->getId()))
+        ;
+        $searchResult = $searchService->search($dataObjectSearch);
+
+        $this->assertIdArrayEquals(
+            [$object1->getId(), $object2->getId()],
+            $searchResult->getIds(),
+            'Empty folderKeys should return only non-folder PQL matches'
+        );
+    }
+
+    public function testTreePqlFilterExcludesNonMatchingFolders(): void
+    {
+        $folderMatch = TestHelper::createObjectFolder('match_');
+        $folderNoMatch = TestHelper::createObjectFolder('nomatch_');
+
+        /** @var Unittest $object1 */
+        $object1 = TestHelper::createEmptyObject('obj1_', false);
+        $object1->setParent($folderMatch)->setPublished(true)->save();
+
+        /** @var Unittest $object2 */
+        $object2 = TestHelper::createEmptyObject('obj2_', false);
+        $object2->setParent($folderNoMatch)->setPublished(true)->save();
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        // PQL matches objects under both folders, but only folderMatch is relevant.
+        $pqlQuery = 'fullPath LIKE "' . $folderMatch->getRealFullPath() . '/*"'
+            . ' or fullPath LIKE "' . $folderNoMatch->getRealFullPath() . '/*"';
+
+        $treePqlFilter = new TreePqlFilter(
+            $pqlQuery,
+            [$folderMatch->getKey()]
+        );
+
+        $dataObjectSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier($treePqlFilter)
+            ->addModifier(new ParentIdFilter(1))
+        ;
+        $searchResult = $searchService->search($dataObjectSearch);
+
+        // Only folderMatch should appear (folderNoMatch excluded despite having matching descendants)
+        $this->assertIdArrayEquals(
+            [$folderMatch->getId()],
+            $searchResult->getIds(),
+            'Only folders in relevantFolderKeys should be returned'
+        );
+    }
+
+    public function testTreePqlFilterWithMultipleFolders(): void
+    {
+        $folderA = TestHelper::createObjectFolder('multiA_');
+        $folderB = TestHelper::createObjectFolder('multiB_');
+        $folderC = TestHelper::createObjectFolder('multiC_');
+
+        /** @var Unittest $object1 */
+        $object1 = TestHelper::createEmptyObject('obj1_', false);
+        $object1->setParent($folderA)->setPublished(true)->save();
+
+        /** @var Unittest $object2 */
+        $object2 = TestHelper::createEmptyObject('obj2_', false);
+        $object2->setParent($folderB)->setPublished(true)->save();
+
+        /** @var Unittest $object3 */
+        $object3 = TestHelper::createEmptyObject('obj3_', false);
+        $object3->setParent($folderC)->setPublished(true)->save();
+
+        /** @var Unittest $object4 */
+        $object4 = TestHelper::createEmptyObject('obj4_');
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        // PQL matches objects under folderA and folderB only
+        $pqlQuery = 'fullPath LIKE "' . $folderA->getRealFullPath() . '/*"'
+            . ' or fullPath LIKE "' . $folderB->getRealFullPath() . '/*"';
+
+        $treePqlFilter = new TreePqlFilter(
+            $pqlQuery,
+            [$folderA->getKey(), $folderB->getKey()]
+        );
+
+        $dataObjectSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier($treePqlFilter)
+            ->addModifier(new ParentIdFilter(1))
+        ;
+        $searchResult = $searchService->search($dataObjectSearch);
+
+        // At root level: folderA, folderB (matching folders); object4 does NOT match PQL
+        $this->assertIdArrayEquals(
+            [$folderA->getId(), $folderB->getId()],
+            $searchResult->getIds(),
+            'Multiple relevant folders should all appear at root'
+        );
+    }
+
+    public function testTreePqlFilterInsideFolder(): void
+    {
+        $folder = TestHelper::createObjectFolder('inside_');
+
+        /** @var Unittest $objectMatch */
+        $objectMatch = TestHelper::createEmptyObject('objM_', false);
+        $objectMatch->setParent($folder)->setPublished(true)->save();
+
+        /** @var Unittest $objectNoMatch */
+        $objectNoMatch = TestHelper::createEmptyObject('objNM_', false);
+        $objectNoMatch->setParent($folder)->setPublished(true)->save();
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        // PQL that only matches objectMatch by its fullPath
+        $pqlQuery = 'fullPath = "' . $objectMatch->getRealFullPath() . '"';
+        $treePqlFilter = new TreePqlFilter($pqlQuery, []);
+
+        $dataObjectSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier($treePqlFilter)
+            ->addModifier(new ParentIdFilter($folder->getId()))
+        ;
+        $searchResult = $searchService->search($dataObjectSearch);
+
+        $this->assertIdArrayEquals(
+            [$objectMatch->getId()],
+            $searchResult->getIds(),
+            'Inside a folder with empty folderKeys, only PQL-matching non-folders should appear'
+        );
+    }
+
+    public function testTreePqlFilterNoMatches(): void
+    {
+        /** @var Unittest $object */
+        $object = TestHelper::createEmptyObject('obj_');
+
+        $folder = TestHelper::createObjectFolder('noMatch_');
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        $treePqlFilter = new TreePqlFilter('fullPath LIKE "/nonexistent_path_xyz/*"', []);
+
+        $dataObjectSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier($treePqlFilter)
+        ;
+        $searchResult = $searchService->search($dataObjectSearch);
+
+        $this->assertEmpty(
+            $searchResult->getIds(),
+            'No results when PQL matches nothing and no folder keys provided'
+        );
+    }
+
+    public function testTreePqlFilterNestedHierarchy(): void
+    {
+        $topFolder = TestHelper::createObjectFolder('top_');
+        $subFolder = TestHelper::createObjectFolder('sub_', false);
+        $subFolder->setParent($topFolder)->save();
+        $otherFolder = TestHelper::createObjectFolder('other_');
+
+        /** @var Unittest $object1 */
+        $object1 = TestHelper::createEmptyObject('obj1_', false);
+        $object1->setParent($subFolder)->setPublished(true)->save();
+
+        /** @var Unittest $object2 */
+        $object2 = TestHelper::createEmptyObject('obj2_', false);
+        $object2->setParent($topFolder)->setPublished(true)->save();
+
+        /** @var Unittest $object3 */
+        $object3 = TestHelper::createEmptyObject('obj3_', false);
+        $object3->setParent($otherFolder)->setPublished(true)->save();
+
+        /** @var DataObjectSearchServiceInterface $searchService */
+        $searchService = $this->tester->grabService('generic-data-index.test.service.data-object-search-service');
+        /** @var SearchProviderInterface $searchProvider */
+        $searchProvider = $this->tester->grabService(SearchProviderInterface::class);
+
+        // PQL matches all three objects (descendants of topFolder or otherFolder)
+        $pqlQuery = 'fullPath LIKE "' . $topFolder->getRealFullPath() . '/*"'
+            . ' or fullPath LIKE "' . $otherFolder->getRealFullPath() . '/*"';
+
+        // At root level: both topFolder and otherFolder have PQL-matching descendants.
+        $treePqlFilter = new TreePqlFilter(
+            $pqlQuery,
+            [$topFolder->getKey(), $otherFolder->getKey()]
+        );
+
+        $dataObjectSearch = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier($treePqlFilter)
+            ->addModifier(new ParentIdFilter(1))
+        ;
+        $searchResult = $searchService->search($dataObjectSearch);
+
+        // At root level: topFolder and otherFolder
+        $this->assertIdArrayEquals(
+            [$topFolder->getId(), $otherFolder->getId()],
+            $searchResult->getIds(),
+            'Both folders with matching descendants should appear at root level'
+        );
+
+        // Now expand topFolder — subFolder has matching content, plus object2 directly matches PQL.
+        $treePqlFilterTop = new TreePqlFilter(
+            $pqlQuery,
+            [$subFolder->getKey()]
+        );
+
+        $dataObjectSearchTop = $searchProvider
+            ->createDataObjectSearch()
+            ->addModifier($treePqlFilterTop)
+            ->addModifier(new ParentIdFilter($topFolder->getId()))
+        ;
+        $searchResultTop = $searchService->search($dataObjectSearchTop);
+
+        // Inside topFolder: subFolder (has matching content) + object2 (non-folder, matches PQL)
+        $this->assertIdArrayEquals(
+            [$subFolder->getId(), $object2->getId()],
+            $searchResultTop->getIds(),
+            'Inside parent folder: sub-folder with matches + direct PQL-matching objects'
+        );
+    }
+
+    private function assertIdArrayEquals(array $ids1, array $ids2, string $message = ''): void
+    {
+        sort($ids1);
+        sort($ids2);
+        $this->assertEquals($ids1, $ids2, $message);
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-ui-bundle/issues/2245

## Additional info
- add new modifiers which are necessary for correct application of PQL in the tree
- filter folder IDs which are not empty from top level to target level
- add modifier to apply PQL and include folderIds from first query