### PR TITLE
[Bug] Include key ID and exception message in classification store field definition warning

### DIFF
--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapter.php
@@ -295,9 +295,11 @@ final class ClassificationStoreAdapter extends AbstractAdapter
     {
         try {
             $definition = $this->classificationService->getFieldDefinitionFromKeyConfig($key);
-        } catch (Exception) {
+        } catch (Exception $e) {
             $this->logger->warning(
-                'Could not get field definition for type ' . $key->getType() . ' in group ' . $key->getGroupId()
+                'Could not get field definition for type ' . $key->getType() .
+                ' for key ' . $key->getKeyId() . ' in group ' . $key->getGroupId() .
+                ': ' . $e->getMessage()
             );
 
             return null;

--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapter.php
@@ -296,11 +296,13 @@ final class ClassificationStoreAdapter extends AbstractAdapter
         try {
             $definition = $this->classificationService->getFieldDefinitionFromKeyConfig($key);
         } catch (Exception $e) {
-            $this->logger->warning(
-                'Could not get field definition for type ' . $key->getType() .
-                ' for key ' . $key->getKeyId() . ' in group ' . $key->getGroupId() .
-                ': ' . $e->getMessage()
-            );
+            $this->logger->warning(sprintf(
+                'Could not get field definition for type %s for key %s in group %s: %s',
+                $key->getType(),
+                $key->getKeyId(),
+                $key->getGroupId(),
+                $e->getMessage()
+            ));
 
             return null;
         }

--- a/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapterTest.php
@@ -77,12 +77,10 @@ final class ClassificationStoreAdapterTest extends Unit
         $this->assertNull($result);
         $this->assertCount(1, $logger->records);
         $this->assertSame('warning', $logger->records[0]['level']);
-
-        $message = $logger->records[0]['message'];
-        $this->assertStringContainsString('input', $message);
-        $this->assertStringContainsString('42', $message);
-        $this->assertStringContainsString('9', $message);
-        $this->assertStringContainsString('unknown implementation for type input', $message);
+        $this->assertSame(
+            'Could not get field definition for type input for key 42 in group 9: unknown implementation for type input',
+            $logger->records[0]['message']
+        );
     }
 
     private function createCollectingLogger(): AbstractLogger

--- a/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapterTest.php
@@ -14,12 +14,17 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\SearchIndexAdapter\DataObject\FieldDefinitionAdapter;
 
 use Codeception\Test\Unit;
+use Exception;
 use InvalidArgumentException;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject\FieldDefinitionServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DataObject\FieldDefinitionAdapter\ClassificationStoreAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassificationStore\ServiceResolverInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Checkbox;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore;
+use Pimcore\Model\DataObject\Classificationstore\KeyGroupRelation;
+use Psr\Log\AbstractLogger;
+use ReflectionMethod;
 
 /**
  * @internal
@@ -42,5 +47,54 @@ final class ClassificationStoreAdapterTest extends Unit
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Field definition must be an instance of ' . Classificationstore::class);
         $adapter->getIndexMapping();
+    }
+
+    public function testWarningIncludesTypeKeyIdGroupIdAndExceptionMessageWhenFieldDefinitionCannotBeResolved(): void
+    {
+        $adapter = new ClassificationStoreAdapter(
+            $this->makeEmpty(SearchIndexConfigServiceInterface::class),
+            $this->makeEmpty(FieldDefinitionServiceInterface::class)
+        );
+
+        $resolverException = new Exception('unknown implementation for type input');
+        $adapter->setClassificationService($this->makeEmpty(ServiceResolverInterface::class, [
+            'getFieldDefinitionFromKeyConfig' => static function () use ($resolverException): never {
+                throw $resolverException;
+            },
+        ]));
+
+        $logger = $this->createCollectingLogger();
+        $adapter->setLogger($logger);
+
+        $key = new KeyGroupRelation();
+        $key->setType('input');
+        $key->setGroupId(9);
+        $key->setKeyId(42);
+
+        $method = new ReflectionMethod(ClassificationStoreAdapter::class, 'getFieldDefinitionForKey');
+        $result = $method->invoke($adapter, $key);
+
+        $this->assertNull($result);
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('warning', $logger->records[0]['level']);
+
+        $message = $logger->records[0]['message'];
+        $this->assertStringContainsString('input', $message);
+        $this->assertStringContainsString('42', $message);
+        $this->assertStringContainsString('9', $message);
+        $this->assertStringContainsString('unknown implementation for type input', $message);
+    }
+
+    private function createCollectingLogger(): AbstractLogger
+    {
+        return new class extends AbstractLogger {
+            /** @var array<int, array{level: string, message: string}> */
+            public array $records = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = ['level' => (string) $level, 'message' => (string) $message];
+            }
+        };
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/pimcore/platform-version/issues/190

## Summary
- The warning logged when a classification store key's field definition could not be resolved (`ClassificationStoreAdapter::getFieldDefinitionForKey`) omitted the key ID and swallowed the original exception message, making the warning impossible to act on.
- Reported in https://github.com/pimcore/generic-data-index-bundle/issues/190 — after upgrading, `generic-data-index:update:index -r` produced many warnings like `Could not get field definition for type input in group 9` with no way to identify which key was affected or why.
- Now logs the key ID and the caught exception's message alongside the type/group, so the specific broken/legacy classification key can be identified and fixed.

## Test plan
- [x] Existing unit tests in `tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/ClassificationStoreAdapterTest.php` pass
- [x] Manually trigger a classification store key with a broken/unresolvable field definition and confirm the warning now includes key ID and exception message