### PR TITLE
[Bug]: Unpublished data objects not indexed in relation fields  

### DIFF
--- a/doc/01_Installation/02_Upgrade.md
+++ b/doc/01_Installation/02_Upgrade.md
@@ -2,9 +2,18 @@
 
 Following steps are necessary during updating to newer versions.
 
+## Upgrade to 2.5.3
+- [Indexing] Fixed: Unpublished data objects are now correctly indexed in relation fields (ManyToOne, ManyToMany, AdvancedManyToMany)
+
+### Re-indexing required
+After upgrading, execute the following command to re-index elements to include new fixes:
+```
+bin/console generic-data-index:update:index -r
+```
+
 ## Upgrade to 2.2.0
 - [Indexing] Added `id` column as new primary key to `generic_data_index_queue`. Please make sure to execute migrations.
-- [Searching] Added `trackTotalHits` parameter to `DefaultSearchService` and `SearchExecutionService`. The default value is true,       which means that total hits will always be computed accurately, even if they exceed the search engines threshold for accurate hit calculation. Change this parameter to `null`, to use the default threshold, pass an integer value to set a specific one.
+- [Searching] Added `trackTotalHits` parameter to `DefaultSearchService` and `SearchExecutionService`. The default value is true, which means that total hits will always be computed accurately, even if they exceed the search engines threshold for accurate hit calculation. Change this parameter to `null`, to use the default threshold, pass an integer value to set a specific one.
 
 ## Upgrade to 2.1.0
 - Added support for Symfony 7

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -293,7 +293,7 @@ final class DefaultSearchService implements SearchIndexServiceInterface
             'body' => $body,
         ]);
 
-        return $result['count'];
+        return $result['count'] ?? 0;
     }
 
     /**

--- a/src/Service/Serializer/Normalizer/DataObjectNormalizer.php
+++ b/src/Service/Serializer/Normalizer/DataObjectNormalizer.php
@@ -151,13 +151,16 @@ final class DataObjectNormalizer implements NormalizerInterface
      */
     private function normalizeStandardFields(Concrete $dataObject): array
     {
+        $inheritedValuesBackup = AbstractObject::doGetInheritedValues();
+        $fallbackLanguagesBackup = Localizedfield::doGetFallbackValues();
+        $hideUnpublishedBackup = AbstractObject::getHideUnpublished();
+
         try {
             $class = $dataObject->getClass();
             $fieldDefinitions = $class->getFieldDefinitions();
             $result[FieldCategory::INHERITED_FIELDS->value] = [];
-            $inheritedValuesBackup = AbstractObject::doGetInheritedValues();
-            $fallbackLanguagesBackup = Localizedfield::doGetFallbackValues();
             Localizedfield::setGetFallbackValues(true);
+            AbstractObject::setHideUnpublished(false);
             if ($class->getAllowInherit()) {
                 AbstractObject::setGetInheritedValues(false);
                 $result = $this->getInheritedFields($fieldDefinitions, $dataObject, $result);
@@ -172,9 +175,6 @@ final class DataObjectNormalizer implements NormalizerInterface
                 $result[$key] = $normalizedValue;
             }
 
-            AbstractObject::setGetInheritedValues($inheritedValuesBackup);
-            Localizedfield::setGetFallbackValues($fallbackLanguagesBackup);
-
             if (isset($result[StandardField::LOCALIZED_FIELDS->value])) {
                 $result = array_merge($result[StandardField::LOCALIZED_FIELDS->value], $result);
                 unset($result[StandardField::LOCALIZED_FIELDS->value]);
@@ -183,6 +183,10 @@ final class DataObjectNormalizer implements NormalizerInterface
             return $result;
         } catch (Exception $e) {
             throw new DataObjectNormalizerException($e->getMessage());
+        } finally {
+            AbstractObject::setGetInheritedValues($inheritedValuesBackup);
+            Localizedfield::setGetFallbackValues($fallbackLanguagesBackup);
+            AbstractObject::setHideUnpublished($hideUnpublishedBackup);
         }
     }
 

--- a/tests/Functional/DefaultSearch/DefaultSearchServiceTest.php
+++ b/tests/Functional/DefaultSearch/DefaultSearchServiceTest.php
@@ -256,6 +256,48 @@ class DefaultSearchServiceTest extends \Codeception\Test\Unit
         $searchIndexService->deleteIndex('test_index');
     }
 
+    public function testGetCount(): void
+    {
+        /** @var SearchIndexServiceInterface $searchIndexService */
+        $searchIndexService = $this->tester->grabService(SearchIndexServiceInterface::class);
+        /** @var SearchClientInterface $searchClient */
+        $searchClient = $this->tester->grabService('generic-data-index.search-client');
+
+        $searchIndexService->createIndex('test_index');
+        $searchClient->create(['index' => 'test_index', 'refresh' => true, 'id'=>1, 'body' => ['test' => 'test']]);
+        $searchClient->create(['index' => 'test_index', 'refresh' => true, 'id'=>2, 'body' => ['test' => 'test']]);
+        $searchClient->create(['index' => 'test_index', 'refresh' => true, 'id'=>3, 'body' => ['test' => 'test2']]);
+
+        // Count all documents
+        /** @var Search $search */
+        $search = $searchIndexService->createPaginatedSearch(1, 10);
+        $count = $searchIndexService->getCount($search, 'test_index');
+        $this->assertEquals(3, $count);
+
+        // Count with a filter
+        $search = $searchIndexService->createPaginatedSearch(1, 10);
+        $search->addQuery(new TermFilter('test', 'test'));
+        $count = $searchIndexService->getCount($search, 'test_index');
+        $this->assertEquals(2, $count);
+
+        $searchIndexService->deleteIndex('test_index');
+    }
+
+    public function testGetCountReturnsZeroForEmptyIndex(): void
+    {
+        /** @var SearchIndexServiceInterface $searchIndexService */
+        $searchIndexService = $this->tester->grabService(SearchIndexServiceInterface::class);
+
+        $searchIndexService->createIndex('test_empty_index');
+
+        /** @var Search $search */
+        $search = $searchIndexService->createPaginatedSearch(1, 10);
+        $count = $searchIndexService->getCount($search, 'test_empty_index');
+        $this->assertEquals(0, $count);
+
+        $searchIndexService->deleteIndex('test_empty_index');
+    }
+
     public function getTestGetStats(): void
     {
         /** @var SearchIndexServiceInterface $searchIndexService */

--- a/tests/Functional/SearchIndex/UnpublishedRelationIndexingTest.php
+++ b/tests/Functional/SearchIndex/UnpublishedRelationIndexingTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Functional\SearchIndex;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\ElementTypeAdapter\DataObjectTypeAdapter;
+use Pimcore\Model\DataObject\Unittest;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+/**
+ * Tests that unpublished data objects are correctly indexed in relation fields.
+ *
+ * @see https://github.com/pimcore/generic-data-index-bundle/issues/424
+ */
+class UnpublishedRelationIndexingTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \Pimcore\Bundle\GenericDataIndexBundle\Tests\IndexTester
+     */
+    protected $tester;
+
+    private DataObjectTypeAdapter $dataObjectTypeAdapter;
+
+    protected function _before()
+    {
+        $this->dataObjectTypeAdapter = $this->tester->grabService(DataObjectTypeAdapter::class);
+        $this->tester->enableSynchronousProcessing();
+        $this->tester->enableSynchronousProcessingRelatedIds();
+        $this->tester->clearQueue();
+    }
+
+    protected function _after()
+    {
+        TestHelper::cleanUp();
+        $this->tester->flushIndex();
+        $this->tester->cleanupIndex();
+        $this->tester->flushIndex();
+    }
+
+    public function testUnpublishedObjectIsIndexedInManyToManyRelation(): void
+    {
+        /** @var Unittest $unpublishedObject */
+        $unpublishedObject = TestHelper::createEmptyObject('', true, false);
+        $this->assertFalse($unpublishedObject->getPublished());
+
+        /** @var Unittest $publishedObject */
+        $publishedObject = TestHelper::createEmptyObject();
+        $publishedObject->setObjects([$unpublishedObject])->save();
+
+        $indexName = $this->dataObjectTypeAdapter->getAliasIndexName($publishedObject->getClass());
+        $response = $this->tester->checkIndexEntry($publishedObject->getId(), $indexName);
+
+        $standardFields = $response['_source'][FieldCategory::STANDARD_FIELDS->value];
+        $this->assertArrayHasKey('objects', $standardFields, 'objects relation field should exist in index');
+
+        $relationData = $standardFields['objects'];
+        $this->assertContains(
+            $unpublishedObject->getId(),
+            $relationData['object'],
+            'Unpublished object ID should be present in the relation field index data'
+        );
+    }
+
+    public function testRelationIndexesBothPublishedAndUnpublishedObjects(): void
+    {
+        /** @var Unittest $unpublishedObject */
+        $unpublishedObject = TestHelper::createEmptyObject('', true, false);
+        $this->assertFalse($unpublishedObject->getPublished());
+
+        /** @var Unittest $publishedRelated */
+        $publishedRelated = TestHelper::createEmptyObject();
+        $this->assertTrue($publishedRelated->getPublished());
+
+        /** @var Unittest $objectWithRelations */
+        $objectWithRelations = TestHelper::createEmptyObject();
+        $objectWithRelations->setObjects([$unpublishedObject, $publishedRelated])->save();
+
+        $indexName = $this->dataObjectTypeAdapter->getAliasIndexName($objectWithRelations->getClass());
+        $response = $this->tester->checkIndexEntry($objectWithRelations->getId(), $indexName);
+
+        $standardFields = $response['_source'][FieldCategory::STANDARD_FIELDS->value];
+        $relationData = $standardFields['objects'];
+
+        $this->assertContains(
+            $unpublishedObject->getId(),
+            $relationData['object'],
+            'Unpublished object ID should be in the relation index data'
+        );
+        $this->assertContains(
+            $publishedRelated->getId(),
+            $relationData['object'],
+            'Published object ID should be in the relation index data'
+        );
+        $this->assertCount(
+            2,
+            $relationData['object'],
+            'Both published and unpublished objects should be indexed in relation'
+        );
+    }
+
+    public function testUnpublishedObjectIsInBothDependenciesAndRelations(): void
+    {
+        /** @var Unittest $unpublishedObject */
+        $unpublishedObject = TestHelper::createEmptyObject('', true, false);
+
+        /** @var Unittest $objectWithRelation */
+        $objectWithRelation = TestHelper::createEmptyObject();
+        $objectWithRelation->setObjects([$unpublishedObject])->save();
+
+        $indexName = $this->dataObjectTypeAdapter->getAliasIndexName($objectWithRelation->getClass());
+        $response = $this->tester->checkIndexEntry($objectWithRelation->getId(), $indexName);
+
+        // Check relation field
+        $standardFields = $response['_source'][FieldCategory::STANDARD_FIELDS->value];
+        $relationData = $standardFields['objects'];
+        $this->assertContains(
+            $unpublishedObject->getId(),
+            $relationData['object'],
+            'Unpublished object should be in relation field'
+        );
+
+        $systemFields = $response['_source']['system_fields'];
+        $dependencies = $systemFields['dependencies'];
+        $dependencyObjectIds = $dependencies['object'] ?? [];
+        $this->assertContains(
+            $unpublishedObject->getId(),
+            $dependencyObjectIds,
+            'Unpublished object should be in dependencies'
+        );
+    }
+}

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\SearchIndexAdapter\DefaultSearch;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DefaultSearchService;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Search\SearchExecutionServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\SearchClient\SearchClientInterface;
+
+/**
+ * @internal
+ */
+final class DefaultSearchServiceTest extends Unit
+{
+    public function testGetCountReturnsCountFromResult(): void
+    {
+        $service = $this->createService(
+            client: $this->makeEmpty(SearchClientInterface::class, [
+                'count' => Expected::once(['count' => 42]),
+            ])
+        );
+
+        $search = $this->makeEmpty(AdapterSearchInterface::class, [
+            'toArray' => [],
+        ]);
+
+        $this->assertSame(42, $service->getCount($search, 'test_index'));
+    }
+
+    public function testGetCountReturnsZeroWhenCountKeyIsMissing(): void
+    {
+        $service = $this->createService(
+            client: $this->makeEmpty(SearchClientInterface::class, [
+                'count' => Expected::once([]),
+            ])
+        );
+
+        $search = $this->makeEmpty(AdapterSearchInterface::class, [
+            'toArray' => [],
+        ]);
+
+        $this->assertSame(0, $service->getCount($search, 'test_index'));
+    }
+
+    public function testGetCountReturnsZeroWhenCountIsZero(): void
+    {
+        $service = $this->createService(
+            client: $this->makeEmpty(SearchClientInterface::class, [
+                'count' => ['count' => 0],
+            ])
+        );
+
+        $search = $this->makeEmpty(AdapterSearchInterface::class, [
+            'toArray' => [],
+        ]);
+
+        $this->assertSame(0, $service->getCount($search, 'test_index'));
+    }
+
+    public function testGetCountStripsDisallowedKeysFromBody(): void
+    {
+        $service = $this->createService(
+            client: $this->makeEmpty(SearchClientInterface::class, [
+                'count' => Expected::once(function (array $params) {
+                    $body = $params['body'];
+                    $this->assertArrayNotHasKey('_source', $body);
+                    $this->assertArrayNotHasKey('sort', $body);
+                    $this->assertArrayNotHasKey('from', $body);
+                    $this->assertArrayNotHasKey('size', $body);
+                    $this->assertArrayNotHasKey('aggs', $body);
+                    $this->assertArrayHasKey('query', $body);
+
+                    return ['count' => 10];
+                }),
+            ])
+        );
+
+        $search = $this->makeEmpty(AdapterSearchInterface::class, [
+            'toArray' => [
+                'query' => ['match_all' => new \stdClass()],
+                '_source' => ['field1'],
+                'sort' => ['field1' => 'asc'],
+                'from' => 0,
+                'size' => 10,
+                'aggs' => ['my_agg' => []],
+            ],
+        ]);
+
+        $this->assertSame(10, $service->getCount($search, 'test_index'));
+    }
+
+    private function createService(
+        ?SearchIndexConfigServiceInterface $configService = null,
+        ?SearchExecutionServiceInterface $searchExecutionService = null,
+        ?IndexAliasServiceInterface $indexAliasService = null,
+        ?SearchClientInterface $client = null,
+    ): DefaultSearchService {
+        return new DefaultSearchService(
+            $configService ?? $this->makeEmpty(SearchIndexConfigServiceInterface::class),
+            $searchExecutionService ?? $this->makeEmpty(SearchExecutionServiceInterface::class),
+            $indexAliasService ?? $this->makeEmpty(IndexAliasServiceInterface::class),
+            $client ?? $this->makeEmpty(SearchClientInterface::class),
+        );
+    }
+}

--- a/tests/Unit/Service/Serializer/Normalizer/DataObjectNormalizerTest.php
+++ b/tests/Unit/Service/Serializer/Normalizer/DataObjectNormalizerTest.php
@@ -1,0 +1,201 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Service\Serializer\Normalizer;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\DataObjectNormalizerException;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject\FieldDefinitionServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Dependency\DependencyServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Serializer\Normalizer\DataObjectNormalizer;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Workflow\WorkflowServiceInterface;
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Localizedfield;
+
+/**
+ * @internal
+ */
+final class DataObjectNormalizerTest extends Unit
+{
+    public function testGlobalStateIsRestoredAfterNormalization(): void
+    {
+        AbstractObject::setGetInheritedValues(true);
+        AbstractObject::setHideUnpublished(true);
+        Localizedfield::setGetFallbackValues(false);
+
+        $classDefinition = new ClassDefinition();
+        $classDefinition->setFieldDefinitions([]);
+        $classDefinition->setAllowInherit(false);
+
+        $dataObject = $this->makeEmpty(Concrete::class, [
+            'getClass' => $classDefinition,
+            'getId' => 1,
+            'getParentId' => 0,
+            'getCreationDate' => null,
+            'getModificationDate' => null,
+            'getType' => 'object',
+            'getKey' => 'test',
+            'getIndex' => 0,
+            'getChildrenSortBy' => null,
+            'getChildrenSortOrder' => null,
+            'getPath' => '/',
+            'getRealFullPath' => '/test',
+            'getUserOwner' => 1,
+            'getUserModification' => 1,
+            'getLocked' => null,
+            'getClassId' => '1',
+            'getClassName' => 'Test',
+            'getPublished' => true,
+        ]);
+
+        $normalizer = $this->createNormalizer();
+        $normalizer->normalize($dataObject);
+
+        $this->assertTrue(
+            AbstractObject::doGetInheritedValues(),
+            'InheritedValues should be restored after normalization'
+        );
+        $this->assertTrue(
+            AbstractObject::getHideUnpublished(),
+            'HideUnpublished should be restored after normalization'
+        );
+        $this->assertFalse(
+            Localizedfield::doGetFallbackValues(),
+            'FallbackValues should be restored after normalization'
+        );
+    }
+
+    public function testGlobalStateIsRestoredOnException(): void
+    {
+        AbstractObject::setGetInheritedValues(true);
+        AbstractObject::setHideUnpublished(true);
+        Localizedfield::setGetFallbackValues(false);
+
+        $classDefinition = new ClassDefinition();
+        $classDefinition->setFieldDefinitions([
+            'broken_field' => new ClassDefinition\Data\Input(),
+        ]);
+        $classDefinition->setAllowInherit(false);
+
+        $fieldDefinitionService = $this->makeEmpty(FieldDefinitionServiceInterface::class, [
+            'normalizeValue' => function () {
+                throw new Exception('Normalization failed');
+            },
+        ]);
+
+        $dataObject = $this->makeEmpty(Concrete::class, [
+            'getClass' => $classDefinition,
+            'get' => 'some_value',
+        ]);
+
+        $normalizer = $this->createNormalizer(fieldDefinitionService: $fieldDefinitionService);
+
+        try {
+            $normalizer->normalize($dataObject);
+            $this->fail('Expected DataObjectNormalizerException was not thrown');
+        } catch (DataObjectNormalizerException) {
+            // Expected
+        }
+
+        $this->assertTrue(
+            AbstractObject::doGetInheritedValues(),
+            'InheritedValues should be restored even after exception'
+        );
+        $this->assertTrue(
+            AbstractObject::getHideUnpublished(),
+            'HideUnpublished should be restored even after exception'
+        );
+        $this->assertFalse(
+            Localizedfield::doGetFallbackValues(),
+            'FallbackValues should be restored even after exception'
+        );
+    }
+
+    public function testHideUnpublishedIsDisabledDuringNormalization(): void
+    {
+        AbstractObject::setHideUnpublished(true);
+
+        $classDefinition = new ClassDefinition();
+        $classDefinition->setFieldDefinitions([
+            'test_field' => new ClassDefinition\Data\Input(),
+        ]);
+        $classDefinition->setAllowInherit(false);
+
+        $hideUnpublishedDuringNormalization = null;
+
+        $fieldDefinitionService = $this->makeEmpty(FieldDefinitionServiceInterface::class, [
+            'normalizeValue' => function () use (&$hideUnpublishedDuringNormalization) {
+                $hideUnpublishedDuringNormalization = AbstractObject::getHideUnpublished();
+
+                return 'normalized_value';
+            },
+        ]);
+
+        $dataObject = $this->makeEmpty(Concrete::class, [
+            'getClass' => $classDefinition,
+            'get' => 'some_value',
+        ]);
+
+        $normalizer = $this->createNormalizer(fieldDefinitionService: $fieldDefinitionService);
+        $normalizer->normalize($dataObject);
+
+        $this->assertFalse(
+            $hideUnpublishedDuringNormalization,
+            'HideUnpublished should be false during field normalization'
+        );
+        $this->assertTrue(
+            AbstractObject::getHideUnpublished(),
+            'HideUnpublished should be restored after normalization'
+        );
+    }
+
+    public function testNormalizeThrowsDataObjectNormalizerException(): void
+    {
+        $this->expectException(DataObjectNormalizerException::class);
+
+        $classDefinition = new ClassDefinition();
+        $classDefinition->setFieldDefinitions([
+            'broken_field' => new ClassDefinition\Data\Input(),
+        ]);
+        $classDefinition->setAllowInherit(false);
+
+        $fieldDefinitionService = $this->makeEmpty(FieldDefinitionServiceInterface::class, [
+            'normalizeValue' => function () {
+                throw new Exception('Something went wrong');
+            },
+        ]);
+
+        $dataObject = $this->makeEmpty(Concrete::class, [
+            'getClass' => $classDefinition,
+            'get' => 'value',
+        ]);
+
+        $normalizer = $this->createNormalizer(fieldDefinitionService: $fieldDefinitionService);
+        $normalizer->normalize($dataObject);
+    }
+
+    private function createNormalizer(
+        ?FieldDefinitionServiceInterface $fieldDefinitionService = null,
+        ?WorkflowServiceInterface $workflowService = null,
+        ?DependencyServiceInterface $dependencyService = null,
+    ): DataObjectNormalizer {
+        return new DataObjectNormalizer(
+            $fieldDefinitionService ?? $this->makeEmpty(FieldDefinitionServiceInterface::class),
+            $workflowService ?? $this->makeEmpty(WorkflowServiceInterface::class),
+            $dependencyService ?? $this->makeEmpty(DependencyServiceInterface::class),
+        );
+    }
+}

--- a/tests/Unit/Service/Serializer/Normalizer/DataObjectNormalizerTest.php
+++ b/tests/Unit/Service/Serializer/Normalizer/DataObjectNormalizerTest.php
@@ -36,30 +36,7 @@ final class DataObjectNormalizerTest extends Unit
         AbstractObject::setHideUnpublished(true);
         Localizedfield::setGetFallbackValues(false);
 
-        $classDefinition = new ClassDefinition();
-        $classDefinition->setFieldDefinitions([]);
-        $classDefinition->setAllowInherit(false);
-
-        $dataObject = $this->makeEmpty(Concrete::class, [
-            'getClass' => $classDefinition,
-            'getId' => 1,
-            'getParentId' => 0,
-            'getCreationDate' => null,
-            'getModificationDate' => null,
-            'getType' => 'object',
-            'getKey' => 'test',
-            'getIndex' => 0,
-            'getChildrenSortBy' => null,
-            'getChildrenSortOrder' => null,
-            'getPath' => '/',
-            'getRealFullPath' => '/test',
-            'getUserOwner' => 1,
-            'getUserModification' => 1,
-            'getLocked' => null,
-            'getClassId' => '1',
-            'getClassName' => 'Test',
-            'getPublished' => true,
-        ]);
+        $dataObject = $this->createConcreteObjectMock();
 
         $normalizer = $this->createNormalizer();
         $normalizer->normalize($dataObject);
@@ -84,11 +61,9 @@ final class DataObjectNormalizerTest extends Unit
         AbstractObject::setHideUnpublished(true);
         Localizedfield::setGetFallbackValues(false);
 
-        $classDefinition = new ClassDefinition();
-        $classDefinition->setFieldDefinitions([
+        $classDefinition = $this->createClassDefinition([
             'broken_field' => new ClassDefinition\Data\Input(),
         ]);
-        $classDefinition->setAllowInherit(false);
 
         $fieldDefinitionService = $this->makeEmpty(FieldDefinitionServiceInterface::class, [
             'normalizeValue' => function () {
@@ -96,10 +71,7 @@ final class DataObjectNormalizerTest extends Unit
             },
         ]);
 
-        $dataObject = $this->makeEmpty(Concrete::class, [
-            'getClass' => $classDefinition,
-            'get' => 'some_value',
-        ]);
+        $dataObject = $this->createConcreteObjectMock($classDefinition);
 
         $normalizer = $this->createNormalizer(fieldDefinitionService: $fieldDefinitionService);
 
@@ -128,11 +100,9 @@ final class DataObjectNormalizerTest extends Unit
     {
         AbstractObject::setHideUnpublished(true);
 
-        $classDefinition = new ClassDefinition();
-        $classDefinition->setFieldDefinitions([
+        $classDefinition = $this->createClassDefinition([
             'test_field' => new ClassDefinition\Data\Input(),
         ]);
-        $classDefinition->setAllowInherit(false);
 
         $hideUnpublishedDuringNormalization = null;
 
@@ -144,10 +114,7 @@ final class DataObjectNormalizerTest extends Unit
             },
         ]);
 
-        $dataObject = $this->makeEmpty(Concrete::class, [
-            'getClass' => $classDefinition,
-            'get' => 'some_value',
-        ]);
+        $dataObject = $this->createConcreteObjectMock($classDefinition);
 
         $normalizer = $this->createNormalizer(fieldDefinitionService: $fieldDefinitionService);
         $normalizer->normalize($dataObject);
@@ -166,11 +133,9 @@ final class DataObjectNormalizerTest extends Unit
     {
         $this->expectException(DataObjectNormalizerException::class);
 
-        $classDefinition = new ClassDefinition();
-        $classDefinition->setFieldDefinitions([
+        $classDefinition = $this->createClassDefinition([
             'broken_field' => new ClassDefinition\Data\Input(),
         ]);
-        $classDefinition->setAllowInherit(false);
 
         $fieldDefinitionService = $this->makeEmpty(FieldDefinitionServiceInterface::class, [
             'normalizeValue' => function () {
@@ -178,13 +143,44 @@ final class DataObjectNormalizerTest extends Unit
             },
         ]);
 
-        $dataObject = $this->makeEmpty(Concrete::class, [
-            'getClass' => $classDefinition,
-            'get' => 'value',
-        ]);
+        $dataObject = $this->createConcreteObjectMock($classDefinition);
 
         $normalizer = $this->createNormalizer(fieldDefinitionService: $fieldDefinitionService);
         $normalizer->normalize($dataObject);
+    }
+
+    private function createClassDefinition(array $fieldDefinitions = []): ClassDefinition
+    {
+        $classDefinition = new ClassDefinition();
+        $classDefinition->setFieldDefinitions($fieldDefinitions);
+        $classDefinition->setAllowInherit(false);
+
+        return $classDefinition;
+    }
+
+    private function createConcreteObjectMock(?ClassDefinition $classDefinition = null): Concrete
+    {
+        return $this->makeEmpty(Concrete::class, [
+            'getClass' => $classDefinition ?? $this->createClassDefinition(),
+            'getId' => 1,
+            'getParentId' => 0,
+            'getCreationDate' => null,
+            'getModificationDate' => null,
+            'getType' => 'object',
+            'getKey' => 'test',
+            'getIndex' => 0,
+            'getChildrenSortBy' => 'key',
+            'getChildrenSortOrder' => 'asc',
+            'getPath' => '/',
+            'getRealFullPath' => '/test',
+            'getUserOwner' => 1,
+            'getUserModification' => 1,
+            'getLocked' => null,
+            'getClassId' => '1',
+            'getClassName' => 'Test',
+            'getPublished' => true,
+            'get' => 'some_value',
+        ]);
     }
 
     private function createNormalizer(


### PR DESCRIPTION
## Changes in this pull request
Resolves #424 
Resovles #425 

## Additional info
- include unpublished objects in the normalizer
- check if count is present in index data