### PR TITLE
[Documentation] State supported OpenSearch version range as >= 2.7 and < 3.0

### DIFF
--- a/doc/01_Installation/README.md
+++ b/doc/01_Installation/README.md
@@ -2,7 +2,8 @@
 
 :::info
 
- This bundle requires minimum version of OpenSearch 2.7. or Elasticsearch 8.0.0.
+ This bundle requires OpenSearch >= 2.7 and < 3.0 or Elasticsearch 8.0.0.
+ OpenSearch 3 is not supported yet.
 
 :::
 

--- a/doc/02_Configuration/04_Opensearch.md
+++ b/doc/02_Configuration/04_Opensearch.md
@@ -2,7 +2,10 @@
 
 :::info
 
-Supported versions of OpenSearch are 2.7. to 2.19
+Supported versions of OpenSearch are >= 2.7 and < 3.0.
+OpenSearch 3 is not supported yet — see the
+[Pimcore OpenSearch Client](https://github.com/pimcore/opensearch-client) for the
+supported client versions.
 
 :::
 


### PR DESCRIPTION
## Changes in this pull request

Clarifies the supported OpenSearch version range in the documentation, prompted by #430:

- `doc/01_Installation/README.md` stated only a minimum (`>= 2.7` / "minimum version of OpenSearch 2.7"), implying OpenSearch 3.x is supported.
- `doc/02_Configuration/04_Opensearch.md` pinned a stale `2.7 to 2.19` range.

Both now state **`>= 2.7 and < 3.0`** with an explicit "OpenSearch 3 is not supported yet" note (the underlying [pimcore/opensearch-client](https://github.com/pimcore/opensearch-client) does not support OpenSearch 3), and the configuration page links to the client for supported client versions.

## Additional info

- The same two statements exist with slightly different wording on 2026.1/2026.2/2026.x — the forward merge will adapt them per branch.
- This addresses the documentation aspect of #430 (reporter ran `opensearchproject/opensearch:3.7.0`). The underlying `[]`-vs-`{}` mapping serialization behavior on unsupported OpenSearch 3 remains out of scope here.

See #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)