### PR TITLE
[Bugfix] Fix IndexQueueRepositoryTest stubbing iterateAssociative as Traversable

### DIFF
--- a/tests/Unit/Repository/IndexQueueRepositoryTest.php
+++ b/tests/Unit/Repository/IndexQueueRepositoryTest.php
@@ -159,7 +159,7 @@ final class IndexQueueRepositoryTest extends Unit
     public function testEnqueueBySelectQueryWithEmptyResult(): void
     {
         $connection = $this->makeEmpty(Connection::class, [
-            'iterateAssociative' => [],
+            'iterateAssociative' => new \ArrayIterator([]),
         ]);
 
         $repository = $this->createRepository($connection);
@@ -181,7 +181,7 @@ final class IndexQueueRepositoryTest extends Unit
         $insertStatements = [];
 
         $connection = $this->makeEmpty(Connection::class, [
-            'iterateAssociative' => [
+            'iterateAssociative' => new \ArrayIterator([
                 [
                     'elementId' => '10',
                     'elementType' => 'asset',
@@ -198,7 +198,7 @@ final class IndexQueueRepositoryTest extends Unit
                     'operationTime' => '1711800000000',
                     'dispatched' => '0',
                 ],
-            ],
+            ]),
             'beginTransaction' => null,
             'commit' => null,
             'quoteIdentifier' => function (string $identifier) {
@@ -248,7 +248,7 @@ final class IndexQueueRepositoryTest extends Unit
         $insertStatements = [];
 
         $connection = $this->makeEmpty(Connection::class, [
-            'iterateAssociative' => [
+            'iterateAssociative' => new \ArrayIterator([
                 [
                     'elementId' => '100',
                     'elementType' => 'data_object',
@@ -257,7 +257,7 @@ final class IndexQueueRepositoryTest extends Unit
                     'operationTime' => '1711800000000',
                     'dispatched' => '0',
                 ],
-            ],
+            ]),
             'beginTransaction' => null,
             'commit' => null,
             'quoteIdentifier' => function (string $identifier) {


### PR DESCRIPTION
## What

Wrap the `iterateAssociative` stub return values in `IndexQueueRepositoryTest` with `ArrayIterator` so they satisfy the method's declared `Traversable` return type.

## Why

CI on `2026.1` (e.g. run [27687121541](https://github.com/pimcore/generic-data-index-bundle/actions/runs/27687121541)) fails with 3 errors, all the same `TypeError`:

```
MockObject_Connection::iterateAssociative(): Return value must be of type Traversable, array returned
```

`enqueueBySelectQuery()` was refactored to consume `Connection::iterateAssociative()` (declared `: Traversable`) instead of `fetchAllAssociative()` (`: array`). The accompanying unit test still stubbed the method with a **plain array** via `makeEmpty()`. PHPUnit's generated double honours the real `: Traversable` return type, so returning an array throws.

This surfaced only after the `2.5 → 2026.1` forward merge combined the `iterateAssociative()` implementation (from `2.5`, which had no unit test for it) with the test (from `2026.1`, previously stubbing `fetchAllAssociative`) — a pairing that had never executed before. It is not a dependency/version issue: `composer.json` is unchanged and `iterateAssociative(): Traversable` is declared identically across the involved DBAL versions.

## Fix

Return `ArrayIterator` instances from the stub instead of raw arrays. This satisfies the `Traversable` return type and is consumed correctly by the `foreach` in `enqueueBySelectQuery()`.

Affects 3 tests:
- `testEnqueueBySelectQueryWithEmptyResult`
- `testEnqueueBySelectQueryExtractsNamedColumns`
- `testEnqueueBySelectQueryExtractsDataObjectNamedColumns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)