### PR TITLE
[Bug] Enhance Full-Text Search with default operator and flags.

### DIFF
--- a/doc/01_Installation/02_Upgrade.md
+++ b/doc/01_Installation/02_Upgrade.md
@@ -2,6 +2,10 @@
 
 Following steps are necessary during updating to newer versions.
 
+## Upgrade to 2.5.4
+- [Searching] The full-text search (`FullTextSearch` modifier) now defaults to `default_operator: AND` and
+  `flags: PHRASE|WHITESPACE` for better relevance and to treat characters like `-` and `.` as literal text.
+
 ## Upgrade to 2.5.3
 - [Indexing] Added `isReferenced` field to asset index to support filtering for unreferenced assets.
 - [Indexing] Fixed: Unpublished data objects are now correctly indexed in relation fields (ManyToOne, ManyToMany, AdvancedManyToMany)

--- a/doc/04_Searching_For_Data_In_Index/README.md
+++ b/doc/04_Searching_For_Data_In_Index/README.md
@@ -99,6 +99,30 @@ public function searchAction(SearchProviderInterface $searchProvider, ElementSea
 }
 ```
 
+## Full-Text Search
+
+Use the `FullTextSearch` modifier for full-text queries. It supports the following options:
+
+```php
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\FullTextSearch\FullTextSearch;
+
+new FullTextSearch(
+    $term,
+    defaultOperator: 'AND',          // 'AND' (default) requires all terms, 'OR' matches any
+    fields: [],                      // limit to specific fields (with optional boosts), e.g. ['system_fields.key^3']
+    flags: 'PHRASE|WHITESPACE',      // enabled simple_query_string operators; null/'ALL' enables all of them
+);
+```
+
+By default, characters like `-` and `.` are treated as literal text (not as operators), and double quotes
+enable phrase search.
+
+> **Note on partial matches of values containing punctuation** (e.g. version numbers or SKUs like `1.1.1`):
+> partial matching is powered by an n-gram analyzer whose tokenizer only keeps letters and digits by default,
+> so punctuation splits the value. As a result, searching `1.1` does not match `1.1.1`. To enable this, extend
+> the n-gram tokenizer's `token_chars` (e.g. add `punctuation` and `symbol`) via `index_service.index_settings`
+> and re-index. See [Index Management](../02_Configuration/03_Index_Management.md).
+
 ## Search Modifiers
 
 To influence the data which gets fetched its possible to use so-called search modifiers.

--- a/src/Model/DefaultSearch/Query/SimpleQueryStringFilter.php
+++ b/src/Model/DefaultSearch/Query/SimpleQueryStringFilter.php
@@ -17,14 +17,18 @@ use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\DefaultSearch\Conditi
 
 final class SimpleQueryStringFilter extends BoolQuery implements AsSubQueryInterface
 {
+    /**
+     * @param string[] $fields
+     */
     public function __construct(
-        private readonly string $term
+        private readonly string $term,
+        private readonly string $defaultOperator = 'AND',
+        private readonly array $fields = [],
+        private readonly ?string $flags = 'PHRASE|WHITESPACE',
     ) {
         parent::__construct([
             ConditionType::FILTER->value => [
-                'simple_query_string' => [
-                    'query' => $this->term,
-                ],
+                'simple_query_string' => $this->buildSimpleQueryString(),
             ],
         ]);
     }
@@ -37,9 +41,28 @@ final class SimpleQueryStringFilter extends BoolQuery implements AsSubQueryInter
     public function toArrayAsSubQuery(): array
     {
         return [
-            'simple_query_string' => [
-                'query' => $this->term,
-            ],
+            'simple_query_string' => $this->buildSimpleQueryString(),
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildSimpleQueryString(): array
+    {
+        $simpleQueryString = [
+            'query' => $this->term,
+            'default_operator' => $this->defaultOperator,
+        ];
+
+        if ($this->fields !== []) {
+            $simpleQueryString['fields'] = $this->fields;
+        }
+
+        if ($this->flags !== null) {
+            $simpleQueryString['flags'] = $this->flags;
+        }
+
+        return $simpleQueryString;
     }
 }

--- a/src/Model/Search/Modifier/FullTextSearch/FullTextSearch.php
+++ b/src/Model/Search/Modifier/FullTextSearch/FullTextSearch.php
@@ -17,13 +17,37 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\SearchModifierIn
 
 final readonly class FullTextSearch implements SearchModifierInterface
 {
+    /**
+     * @param string[] $fields
+     */
     public function __construct(
-        private string $searchTerm
+        private string $searchTerm,
+        private string $defaultOperator = 'AND',
+        private array $fields = [],
+        private ?string $flags = 'PHRASE|WHITESPACE',
     ) {
     }
 
     public function getSearchTerm(): string
     {
         return $this->searchTerm;
+    }
+
+    public function getDefaultOperator(): string
+    {
+        return $this->defaultOperator;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    public function getFlags(): ?string
+    {
+        return $this->flags;
     }
 }

--- a/src/SearchIndexAdapter/DefaultSearch/Search/Modifier/Filter/NestedTypeFilters.php
+++ b/src/SearchIndexAdapter/DefaultSearch/Search/Modifier/Filter/NestedTypeFilters.php
@@ -137,6 +137,11 @@ final readonly class NestedTypeFilters
             return null;
         }
 
-        return (new SimpleQueryStringFilter($modifier->getSearchTerm()))->toArrayAsSubQuery();
+        return (new SimpleQueryStringFilter(
+            $modifier->getSearchTerm(),
+            $modifier->getDefaultOperator(),
+            $modifier->getFields(),
+            $modifier->getFlags(),
+        ))->toArrayAsSubQuery();
     }
 }

--- a/src/SearchIndexAdapter/DefaultSearch/Search/Modifier/FullTextSearch/FullTextSearchHandlers.php
+++ b/src/SearchIndexAdapter/DefaultSearch/Search/Modifier/FullTextSearch/FullTextSearchHandlers.php
@@ -100,7 +100,14 @@ final readonly class FullTextSearchHandlers
             return;
         }
 
-        $context->getSearch()->addQuery(new SimpleQueryStringFilter($fullValueSearch->getSearchTerm()));
+        $context->getSearch()->addQuery(
+            new SimpleQueryStringFilter(
+                $fullValueSearch->getSearchTerm(),
+                $fullValueSearch->getDefaultOperator(),
+                $fullValueSearch->getFields(),
+                $fullValueSearch->getFlags(),
+            )
+        );
     }
 
     #[AsSearchModifierHandler]

--- a/tests/Unit/Model/DefaultSearch/Query/SimpleQueryStringFilterTest.php
+++ b/tests/Unit/Model/DefaultSearch/Query/SimpleQueryStringFilterTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Model\DefaultSearch\Query;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Query\SimpleQueryStringFilter;
+
+/**
+ * @internal
+ */
+final class SimpleQueryStringFilterTest extends Unit
+{
+    public function testDefaultsUseAndOperatorAndSafeFlags(): void
+    {
+        $filter = new SimpleQueryStringFilter('Ford 1.1-1');
+
+        self::assertSame([
+            'simple_query_string' => [
+                'query' => 'Ford 1.1-1',
+                'default_operator' => 'AND',
+                'flags' => 'PHRASE|WHITESPACE',
+            ],
+        ], $filter->toArrayAsSubQuery());
+
+        self::assertSame([
+            'bool' => [
+                'filter' => [
+                    'simple_query_string' => [
+                        'query' => 'Ford 1.1-1',
+                        'default_operator' => 'AND',
+                        'flags' => 'PHRASE|WHITESPACE',
+                    ],
+                ],
+            ],
+        ], $filter->toArray(true));
+    }
+
+    public function testFieldsAreOmittedWhenEmpty(): void
+    {
+        $filter = new SimpleQueryStringFilter('value');
+
+        self::assertArrayNotHasKey('fields', $filter->toArrayAsSubQuery()['simple_query_string']);
+    }
+
+    public function testFieldsAndFlagsAreConfigurable(): void
+    {
+        $filter = new SimpleQueryStringFilter(
+            'value',
+            'OR',
+            ['key^3', 'fullPath'],
+            'ALL',
+        );
+
+        self::assertSame([
+            'simple_query_string' => [
+                'query' => 'value',
+                'default_operator' => 'OR',
+                'fields' => ['key^3', 'fullPath'],
+                'flags' => 'ALL',
+            ],
+        ], $filter->toArrayAsSubQuery());
+    }
+
+    public function testFlagsAreOmittedWhenNull(): void
+    {
+        $filter = new SimpleQueryStringFilter('value', 'AND', [], null);
+
+        self::assertArrayNotHasKey('flags', $filter->toArrayAsSubQuery()['simple_query_string']);
+    }
+
+    public function testGetTerm(): void
+    {
+        $filter = new SimpleQueryStringFilter('value');
+
+        self::assertSame('value', $filter->getTerm());
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-ui-bundle/issues/2404

## Additional info
for better relevance and to treat characters like `-` and `.` as literal text.
