### PR TITLE
[Bug, CI] Decouple test Kernel from MicroKernelTrait private API

### DIFF
--- a/.github/ci/files/kernel/Kernel.php
+++ b/.github/ci/files/kernel/Kernel.php
@@ -11,6 +11,7 @@
 
 namespace App;
 
+use Pimcore\Config\BundleConfigLocator;
 use Pimcore\Kernel as BaseKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -34,8 +35,11 @@ class Kernel extends BaseKernel
      * instead avoids this coupling and remains stable across Symfony 6.4, 7.x and
      * future versions.
      *
-     * We still load packages and environment-specific service files
-     * (services_test.yaml) which provide test-only service overrides.
+     * This implementation mirrors Pimcore\Kernel::registerContainerConfiguration()
+     * (BundleConfigLocator + packages + env services) but intentionally skips the
+     * MicroKernelTrait services.yaml auto-load and the dynamic Pimcore config
+     * directories (image_thumbnails, document_types, etc.) which are not used in
+     * this bundle's CI.
      */
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
@@ -51,6 +55,14 @@ class Kernel extends BaseKernel
                     ->setPublic(true);
             }
         });
+
+        // Load bundle-provided config files from <bundle>/Resources/config/pimcore
+        // or <bundle>/config/pimcore (e.g. config.yaml -> messenger.yaml).
+        // This mirrors Pimcore\Kernel::registerContainerConfiguration().
+        $bundleConfigLocator = new BundleConfigLocator($this);
+        foreach ($bundleConfigLocator->locate('config') as $bundleConfig) {
+            $loader->load($bundleConfig);
+        }
 
         $configDir = $this->getProjectDir() . '/config';
 

--- a/.github/ci/files/kernel/Kernel.php
+++ b/.github/ci/files/kernel/Kernel.php
@@ -43,10 +43,21 @@ class Kernel extends BaseKernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        // Register the synthetic "kernel" service. This is normally done by
-        // MicroKernelTrait::registerContainerConfiguration() and is required so
-        // that other services may depend on the kernel via DI.
+        // Register the synthetic "kernel" service and configure the framework
+        // router to load its routes from kernel::loadRoutes(). This is normally
+        // done by MicroKernelTrait::registerContainerConfiguration(); we
+        // replicate the relevant bits here so the kernel may be depended on via
+        // DI and so framework.router.resource is configured (otherwise the
+        // FrameworkBundle config validation fails with "The child config
+        // 'resource' under 'framework.router' must be configured.").
         $loader->load(function (ContainerBuilder $container): void {
+            $container->loadFromExtension('framework', [
+                'router' => [
+                    'resource' => 'kernel::loadRoutes',
+                    'type' => 'service',
+                ],
+            ]);
+
             if (!$container->hasDefinition('kernel')) {
                 $container->register('kernel', static::class)
                     ->addTag('controller.service_arguments')
@@ -54,6 +65,8 @@ class Kernel extends BaseKernel
                     ->setSynthetic(true)
                     ->setPublic(true);
             }
+
+            $container->getDefinition('kernel')->addTag('routing.route_loader');
         });
 
         // Load bundle-provided config files from <bundle>/Resources/config/pimcore

--- a/.github/ci/files/kernel/Kernel.php
+++ b/.github/ci/files/kernel/Kernel.php
@@ -14,32 +14,56 @@ namespace App;
 use Pimcore\Kernel as BaseKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 class Kernel extends BaseKernel
 {
     /**
-     * Override configureContainer to prevent MicroKernelTrait from auto-loading
-     * config/services.yaml. In this CI setup, the bundle IS the project root,
-     * so config/services.yaml belongs to the bundle and is already loaded by the
-     * bundle extension's load() method. Loading it again here would overwrite
+     * Override registerContainerConfiguration() to prevent MicroKernelTrait from
+     * auto-loading config/services.yaml. In this CI setup, the bundle IS the project
+     * root, so config/services.yaml belongs to the bundle and is already loaded by
+     * the bundle extension's load() method. Loading it again here would overwrite
      * the programmatic argument assignments made by the extension
      * (e.g., $clientType, $queueSettings on SearchIndexConfigServiceInterface
      * and DispatchQueueMessagesHandler).
      *
+     * Previously this was achieved by overriding the protected configureContainer()
+     * extension point exposed by Pimcore\Kernel via a MicroKernelTrait alias.
+     * That extension point relies on a private method of Symfony's MicroKernelTrait
+     * whose signature is not part of Symfony's public API and changes between
+     * minor versions. Overriding the public registerContainerConfiguration() method
+     * instead avoids this coupling and remains stable across Symfony 6.4, 7.x and
+     * future versions.
+     *
      * We still load packages and environment-specific service files
      * (services_test.yaml) which provide test-only service overrides.
      */
-    protected function configureContainer(ContainerConfigurator $container, LoaderInterface $loader, ContainerBuilder $builder): void
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        $configDir = $this->getProjectDir() . '/{config}';
+        // Register the synthetic "kernel" service. This is normally done by
+        // MicroKernelTrait::registerContainerConfiguration() and is required so
+        // that other services may depend on the kernel via DI.
+        $loader->load(function (ContainerBuilder $container): void {
+            if (!$container->hasDefinition('kernel')) {
+                $container->register('kernel', static::class)
+                    ->addTag('controller.service_arguments')
+                    ->setAutoconfigured(true)
+                    ->setSynthetic(true)
+                    ->setPublic(true);
+            }
+        });
 
-        $container->import($configDir . '/{packages}/*.{php,yaml}');
-        $container->import($configDir . '/{packages}/' . $this->environment . '/*.{php,yaml}');
+        $configDir = $this->getProjectDir() . '/config';
+
+        // Load packages (mirrors MicroKernelTrait's default configureContainer behavior).
+        $loader->load($configDir . '/packages/*.{php,yaml}', 'glob');
+        $loader->load($configDir . '/packages/' . $this->environment . '/*.{php,yaml}', 'glob');
 
         // Skip loading config/services.yaml — it is the bundle's own service config
         // and is already loaded by PimcoreGenericDataIndexExtension::load().
         // Only load the environment-specific services file (e.g., services_test.yaml).
-        $container->import($configDir . '/{services}_' . $this->environment . '.yaml');
+        $envServices = $configDir . '/services_' . $this->environment . '.yaml';
+        if (file_exists($envServices)) {
+            $loader->load($envServices);
+        }
     }
 }


### PR DESCRIPTION
## Summary

The CI test `Kernel` (under `.github/ci/files/kernel/Kernel.php`) overrides
`configureContainer()` to prevent `MicroKernelTrait` from auto-loading
`config/services.yaml` — in this CI setup the bundle IS the project root, so
that file is the bundle's own service config and is already loaded by
`PimcoreGenericDataIndexExtension::load()`. Loading it again would overwrite
programmatic argument assignments made by the extension (e.g. `$clientType`,
`$queueSettings` on `SearchIndexConfigServiceInterface` and
`DispatchQueueMessagesHandler`).

The override hooks into a `MicroKernelTrait` extension point that
`Pimcore\Kernel` aliases as `protected`. That extension point relies on a
**private** method of Symfony's `MicroKernelTrait` whose signature is not part
of Symfony's public API and changes between minor versions (notably Symfony
7.4 changes the signature of `configureContainer()`), which breaks any
subclass that overrides it.

## Fix

Override the **public** `registerContainerConfiguration(LoaderInterface)`
method instead. This:

- Avoids any coupling to private trait internals.
- Remains stable across Symfony 6.4, 7.x and future versions.
- Preserves the original behavior:
  - Registers the synthetic `kernel` service (normally done by the trait).
  - Loads `config/packages/*.{php,yaml}` and `config/packages/{env}/*.{php,yaml}`.
  - Skips `config/services.yaml` (intentional — see above).
  - Loads `config/services_{env}.yaml` if it exists (e.g. `services_test.yaml`).

Companion PRs in `pimcore/pimcore`:
- pimcore/pimcore#19113 — fixes the equivalent issue in `InstallerKernel`.
- pimcore/pimcore#19114 — adds a deprecation for overriding `configureContainer()` / `configureRoutes()` (removal in 2027.1).