### PR TITLE
[Bug] Delete index occupying the alias name during index recovery

### DIFF
--- a/src/SearchIndexAdapter/SearchIndexServiceInterface.php
+++ b/src/SearchIndexAdapter/SearchIndexServiceInterface.php
@@ -40,6 +40,8 @@ interface SearchIndexServiceInterface
 
     public function existsAlias(string $aliasName, ?string $indexName = null): bool;
 
+    public function existsIndex(string $indexName): bool;
+
     public function deleteAlias(string $indexName, string $aliasName): array;
 
     public function getDocument(string $index, int $id, bool $ignore404 = false): array;

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -50,6 +50,17 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
                 foreach ($versions as $version) {
                     $this->searchIndexService->deleteIndex($aliasName . '-' . $version, true);
                 }
+
+                // While the alias is missing, indexing traffic can auto-create a concrete
+                // index carrying the exact alias name; attaching the alias would then fail
+                // with invalid_alias_name_exception. Its data is derived from the database
+                // and gets rebuilt by the reindex following the recreation.
+                if ($this->searchIndexService->existsIndex($aliasName)) {
+                    $this->logger->warning(
+                        sprintf('Deleting index "%s" occupying the alias name before recreation', $aliasName)
+                    );
+                    $this->searchIndexService->deleteIndex($aliasName, true);
+                }
             }
 
             $this->createIndex($context, $aliasName);

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Service\SearchIndex\IndexService\IndexHandler;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler\AbstractIndexHandler;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Psr\Log\NullLogger;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+final class AbstractIndexHandlerTest extends Unit
+{
+    private const ALIAS_NAME = 'test_alias';
+
+    /**
+     * An interrupted reindex can leave the alias missing while indexing traffic
+     * auto-creates a concrete index carrying the exact alias name. Attaching the
+     * alias then fails with invalid_alias_name_exception, so the recovery in
+     * updateMapping() must remove such an index before recreating.
+     *
+     * @see https://github.com/pimcore/generic-data-index-bundle/issues/412
+     */
+    public function testUpdateMappingDeletesIndexSquattingOnAliasName(): void
+    {
+        $deletedIndices = [];
+        $handler = $this->createHandler(
+            indexSquatsAliasName: true,
+            deletedIndices: $deletedIndices
+        );
+
+        $handler->updateMapping();
+
+        $this->assertContains(self::ALIAS_NAME . '-even', $deletedIndices);
+        $this->assertContains(self::ALIAS_NAME . '-odd', $deletedIndices);
+        $this->assertContains(
+            self::ALIAS_NAME,
+            $deletedIndices,
+            'An index occupying the alias name must be deleted before the alias is attached'
+        );
+    }
+
+    public function testUpdateMappingKeepsAliasNameUntouchedWhenNoIndexSquatsOnIt(): void
+    {
+        $deletedIndices = [];
+        $handler = $this->createHandler(
+            indexSquatsAliasName: false,
+            deletedIndices: $deletedIndices
+        );
+
+        $handler->updateMapping();
+
+        $this->assertNotContains(self::ALIAS_NAME, $deletedIndices);
+    }
+
+    private function createHandler(bool $indexSquatsAliasName, array &$deletedIndices): AbstractIndexHandler
+    {
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => false,
+            'existsIndex' => static fn (string $indexName): bool => $indexSquatsAliasName
+                && $indexName === self::ALIAS_NAME,
+            'deleteIndex' => static function ($indexName, bool $silent = false) use (&$deletedIndices): void {
+                $deletedIndices[] = $indexName;
+            },
+            'getCurrentIndexVersion' => '',
+            'putMapping' => [],
+        ]);
+
+        $handler = new class(
+            $searchIndexService,
+            $this->makeEmpty(SearchIndexConfigServiceInterface::class),
+            $this->makeEmpty(EventDispatcherInterface::class),
+            $this->makeEmpty(IndexMappingServiceInterface::class),
+        ) extends AbstractIndexHandler {
+            protected function extractMappingProperties(mixed $context = null): array
+            {
+                return [];
+            }
+
+            protected function getAliasIndexName(mixed $context = null): string
+            {
+                return 'test_alias';
+            }
+        };
+        $handler->setLogger(new NullLogger());
+
+        return $handler;
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

Fixes the permanently failing reindex reported in #412 (`invalid_alias_name_exception: an index exists with the same name as the alias`).

**Root cause**: after an interrupted reindex the alias is missing; indexing traffic writing to the alias name then auto-creates a concrete index carrying the exact alias name (engine default `action.auto_create_index`). The recovery block in `AbstractIndexHandler::updateMapping()` (from #439) only deletes `-even`/`-odd` suffixed indices, so the squatting index survives and `addAlias()` fails on every subsequent reindex — until someone deletes the index manually via curl.

**Fix**: the recovery block now also checks for and deletes a concrete index bearing the alias name before recreating (with a warning log). This is safe in this specific branch: it only runs when no alias exists and is immediately followed by index recreation + reindex from the database, which rebuilds the data the auto-created index held.

**Note for reviewers**: this exposes the existing `DefaultSearchService::existsIndex()` through `SearchIndexServiceInterface`. The interface is `@internal` (outside the BC promise) and its only implementation already has the method with this exact signature — same pattern as #391's `getIndexSettings()` addition.

## Additional info

- TDD: the new unit test `AbstractIndexHandlerTest` fails on the current 2.5 code (`Failed asserting that an array contains 'test_alias'`) and passes with the fix; verified in the `pimcore/pimcore:php8.4-latest` container. Full Unit suite shows the identical pre-existing environment-dependent failures as pristine 2.5 (300→302 tests, same 6 errors/1 failure baseline).
- Base is `2.5` as the oldest affected line; needs the usual forward merge up to 2026.x after merge.
- Tactical fix only — the broader idempotent-reconcile refactoring of the index lifecycle (single owner for alias/index/desired-state, would also cover `createGlobalIndexAliases()`) remains a separate discussion.

Resolves #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)