### PR TITLE
Fix TypeError in EnqueueRelatedIdsHandler when element was deleted before message consumption

### DIFF
--- a/src/MessageHandler/EnqueueRelatedIdsHandler.php
+++ b/src/MessageHandler/EnqueueRelatedIdsHandler.php
@@ -40,6 +40,10 @@ final readonly class EnqueueRelatedIdsHandler
         $elementType = $message->getElementType();
         $element = $this->elementService->getElementByType($message->getElementId(), $elementType->value);
 
+        if ($element === null) {
+            return;
+        }
+
         if ($elementType === ElementType::DATA_OBJECT) {
             $inheritanceBackup = AbstractObject::getGetInheritedValues();
             AbstractObject::setGetInheritedValues(true);

--- a/tests/Unit/MessageHandler/EnqueueRelatedIdsHandlerTest.php
+++ b/tests/Unit/MessageHandler/EnqueueRelatedIdsHandlerTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\MessageHandler;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ElementType;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexQueueOperation;
+use Pimcore\Bundle\GenericDataIndexBundle\Message\EnqueueRelatedIdsMessage;
+use Pimcore\Bundle\GenericDataIndexBundle\MessageHandler\EnqueueRelatedIdsHandler;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\ElementServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexQueue\QueueMessagesDispatcher;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexQueueServiceInterface;
+use ReflectionClass;
+
+/**
+ * @internal
+ */
+final class EnqueueRelatedIdsHandlerTest extends Unit
+{
+    public function testDeletedElementSkipsProcessing(): void
+    {
+        // QueueMessagesDispatcher is final and cannot be doubled; the guard
+        // returns before it is used, so an uninitialized instance is safe here.
+        $queueMessagesDispatcher = (new ReflectionClass(QueueMessagesDispatcher::class))
+            ->newInstanceWithoutConstructor();
+
+        $handler = new EnqueueRelatedIdsHandler(
+            $this->makeEmpty(IndexQueueServiceInterface::class, [
+                'updateIndexQueue' => Expected::never(),
+            ]),
+            $queueMessagesDispatcher,
+            $this->makeEmpty(ElementServiceInterface::class, [
+                'getElementByType' => null,
+            ])
+        );
+
+        $handler(new EnqueueRelatedIdsMessage(
+            999,
+            ElementType::ASSET,
+            IndexQueueOperation::UPDATE->value,
+            false
+        ));
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

`EnqueueRelatedIdsMessage` carries only an element ID. If the element is deleted between the dispatch of the message (e.g. from `updateIndexQueue(..., enqueueRelatedItemsAsync: true)` on element save) and its consumption by a messenger worker, `ElementService::getElementByType()` returns `null`. Passing that to `IndexQueueService::updateIndexQueue()` throws:

```
TypeError: Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexQueueService::updateIndexQueue(): Argument #1 ($element) must be of type Pimcore\Model\Element\ElementInterface, null given, called in .../src/MessageHandler/EnqueueRelatedIdsHandler.php on line 48
```

Since a `TypeError` is an `Error` (and is raised at argument binding), the `try/catch (Exception)` inside `updateIndexQueue()` cannot catch it, so the message lands in the failed transport where retries can never succeed — the element is gone.

This PR skips processing when the element no longer exists, and adds a unit test covering the regression. There is nothing left to enqueue related items for in that case; the deletion of the element itself is handled separately via the `DELETE` queue operation.

## Additional info

Observed in production on v2.5.2 under a save-then-delete race (transient objects from import jobs). The same guard already exists conceptually in other ID-based async flows where the element is re-loaded from an ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)