### PR TITLE
[Bug, EC] PEES-1206: Reindex failures are silently swallowed and deployment reindex exits 0

### DIFF
--- a/doc/01_Installation/02_Upgrade.md
+++ b/doc/01_Installation/02_Upgrade.md
@@ -2,6 +2,14 @@
 
 Following steps are necessary during updating to newer versions.
 
+## Upgrade to 2.5.6
+- [Commands] `generic-data-index:deployment:reindex` and `generic-data-index:reindex` now exit with a non-zero status
+  code when reindexing fails, instead of always returning `0`. Deployment pipelines executing these commands will now
+  fail visibly on reindex errors — previously such errors were only printed while the process reported success.
+- [Indexing] Reindexing failures are no longer silently swallowed: if both the reindex and the fallback index
+  recreation fail, the exception now propagates and the mapping checksum is not stored, so the reindex of the class
+  definition is retried on the next run.
+
 ## Upgrade to 2.5.4
 - [Searching] The full-text search (`FullTextSearch` modifier) now defaults to `default_operator: AND` and
   `flags: PHRASE|WHITESPACE` for better relevance and to treat characters like `-` and `.` as literal text.

--- a/src/Command/DeploymentReindexCommand.php
+++ b/src/Command/DeploymentReindexCommand.php
@@ -97,6 +97,8 @@ final class DeploymentReindexCommand extends AbstractCommand
             $output->writeln('<info>Finished</info>', OutputInterface::VERBOSITY_NORMAL);
         } catch (Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return self::FAILURE;
         } finally {
             $this->release();
         }

--- a/src/Command/ReindexItemsCommand.php
+++ b/src/Command/ReindexItemsCommand.php
@@ -65,6 +65,8 @@ final class ReindexItemsCommand extends AbstractCommand
             $this->reindexService->reindexAllIndices();
         } catch (Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return self::FAILURE;
         } finally {
             $this->release();
         }

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -100,8 +100,17 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
             } catch (Exception $e) {
                 try {
                     $this->updateMapping($context, true, $mappingProperties);
-                } catch (Exception $e) {
-                    $this->logger->error('Reindexing failed due to following error: ' . $e);
+                } catch (Exception $fallbackException) {
+                    // Both the reindex and the fallback recreation failed: rethrow so the
+                    // failure reaches the caller instead of the mapping checksum being
+                    // stored as if the reindex had succeeded.
+                    $this->logger->error(sprintf(
+                        'Reindexing failed due to following error: %s (initial reindex failure: %s)',
+                        $fallbackException,
+                        $e->getMessage()
+                    ));
+
+                    throw $fallbackException;
                 }
             }
         }

--- a/tests/Functional/Command/DeploymentReindexCommandTest.php
+++ b/tests/Functional/Command/DeploymentReindexCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Functional\Command;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\Command\DeploymentReindexCommand;
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\ClassDefinitionIndexUpdateFailedException;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\ClassDefinition\ClassDefinitionReindexServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexQueue\EnqueueServiceInterface;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DeploymentReindexCommandTest extends Unit
+{
+    /**
+     * @var \Pimcore\Bundle\GenericDataIndexBundle\Tests\IndexTester
+     */
+    protected $tester;
+
+    protected function _before(): void
+    {
+        // The command iterates all class definitions; the functional suite provisions
+        // several, so the loop body is guaranteed to run.
+        $this->assertNotEmpty(
+            (new ClassDefinition\Listing())->load(),
+            'Precondition failed: no class definitions available in the test environment'
+        );
+    }
+
+    /**
+     * When reindexing a class definition fails, the deployment pipeline must see a
+     * non-zero exit code instead of silently continuing with a stale index.
+     *
+     * @see https://github.com/pimcore/service-operations/issues/853
+     */
+    public function testReturnsFailureWhenClassDefinitionReindexThrows(): void
+    {
+        $classDefinitionReindexService = $this->makeEmpty(ClassDefinitionReindexServiceInterface::class, [
+            'reindexClassDefinition' => static function (): bool {
+                throw new ClassDefinitionIndexUpdateFailedException('OpenSearch reindex failed (simulated 504)');
+            },
+        ]);
+        $enqueueService = $this->makeEmpty(EnqueueServiceInterface::class, [
+            'dispatchQueueMessages' => Expected::never(),
+        ]);
+
+        $commandTester = new CommandTester(
+            new DeploymentReindexCommand($enqueueService, $classDefinitionReindexService)
+        );
+        $commandTester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        $this->assertStringContainsString('OpenSearch reindex failed (simulated 504)', $commandTester->getDisplay());
+    }
+
+    public function testReturnsSuccessWhenNoClassDefinitionChanged(): void
+    {
+        $classDefinitionReindexService = $this->makeEmpty(ClassDefinitionReindexServiceInterface::class, [
+            'reindexClassDefinition' => false,
+        ]);
+        $enqueueService = $this->makeEmpty(EnqueueServiceInterface::class, [
+            'dispatchQueueMessages' => Expected::never(),
+        ]);
+
+        $commandTester = new CommandTester(
+            new DeploymentReindexCommand($enqueueService, $classDefinitionReindexService)
+        );
+        $commandTester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        $this->assertStringContainsString('No updates needed', $commandTester->getDisplay());
+    }
+}

--- a/tests/Unit/Command/ReindexItemsCommandTest.php
+++ b/tests/Unit/Command/ReindexItemsCommandTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Command;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Command\ReindexItemsCommand;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\ReindexServiceInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+final class ReindexItemsCommandTest extends Unit
+{
+    public function testReturnsSuccessWhenReindexingSucceeds(): void
+    {
+        $reindexCalls = 0;
+        $reindexService = null;
+        $reindexService = $this->makeEmpty(ReindexServiceInterface::class, [
+            'reindexAllIndices' => function () use (&$reindexCalls, &$reindexService): ReindexServiceInterface {
+                $reindexCalls++;
+
+                return $reindexService;
+            },
+        ]);
+
+        $commandTester = new CommandTester(new ReindexItemsCommand($reindexService));
+        $commandTester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        $this->assertSame(1, $reindexCalls);
+    }
+
+    /**
+     * A failed reindex must be visible to the calling process (e.g. a deployment
+     * pipeline) through a non-zero exit code.
+     *
+     * @see https://github.com/pimcore/service-operations/issues/853
+     */
+    public function testReturnsFailureWhenReindexingThrows(): void
+    {
+        $reindexService = $this->makeEmpty(ReindexServiceInterface::class, [
+            'reindexAllIndices' => static function (): void {
+                throw new Exception('OpenSearch reindex failed (simulated)');
+            },
+        ]);
+
+        $commandTester = new CommandTester(new ReindexItemsCommand($reindexService));
+        $commandTester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        $this->assertStringContainsString('OpenSearch reindex failed (simulated)', $commandTester->getDisplay());
+    }
+}

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Service\SearchIndex\IndexService\IndexHandler;
 
 use Codeception\Test\Unit;
+use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler\AbstractIndexHandler;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Psr\Log\AbstractLogger;
 use Psr\Log\NullLogger;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -68,6 +70,109 @@ final class AbstractIndexHandlerTest extends Unit
         $this->assertNotContains(self::ALIAS_NAME, $deletedIndices);
     }
 
+    /**
+     * When the in-place reindex fails (e.g. a 5xx from OpenSearch) and the fallback
+     * index recreation fails too, the failure must propagate to the caller. Otherwise
+     * the mapping checksum gets stored as if the reindex succeeded and the class is
+     * never retried on subsequent deployments.
+     *
+     * @see https://github.com/pimcore/service-operations/issues/853
+     */
+    public function testReindexMappingRethrowsWhenFallbackRecreationAlsoFails(): void
+    {
+        $reindexException = new Exception('initial reindex failure (504 Gateway Time-out)');
+        $fallbackException = new Exception('fallback recreation failed');
+
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => true,
+            'getCurrentIndexVersion' => '',
+            'reindex' => static function () use ($reindexException): void {
+                throw $reindexException;
+            },
+            'createIndex' => static function () use ($fallbackException): void {
+                throw $fallbackException;
+            },
+        ]);
+
+        $logger = $this->createCollectingLogger();
+        $handler = $this->createHandlerWithService($searchIndexService);
+        $handler->setLogger($logger);
+
+        $thrown = null;
+
+        try {
+            $handler->reindexMapping();
+        } catch (Exception $e) {
+            $thrown = $e;
+        }
+
+        $this->assertSame(
+            $fallbackException,
+            $thrown,
+            'Expected the fallback exception to propagate out of reindexMapping()'
+        );
+
+        $errorLogs = array_filter($logger->records, static fn (array $r): bool => $r['level'] === 'error');
+        $this->assertNotEmpty($errorLogs, 'The failure must still be logged');
+        $loggedMessage = implode(' | ', array_column($errorLogs, 'message'));
+        $this->assertStringContainsString(
+            'initial reindex failure',
+            $loggedMessage,
+            'The original reindex exception must not be lost through variable shadowing'
+        );
+    }
+
+    /**
+     * The fallback to a forced index recreation is the designed recovery for mapping
+     * changes that cannot be applied via reindex. When it succeeds, no exception
+     * may propagate.
+     */
+    public function testReindexMappingRecoversWhenFallbackRecreationSucceeds(): void
+    {
+        $createdIndices = [];
+        $fluent = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'addAlias' => [],
+        ]);
+
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => true,
+            'getCurrentIndexVersion' => '',
+            'reindex' => static function (): void {
+                throw new Exception('initial reindex failure (504 Gateway Time-out)');
+            },
+            'createIndex' => static function (string $indexName) use (&$createdIndices, $fluent) {
+                $createdIndices[] = $indexName;
+
+                return $fluent;
+            },
+            'putMapping' => [],
+        ]);
+
+        $handler = $this->createHandlerWithService($searchIndexService);
+        $handler->setLogger(new NullLogger());
+
+        $handler->reindexMapping();
+
+        $this->assertContains(
+            self::ALIAS_NAME . '-odd',
+            $createdIndices,
+            'The fallback must recreate the index when the reindex fails'
+        );
+    }
+
+    private function createCollectingLogger(): AbstractLogger
+    {
+        return new class extends AbstractLogger {
+            /** @var array<int, array{level: string, message: string}> */
+            public array $records = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = ['level' => (string) $level, 'message' => (string) $message];
+            }
+        };
+    }
+
     private function createHandler(bool $indexSquatsAliasName, array &$deletedIndices): AbstractIndexHandler
     {
         $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
@@ -81,7 +186,15 @@ final class AbstractIndexHandlerTest extends Unit
             'putMapping' => [],
         ]);
 
-        $handler = new class($searchIndexService, $this->makeEmpty(SearchIndexConfigServiceInterface::class), $this->makeEmpty(EventDispatcherInterface::class), $this->makeEmpty(IndexMappingServiceInterface::class), ) extends AbstractIndexHandler {
+        $handler = $this->createHandlerWithService($searchIndexService);
+        $handler->setLogger(new NullLogger());
+
+        return $handler;
+    }
+
+    private function createHandlerWithService(SearchIndexServiceInterface $searchIndexService): AbstractIndexHandler
+    {
+        return new class($searchIndexService, $this->makeEmpty(SearchIndexConfigServiceInterface::class), $this->makeEmpty(EventDispatcherInterface::class), $this->makeEmpty(IndexMappingServiceInterface::class), ) extends AbstractIndexHandler {
             protected function extractMappingProperties(mixed $context = null): array
             {
                 return [];
@@ -92,8 +205,5 @@ final class AbstractIndexHandlerTest extends Unit
                 return 'test_alias';
             }
         };
-        $handler->setLogger(new NullLogger());
-
-        return $handler;
     }
 }


### PR DESCRIPTION
Resolves https://github.com/pimcore/service-operations/issues/853

## Changes in this pull request

When reindexing fails during `generic-data-index:deployment:reindex` (e.g. a 5xx from OpenSearch, see PEES-1206), the failure was invisible to the deployment pipeline:

1. `AbstractIndexHandler::reindexMapping()` swallowed the exception when both the in-place reindex **and** the fallback index recreation failed — it only logged the error (and, due to variable shadowing, even lost the original reindex exception). Control returned normally, so `ClassDefinitionReindexService` stored the new mapping checksum as if everything had succeeded — the class definition was **never retried** on subsequent deployments.
2. `DeploymentReindexCommand` and `ReindexItemsCommand` caught any remaining exception, printed it, and still returned exit code `0`.

### Fixes

- `AbstractIndexHandler::reindexMapping()`: when the fallback recreation also fails, the exception is now rethrown (with the original reindex failure preserved in the log message). The fallback itself is kept — a forced index recreation is the designed recovery for mapping changes that cannot be applied via reindex.
- `DeploymentReindexCommand` and `ReindexItemsCommand` now return `FAILURE` when an exception is caught, so deployment pipelines fail visibly instead of continuing with a stale index.
- Because the exception now propagates before the checksum is stored, a failed class definition reindex is retried on the next run.

### Behavior change

Deployment pipelines that previously reported success despite reindex errors will now fail. Documented in `doc/01_Installation/02_Upgrade.md` (2.5.6).

Note: the root cause of the customer-side 504 itself (synchronous `_reindex` timing out at the gateway) was already addressed by #435 (async reindex + task polling). This PR fixes the error propagation on top of it. Draft PR #444 is superseded by #435 + this PR.

## Additional info

- Tests: unit tests for the handler rethrow (incl. a regression test that the fallback recovery still works) and for `ReindexItemsCommand` exit codes; functional test for `DeploymentReindexCommand` exit codes.
