### PR TITLE
Drop SKIP LOCKED and make dispatch ids unique in index queue

### DIFF
--- a/src/Repository/IndexQueueRepository.php
+++ b/src/Repository/IndexQueueRepository.php
@@ -41,6 +41,13 @@ final class IndexQueueRepository
 
     public const BATCH_SIZE = 500;
 
+    /**
+     * Factor reserving the low-order digits of a dispatch id for a random
+     * uniqueness suffix, while the millisecond timestamp stays in the
+     * high-order digits. See generateDispatchId().
+     */
+    private const DISPATCH_ID_FACTOR = 1_000_000;
+
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly TimeServiceInterface $timeService,
@@ -85,8 +92,11 @@ final class IndexQueueRepository
             if ($dispatch) {
                 $dispatchId = $this->dispatchItems($limit);
 
+                // No row locking required: dispatchItems() has already claimed the
+                // rows for this worker by stamping them with the unique $dispatchId,
+                // so this query only ever reads its own, exclusively-owned rows.
                 $sql = sprintf(
-                    'SELECT * FROM %s WHERE %s = :dispatchId FOR UPDATE SKIP LOCKED',
+                    'SELECT * FROM %s WHERE %s = :dispatchId',
                     $this->connection->quoteIdentifier(IndexQueue::TABLE),
                     $this->connection->quoteIdentifier('dispatched')
                 );
@@ -97,8 +107,12 @@ final class IndexQueueRepository
                 )->fetchAllAssociative();
             }
 
+            // Non-dispatching read ("peek"): returns unhandled entries without
+            // claiming them. As a pure read it neither needs nor should hold row
+            // locks. Concurrency-safe claiming is handled by the $dispatch branch
+            // above via dispatchItems().
             $sql = sprintf(
-                'SELECT * FROM %s WHERE %s = 0 ORDER BY %s ASC LIMIT %s FOR UPDATE SKIP LOCKED',
+                'SELECT * FROM %s WHERE %s = 0 ORDER BY %s ASC LIMIT %s',
                 $this->connection->quoteIdentifier(IndexQueue::TABLE),
                 $this->connection->quoteIdentifier('dispatched'),
                 $this->connection->quoteIdentifier('operationTime'),
@@ -264,20 +278,38 @@ final class IndexQueueRepository
     public function dispatchItems(
         int $limit
     ): int {
-        $dispatchId = $this->timeService->getCurrentMillisecondTimestamp();
+        $timestamp = $this->timeService->getCurrentMillisecondTimestamp();
+        $dispatchId = $this->generateDispatchId($timestamp);
 
         // Executed as direct SQL statement as doctrine ORM does not support LIMIT in UPDATE queries
         $this->connection->executeQuery(
             'UPDATE ' . IndexQueue::TABLE .
-            ' SET dispatched = :dispatchId WHERE dispatched < :dispatched LIMIT ' . $limit,
+            ' SET dispatched = :dispatchId WHERE dispatched < :threshold LIMIT ' . $limit,
 
             [
                 'dispatchId' => $dispatchId,
-                'dispatched' => $dispatchId - 60*60*24*1000,
+                // 24h staleness threshold, scaled to the dispatch id encoding so
+                // that unhandled (0) and stale rows are still re-dispatched.
+                'threshold' => ($timestamp - 60*60*24*1000) * self::DISPATCH_ID_FACTOR,
             ]
         );
 
         return $dispatchId;
+    }
+
+    /**
+     * Builds a per-dispatch claim token that stays unique even when several
+     * workers dispatch within the same millisecond.
+     *
+     * The millisecond timestamp is kept in the high-order digits - preserving
+     * the chronological ordering the stale-item re-dispatch in dispatchItems()
+     * relies on - while a random suffix in the low-order digits guarantees
+     * uniqueness within a single millisecond. The result stays well within the
+     * unsigned bigint range of the "dispatched" column.
+     */
+    private function generateDispatchId(int $timestamp): int
+    {
+        return $timestamp * self::DISPATCH_ID_FACTOR + random_int(0, self::DISPATCH_ID_FACTOR - 1);
     }
 
     public function resetDispatchedItems(string $dispatchId): void

--- a/tests/Functional/SearchIndex/IndexQueueTest.php
+++ b/tests/Functional/SearchIndex/IndexQueueTest.php
@@ -81,7 +81,9 @@ class IndexQueueTest extends Unit
         $this->assertCount(1, $indexQueueRepository->getUnhandledIndexQueueEntries());
 
         $dispatchedItems = $indexQueueRepository->getUnhandledIndexQueueEntries(true);
-        usleep(1000); //sleep for 1 ms to ensure that the dispatchId is different
+        // No sleep needed: dispatch ids are unique even within the same
+        // millisecond, so a subsequent dispatch never re-fetches already
+        // dispatched items.
         $this->assertEquals([], $indexQueueRepository->getUnhandledIndexQueueEntries(true));
 
         $dispatchedItems = array_map(fn ($entry) => $indexQueueRepository->denormalizeDatabaseEntry($entry), $dispatchedItems);


### PR DESCRIPTION
## Changes in this pull request
Resolves #357

`generic-data-index-bundle` used `SELECT ... FOR UPDATE SKIP LOCKED` in the index queue, but `SKIP LOCKED` is not available on every database Pimcore supports (notably **MariaDB < 10.6**, where it raises a syntax error). Raising the minimum DB version is a BC break that does not belong in a minor/bugfix release, so this PR removes the dependency instead.

**1. Drop `SKIP LOCKED` (both queue queries are now plain `SELECT`s)**
- The locking was not actually needed. Concurrent claiming is already handled by `dispatchItems()`, which atomically stamps rows with a dispatch id via `UPDATE ... SET dispatched = :id`. The follow-up read only ever fetches the worker's own, exclusively-owned rows.
- The non-dispatching path is a pure "peek" (read of `dispatched = 0` rows without claiming), so it neither needs nor should hold row locks.
- Result: portable to all supported databases, no version bump, no DDL.

**2. Make dispatch ids unique (`dispatchItems()`)**
- Previously the dispatch id was a plain millisecond timestamp. Two workers dispatching within the same millisecond received the **same** id, so each `SELECT WHERE dispatched = :id` returned the union of both workers' rows → double processing.
- The id now keeps the millisecond timestamp in the high-order digits and adds a random suffix in the low-order digits (`timestamp * 1_000_000 + random_int(0, 999_999)`), guaranteeing uniqueness within a millisecond while preserving the chronological ordering the 24h stale-item re-dispatch relies on. The value stays well within the `bigint unsigned` range of the `dispatched` column.

## Additional info
- **No schema change / no migration** — the fix reuses the existing `dispatched` column.
- **Backwards compatible** — public signatures and behaviors of `getUnhandledIndexQueueEntries()` and `dispatchItems()` are unchanged.
- The functional test no longer needs its `usleep(1ms)` workaround (it existed only to dodge the same-millisecond id collision this PR fixes), so its removal now actively asserts the fix.
- ⚠️ Worth validating on a large-scale, highly concurrent dataset (millions of rows / many workers): confirm no row is processed twice and none is stranded. The random suffix gives 1,000,000 slots per millisecond, so collisions are astronomically unlikely but not mathematically zero.
