### PR TITLE
[BUG] Adds normalize to boolean adapter

### DIFF
--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/BooleanAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/BooleanAdapter.php
@@ -26,4 +26,9 @@ final class BooleanAdapter extends AbstractAdapter
             'type' => AttributeType::BOOLEAN->value,
         ];
     }
+
+    public function normalize(mixed $value): mixed
+    {
+        return $value !== null ? (bool) $value : null;
+    }
 }


### PR DESCRIPTION
## Changes in this pull request

Fixes issue where checkbox classification store keys would fail on index update as value was being read as string instead of boolean. 

## Additional info

On a typical class definition a boolean field would be a tinyint and there of the correctly expected type. A classification store value is stored as a longtext and there fore interpreted as a string.