### PR TITLE
[BUG] Adds normalize to boolean adapter (takeover of #434)

### DIFF
--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/BooleanAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/BooleanAdapter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DataObject\FieldDefinitionAdapter;
 
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\DefaultSearch\AttributeType;
+use Pimcore\Model\DataObject\ClassDefinition\Data\BooleanSelect;
 
 /**
  * @internal
@@ -29,6 +30,17 @@ final class BooleanAdapter extends AbstractAdapter
 
     public function normalize(mixed $value): mixed
     {
-        return $value !== null ? (bool) $value : null;
+        if ($value === null) {
+            return null;
+        }
+
+        $fieldDefinition = $this->getFieldDefinition();
+        if ($fieldDefinition instanceof BooleanSelect) {
+            // booleanSelect is tri-state (1 = yes, -1 = no, null/0 = empty);
+            // a plain bool cast would turn "no" (-1) into true.
+            return $fieldDefinition->getDataFromResource($value);
+        }
+
+        return (bool) $value;
     }
 }

--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/BooleanAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/BooleanAdapter.php
@@ -26,4 +26,9 @@ final class BooleanAdapter extends AbstractAdapter
             'type' => AttributeType::BOOLEAN->value,
         ];
     }
+
+    public function normalize(mixed $value): mixed
+    {
+        return $value !== null ? (bool) $value : null;
+    }
 }

--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/BooleanAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/BooleanAdapter.php
@@ -30,8 +30,10 @@ final class BooleanAdapter extends AbstractAdapter
 
     public function normalize(mixed $value): mixed
     {
-        if ($value === null) {
-            return null;
+        // Values from object getters are already hydrated booleans; only raw
+        // resource values (e.g. classification store longtext) need conversion.
+        if ($value === null || is_bool($value)) {
+            return $value;
         }
 
         $fieldDefinition = $this->getFieldDefinition();

--- a/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/BooleanAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/BooleanAdapterTest.php
@@ -17,6 +17,9 @@ use Codeception\Test\Unit;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject\FieldDefinitionServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DataObject\FieldDefinitionAdapter\BooleanAdapter;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\ClassDefinition\Data\BooleanSelect;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Checkbox;
 
 /**
  * @internal
@@ -36,5 +39,54 @@ final class BooleanAdapterTest extends Unit
         $this->assertSame([
             'type' => 'boolean',
         ], $mapping);
+    }
+
+    /**
+     * Classification store values are stored as longtext, so checkbox values arrive
+     * as strings ('0'/'1') instead of booleans and must be cast for the boolean
+     * index mapping.
+     *
+     * @see https://github.com/pimcore/generic-data-index-bundle/pull/434
+     */
+    public function testNormalizeCastsCheckboxValuesToBool(): void
+    {
+        $adapter = $this->createAdapter(new Checkbox());
+
+        $this->assertTrue($adapter->normalize('1'));
+        $this->assertFalse($adapter->normalize('0'));
+        $this->assertTrue($adapter->normalize(1));
+        $this->assertFalse($adapter->normalize(0));
+        $this->assertTrue($adapter->normalize(true));
+        $this->assertFalse($adapter->normalize(false));
+        $this->assertNull($adapter->normalize(null));
+    }
+
+    /**
+     * The adapter is also registered for booleanSelect, which is tri-state:
+     * 1 = yes, -1 = no, null/0 = empty. A plain bool cast would turn "no" (-1)
+     * into true, so the field definition's own resource mapping must be used.
+     */
+    public function testNormalizeMapsBooleanSelectTriState(): void
+    {
+        $adapter = $this->createAdapter(new BooleanSelect());
+
+        $this->assertTrue($adapter->normalize('1'));
+        $this->assertTrue($adapter->normalize(1));
+        $this->assertFalse($adapter->normalize('-1'));
+        $this->assertFalse($adapter->normalize(-1));
+        $this->assertNull($adapter->normalize('0'));
+        $this->assertNull($adapter->normalize(0));
+        $this->assertNull($adapter->normalize(null));
+    }
+
+    private function createAdapter(Data $fieldDefinition): BooleanAdapter
+    {
+        $adapter = new BooleanAdapter(
+            $this->makeEmpty(SearchIndexConfigServiceInterface::class),
+            $this->makeEmpty(FieldDefinitionServiceInterface::class)
+        );
+        $adapter->setFieldDefinition($fieldDefinition);
+
+        return $adapter;
     }
 }

--- a/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/BooleanAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/BooleanAdapterTest.php
@@ -79,6 +79,19 @@ final class BooleanAdapterTest extends Unit
         $this->assertNull($adapter->normalize(null));
     }
 
+    /**
+     * Outside classification stores the object getter returns the already hydrated
+     * bool (getDataFromResource ran at load time) — those values must pass through
+     * unchanged instead of being nulled by a second resource conversion.
+     */
+    public function testNormalizeKeepsHydratedBooleanSelectValues(): void
+    {
+        $adapter = $this->createAdapter(new BooleanSelect());
+
+        $this->assertTrue($adapter->normalize(true));
+        $this->assertFalse($adapter->normalize(false));
+    }
+
     private function createAdapter(Data $fieldDefinition): BooleanAdapter
     {
         $adapter = new BooleanAdapter(


### PR DESCRIPTION
Supersedes #434 — recreated upstream with the original commit by @Jonathon-Meney-Torq (authorship preserved), since the head branch lives on an organization-owned fork where "allow edits by maintainers" is not available.

## Changes in this pull request

Classification store values are persisted as `longtext`, so checkbox values arrive at the index pipeline as strings (`'0'`/`'1'`) instead of booleans. `Checkbox`/`BooleanSelect` use `SimpleNormalizerTrait` (a passthrough), so the adapter's default normalization returned the raw string and the index update failed against the `boolean` mapping.

- **Commit 1 (from #434, @Jonathon-Meney-Torq):** adds `normalize()` to `BooleanAdapter`, casting non-null values to `bool`.
- **Commit 2 (review follow-up from #434):** the adapter is also registered for `booleanSelect`, which is tri-state (`1` = yes, `-1` = no, `null`/`0` = empty) — a plain bool cast would turn "no" (`-1`) into `true`. For `BooleanSelect` field definitions the value is now mapped via the field definition's own `getDataFromResource()`, as agreed in the #434 review thread. Includes unit tests for both the checkbox cast and the tri-state mapping.

## Additional info

- Original report and analysis: #434
- Also requested by @MarcoLeko (same issue, asked for a takeover in #434)
