### PR TITLE
Avoid accumulating executed search debug traces outside debug mode

### DIFF
--- a/config/services/search-index-adapter/default-search.yaml
+++ b/config/services/search-index-adapter/default-search.yaml
@@ -22,6 +22,7 @@ services:
         class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Search\SearchExecutionService
         arguments:
             $client: "@generic-data-index.search-client"
+            $debugMode: "%kernel.debug%"
 
     Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\BulkOperationServiceInterface:
         class: Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\BulkOperationService

--- a/src/SearchIndexAdapter/DefaultSearch/Search/SearchExecutionService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/Search/SearchExecutionService.php
@@ -36,6 +36,7 @@ final class SearchExecutionService implements SearchExecutionServiceInterface
     public function __construct(
         private readonly SearchResultDenormalizer $searchResultDenormalizer,
         private readonly SearchClientInterface $client,
+        private readonly bool $debugMode,
     ) {
     }
 
@@ -74,7 +75,9 @@ final class SearchExecutionService implements SearchExecutionServiceInterface
                 []
             );
 
-            $this->executedSearches[] = $searchInformation;
+            if ($this->debugMode) {
+                $this->executedSearches[] = $searchInformation;
+            }
 
             if ($this->isWindowTooLarge($e)) {
                 throw new ResultWindowTooLargeException(
@@ -97,13 +100,15 @@ final class SearchExecutionService implements SearchExecutionServiceInterface
             $defaultSearchResult['hits']['hits'] = array_reverse($defaultSearchResult['hits']['hits']);
         }
 
-        $this->executedSearches[] = new SearchInformation(
-            $search,
-            true,
-            $defaultSearchResult,
-            $executionTime,
-            debug_backtrace(),
-        );
+        if ($this->debugMode) {
+            $this->executedSearches[] = new SearchInformation(
+                $search,
+                true,
+                $defaultSearchResult,
+                $executionTime,
+                debug_backtrace(),
+            );
+        }
 
         return $this->searchResultDenormalizer->denormalize(
             $defaultSearchResult,

--- a/tests/Functional/DefaultSearch/DefaultSearchServiceTest.php
+++ b/tests/Functional/DefaultSearch/DefaultSearchServiceTest.php
@@ -245,13 +245,8 @@ class DefaultSearchServiceTest extends \Codeception\Test\Unit
         $this->assertEquals(3, $result->getTotalHits());
         $this->assertCount(2, $result->getHits());
 
-        $this->assertCount(1, $searchIndexService->getExecutedSearches());
-        $searchInformation = $searchIndexService->getExecutedSearches()[0];
-        $this->assertEquals($search, $searchInformation->getSearch());
-        $this->assertTrue($searchInformation->isSuccess());
-        $this->assertEquals($searchInformation->getResponse()['hits']['total']['value'], $result->getTotalHits());
-        $this->assertIsNumeric($searchInformation->getExecutionTime());
-        $this->assertNotEmpty($searchInformation->getStackTrace());
+        // executed searches are only collected in debug mode (kernel.debug) —
+        // covered by the unit test Tests\Unit\...\Search\SearchExecutionServiceTest
 
         $searchIndexService->deleteIndex('test_index');
     }

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/Search/SearchExecutionServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/Search/SearchExecutionServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\SearchIndexAdapter\DefaultSearch\Search;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\DefaultSearch\SearchFailedException;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Search\SearchExecutionService;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Serializer\Denormalizer\SearchIndexAdapter\SearchResultDenormalizer;
+use Pimcore\SearchClient\SearchClientInterface;
+
+/**
+ * @internal
+ */
+final class SearchExecutionServiceTest extends Unit
+{
+    public function testExecutedSearchesAreCollectedInDebugMode(): void
+    {
+        $service = $this->createService(debugMode: true);
+        $search = $this->createSearch();
+
+        $service->executeSearch($search, 'test_index');
+
+        $executedSearches = $service->getExecutedSearches();
+        $this->assertCount(1, $executedSearches);
+        $searchInformation = $executedSearches[0];
+        $this->assertTrue($searchInformation->isSuccess());
+        $this->assertSame($search, $searchInformation->getSearch());
+        $this->assertSame(0, $searchInformation->getResponse()['hits']['total']['value']);
+        $this->assertIsNumeric($searchInformation->getExecutionTime());
+        $this->assertNotEmpty($searchInformation->getStackTrace());
+    }
+
+    public function testExecutedSearchesAreNotCollectedOutsideDebugMode(): void
+    {
+        $service = $this->createService(debugMode: false);
+
+        $service->executeSearch($this->createSearch(), 'test_index');
+
+        $this->assertSame([], $service->getExecutedSearches());
+    }
+
+    public function testFailedSearchesAreCollectedInDebugMode(): void
+    {
+        $service = $this->createService(
+            debugMode: true,
+            client: $this->makeEmpty(SearchClientInterface::class, [
+                'search' => static fn () => throw new Exception('search failed'),
+            ])
+        );
+
+        try {
+            $service->executeSearch($this->createSearch(), 'test_index');
+            $this->fail('SearchFailedException was not thrown');
+        } catch (SearchFailedException) {
+            // expected
+        }
+
+        $executedSearches = $service->getExecutedSearches();
+        $this->assertCount(1, $executedSearches);
+        $this->assertFalse($executedSearches[0]->isSuccess());
+    }
+
+    public function testFailedSearchesAreNotCollectedOutsideDebugMode(): void
+    {
+        $service = $this->createService(
+            debugMode: false,
+            client: $this->makeEmpty(SearchClientInterface::class, [
+                'search' => static fn () => throw new Exception('search failed'),
+            ])
+        );
+
+        try {
+            $service->executeSearch($this->createSearch(), 'test_index');
+            $this->fail('SearchFailedException was not thrown');
+        } catch (SearchFailedException) {
+            // expected
+        }
+
+        $this->assertSame([], $service->getExecutedSearches());
+    }
+
+    private function createService(
+        bool $debugMode,
+        ?SearchClientInterface $client = null,
+    ): SearchExecutionService {
+        return new SearchExecutionService(
+            new SearchResultDenormalizer(),
+            $client ?? $this->makeEmpty(SearchClientInterface::class, [
+                'search' => [
+                    'hits' => [
+                        'hits' => [],
+                        'total' => ['value' => 0],
+                        'max_score' => null,
+                    ],
+                ],
+            ]),
+            $debugMode,
+        );
+    }
+
+    private function createSearch(): AdapterSearchInterface
+    {
+        return $this->makeEmpty(AdapterSearchInterface::class, [
+            'toArray' => [],
+            'isReverseItemOrder' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Resolves #417

## Prevent SearchExecutionService debug trace accumulation outside debug mode

### What
This PR changes `SearchExecutionService` so that `$executedSearches` is populated only when Pimcore debug mode is enabled.

### Why
`SearchExecutionService` currently stores per-query `SearchInformation` including:
- full search response
- `debug_backtrace()`

In long-running CLI commands this accumulates and causes significant memory growth, although the data is only useful for debugging.

### How
In `SearchExecutionService::executeSearch()`:
- wrap both `$this->executedSearches[] = ...` writes (success + exception path) in:
  - `if (Pimcore::inDebugMode()) { ... }`

### Impact
- **Debug/dev behavior:** unchanged (query debug information still available).
- **Prod/no-debug behavior:** avoids unnecessary in-memory accumulation of debug traces.
- No API change.

### Motivation / use case
This was observed during long-running data object update/import commands where memory rose steadily due to query trace collection.