### PR TITLE
[Documentation] Explain the purpose of odd/even index suffixes

### DIFF
--- a/doc/02_Configuration/03_Index_Management.md
+++ b/doc/02_Configuration/03_Index_Management.md
@@ -27,6 +27,23 @@ For the asset and data object indices the Generic Data Index uses an alias (e.g.
 most current index (e.g. `<index_prefix>_asset-odd`). The alias name always stays the same, the index names alternate
 between `-odd` and `-even` suffix. For more details also see 'Updating index structure for data indices' in the next section.
 
+### Why `-odd` and `-even` Suffixes?
+
+The alternating suffixes enable zero-downtime reindexing (blue-green approach): when the
+index structure changes, the bundle builds a new index under the opposite suffix while
+the current index keeps serving reads and writes through the alias. Once the new index
+is fully populated, the alias is switched atomically and the old index is deleted.
+
+At rest there is only **one** concrete index — and therefore one set of shards — per
+asset index or class definition. Both suffixes exist side by side only transiently
+while a reindex is running. If `-odd` and `-even` indices for the same alias exist
+permanently, they are leftovers from a reindex that was interrupted (e.g. by a killed
+process) before its cleanup could run. Such orphaned indices are not used by the bundle
+and can safely be deleted, as long as they are not referenced by any alias.
+
+The default index settings use `number_of_shards: 1`, so the total shard count of the
+cluster scales with the number of class definitions — not with the suffix scheme.
+
 ## Keeping Indices Up to Date
 
 The element search indices need to be created via the following console commands:


### PR DESCRIPTION
## Changes in this pull request

Documents the `-odd`/`-even` index suffix scheme in `doc/02_Configuration/03_Index_Management.md`:

- **Why the suffixes exist**: zero-downtime (blue-green) reindexing — the new index is built under the opposite suffix while the alias keeps serving the current one, then switched atomically.
- **At-rest guarantee**: only one concrete index (and one set of shards) per asset index / class definition exists outside of a running reindex — addressing the "2x shards per class" concern from the issue.
- **Orphan guidance**: permanently coexisting `-odd`+`-even` indices are leftovers of interrupted reindexes and can safely be deleted when not referenced by an alias. 

Resolves #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)