### PR TITLE
fix: Remove empty mapping array fields to prevent AWS OpenSearch rejection and infinite recursion

### DIFF
--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -254,9 +254,14 @@ final class DefaultSearchService implements SearchIndexServiceInterface
         foreach ($mapping as $key => $value) {
             if (is_array($value)) {
                 if (empty($value)) {
-                    $mapping[$key] = new \stdClass();
+                    unset($mapping[$key]);
                 } else {
-                    $mapping[$key] = $this->castEmptyArraysToObject($value);
+                    $result = $this->castEmptyArraysToObject($value);
+                    if (empty($result)) {
+                        unset($mapping[$key]);
+                    } else {
+                        $mapping[$key] = $result;
+                    }
                 }
             }
         }

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -30,6 +30,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigS
 use Pimcore\Bundle\GenericDataIndexBundle\Traits\LoggerAwareTrait;
 use Pimcore\SearchClient\SearchClientInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 
 /**
  * @internal
@@ -50,6 +51,9 @@ final class DefaultSearchService implements SearchIndexServiceInterface
         private readonly int $reindexMaxPolls,
         private readonly int $reindexPollIntervalSeconds,
     ) {
+        if (!isset($this->logger)) {
+            $this->logger = new NullLogger();
+        }
     }
 
     public function refreshIndex(string $indexName): array

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -231,7 +231,7 @@ final class DefaultSearchService implements SearchIndexServiceInterface
             }
 
             if ($mappings) {
-                $normalized = $this->castEmptyArraysToObject($mappings);
+                $normalized = $this->stripEmptyArraysFromMapping($mappings);
                 if (!empty($normalized)) {
                     $body['mappings']['properties'] = $normalized;
                 }
@@ -252,14 +252,14 @@ final class DefaultSearchService implements SearchIndexServiceInterface
         return $this;
     }
 
-    private function castEmptyArraysToObject(array $mapping): array
+    private function stripEmptyArraysFromMapping(array $mapping): array
     {
         foreach ($mapping as $key => $value) {
             if (is_array($value)) {
                 if (empty($value)) {
                     unset($mapping[$key]);
                 } else {
-                    $result = $this->castEmptyArraysToObject($value);
+                    $result = $this->stripEmptyArraysFromMapping($value);
                     if (empty($result)) {
                         unset($mapping[$key]);
                     } else {
@@ -316,7 +316,7 @@ final class DefaultSearchService implements SearchIndexServiceInterface
     public function putMapping(array $params): array
     {
         if (isset($params['body']['properties'])) {
-            $normalized = $this->castEmptyArraysToObject($params['body']['properties']);
+            $normalized = $this->stripEmptyArraysFromMapping($params['body']['properties']);
             if (!empty($normalized)) {
                 $params['body']['properties'] = $normalized;
             } else {

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -231,7 +231,7 @@ final class DefaultSearchService implements SearchIndexServiceInterface
             }
 
             if ($mappings) {
-                $body['mappings']['properties'] = $mappings;
+                $body['mappings']['properties'] = $this->castEmptyArraysToObject($mappings);
             }
 
             $response = $this->client->createIndex(
@@ -247,6 +247,17 @@ final class DefaultSearchService implements SearchIndexServiceInterface
         }
 
         return $this;
+    }
+
+    private function castEmptyArraysToObject(array $mapping): array
+    {
+        array_walk_recursive($mapping, static function (mixed &$value): void {
+            if (is_array($value) && empty($value)) {
+                $value = new \stdClass();
+            }
+        });
+
+        return $mapping;
     }
 
     public function addAlias(string $aliasName, string $indexName): array

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -231,7 +231,10 @@ final class DefaultSearchService implements SearchIndexServiceInterface
             }
 
             if ($mappings) {
-                $body['mappings']['properties'] = $this->castEmptyArraysToObject($mappings);
+                $normalized = $this->castEmptyArraysToObject($mappings);
+                if (!empty($normalized)) {
+                    $body['mappings']['properties'] = $normalized;
+                }
             }
 
             $response = $this->client->createIndex(
@@ -312,6 +315,15 @@ final class DefaultSearchService implements SearchIndexServiceInterface
 
     public function putMapping(array $params): array
     {
+        if (isset($params['body']['properties'])) {
+            $normalized = $this->castEmptyArraysToObject($params['body']['properties']);
+            if (!empty($normalized)) {
+                $params['body']['properties'] = $normalized;
+            } else {
+                unset($params['body']['properties']);
+            }
+        }
+
         return $this->client->putIndexMapping($params);
     }
 

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -251,11 +251,15 @@ final class DefaultSearchService implements SearchIndexServiceInterface
 
     private function castEmptyArraysToObject(array $mapping): array
     {
-        array_walk_recursive($mapping, static function (mixed &$value): void {
-            if (is_array($value) && empty($value)) {
-                $value = new \stdClass();
+        foreach ($mapping as $key => $value) {
+            if (is_array($value)) {
+                if (empty($value)) {
+                    $mapping[$key] = new \stdClass();
+                } else {
+                    $mapping[$key] = $this->castEmptyArraysToObject($value);
+                }
             }
-        });
+        }
 
         return $mapping;
     }

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -98,6 +98,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
     }
 
     /**
+     * @throws Exception
      * @throws ReindexFailedException
      */
     public function reindexMapping(

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -114,7 +114,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
                 );
             } catch (Exception $e) {
                 try {
-                    $this->updateMapping($context, true, $mappingProperties);
+                    $this->updateMapping($context, true, $mappingProperties, $depth);
                 } catch (Exception $fallbackException) {
                     // Both the reindex and the fallback recreation failed: rethrow so the
                     // failure reaches the caller instead of the mapping checksum being

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -39,16 +39,15 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
     ) {
     }
 
+    /**
+     * @throws ReindexFailedException
+     */
     public function updateMapping(
         mixed $context = null,
         bool $forceCreateIndex = false,
         ?array $mappingProperties = null
     ): void {
-        try {
-            $this->doUpdateMappingFull($context, $forceCreateIndex, $mappingProperties, 0);
-        } catch (ReindexFailedException $reindexException) {
-            $this->logger->error((string) $reindexException);
-        }
+        $this->doUpdateMappingFull($context, $forceCreateIndex, $mappingProperties, 0);
     }
 
     /**
@@ -93,8 +92,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
             $this->doUpdateMapping($context);
         } catch (Exception $e) {
             $this->logger->info($e);
-            //try recreating index — ReindexFailedException propagates to the caller (doReindexMapping
-            //or, for the public entry-point, is caught in updateMapping()).
+            //try recreating index — ReindexFailedException propagates to the caller.
             $this->doReindexMapping($context, $mappingProperties, $reindexDepth + 1, $e);
         }
     }

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -43,7 +43,11 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
         bool $forceCreateIndex = false,
         ?array $mappingProperties = null
     ): void {
-        $this->doUpdateMappingFull($context, $forceCreateIndex, $mappingProperties, 0);
+        try {
+            $this->doUpdateMappingFull($context, $forceCreateIndex, $mappingProperties, 0);
+        } catch (ReindexFailedException $reindexException) {
+            $this->logger->error((string) $reindexException);
+        }
     }
 
     /**
@@ -88,12 +92,9 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
             $this->doUpdateMapping($context);
         } catch (Exception $e) {
             $this->logger->info($e);
-            //try recreating index
-            try {
-                $this->doReindexMapping($context, $mappingProperties, $reindexDepth + 1, $e);
-            } catch (ReindexFailedException $reindexException) {
-                $this->logger->error((string) $reindexException);
-            }
+            //try recreating index — ReindexFailedException propagates to the caller (doReindexMapping
+            //or, for the public entry-point, is caught in updateMapping()).
+            $this->doReindexMapping($context, $mappingProperties, $reindexDepth + 1, $e);
         }
     }
 

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -27,6 +27,10 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
 {
     use LoggerAwareTrait;
 
+    private int $reindexAttempts = 0;
+
+    private const MAX_REINDEX_ATTEMPTS = 3;
+
     public function __construct(
         protected readonly SearchIndexServiceInterface $searchIndexService,
         protected readonly SearchIndexConfigServiceInterface $searchIndexConfigService,
@@ -83,6 +87,14 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
         ?ClassDefinition $context = null,
         ?array $mappingProperties = null
     ): void {
+        if ($this->reindexAttempts >= self::MAX_REINDEX_ATTEMPTS) {
+            $this->logger->error('Max reindex attempts reached, aborting to prevent infinite recursion.');
+            $this->reindexAttempts = 0;
+
+            return;
+        }
+        $this->reindexAttempts++;
+
         $alias = $this->getAliasIndexName($context);
         $mappingProperties = $mappingProperties ?: $this->extractMappingProperties($context);
 
@@ -115,6 +127,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
             }
         }
 
+        $this->reindexAttempts = 0;
         $this->createGlobalIndexAliases($context);
     }
 
@@ -155,6 +168,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
      */
     private function doUpdateMapping(mixed $context): void
     {
+        $mappingProperties = $this->castEmptyArraysToObject($this->extractMappingProperties($context));
         $response = $this->searchIndexService->putMapping(
             [
                 'index' => $this->getCurrentFullIndexName($context),
@@ -162,11 +176,22 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
                     '_source' => [
                         'enabled' => true,
                     ],
-                    'properties' => $this->extractMappingProperties($context),
+                    'properties' => $mappingProperties,
                 ],
             ]
         );
         $this->logger->debug(json_encode($response, JSON_THROW_ON_ERROR));
+    }
+
+    private function castEmptyArraysToObject(array $mapping): array
+    {
+        array_walk_recursive($mapping, static function (mixed &$value): void {
+            if (is_array($value) && empty($value)) {
+                $value = new \stdClass();
+            }
+        });
+
+        return $mapping;
     }
 
     protected function createIndex(mixed $context, string $aliasName): void

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -77,7 +77,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
             $this->logger->info($e);
             //try recreating index
             try {
-                $this->reindexMapping($context, $mappingProperties, $reindexDepth + 1);
+                $this->doReindexMapping($context, $mappingProperties, $reindexDepth + 1, $e);
             } catch (ReindexFailedException $reindexException) {
                 $this->logger->error($reindexException->getMessage());
             }
@@ -85,16 +85,31 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
     }
 
     /**
-     * @throws Exception
      * @throws ReindexFailedException
      */
     public function reindexMapping(
         ?ClassDefinition $context = null,
-        ?array $mappingProperties = null,
-        int $depth = 0
+        ?array $mappingProperties = null
+    ): void {
+        $this->doReindexMapping($context, $mappingProperties, 0);
+    }
+
+    /**
+     * @throws Exception
+     * @throws ReindexFailedException
+     */
+    private function doReindexMapping(
+        ?ClassDefinition $context,
+        ?array $mappingProperties,
+        int $depth,
+        ?\Throwable $cause = null
     ): void {
         if ($depth >= self::MAX_REINDEX_ATTEMPTS) {
-            throw new ReindexFailedException('Max reindex attempts reached, aborting to prevent infinite recursion.');
+            throw new ReindexFailedException(
+                'Max reindex attempts reached, aborting to prevent infinite recursion.',
+                0,
+                $cause
+            );
         }
 
         $alias = $this->getAliasIndexName($context);

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -188,9 +188,14 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
         foreach ($mapping as $key => $value) {
             if (is_array($value)) {
                 if (empty($value)) {
-                    $mapping[$key] = new \stdClass();
+                    unset($mapping[$key]);
                 } else {
-                    $mapping[$key] = $this->castEmptyArraysToObject($value);
+                    $result = $this->castEmptyArraysToObject($value);
+                    if (empty($result)) {
+                        unset($mapping[$key]);
+                    } else {
+                        $mapping[$key] = $result;
+                    }
                 }
             }
         }

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -41,8 +41,21 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
     public function updateMapping(
         mixed $context = null,
         bool $forceCreateIndex = false,
-        ?array $mappingProperties = null,
-        int $reindexDepth = 0
+        ?array $mappingProperties = null
+    ): void {
+        $this->doUpdateMappingFull($context, $forceCreateIndex, $mappingProperties, 0);
+    }
+
+    /**
+     * Depth-aware implementation of updateMapping(); called internally so that
+     * doReindexMapping() can forward the current recursion depth without exposing
+     * the counter through the public interface.
+     */
+    private function doUpdateMappingFull(
+        mixed $context,
+        bool $forceCreateIndex,
+        ?array $mappingProperties,
+        int $reindexDepth
     ): void {
         $aliasName = $this->getAliasIndexName($context);
 
@@ -116,8 +129,9 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
         $mappingProperties = $mappingProperties ?: $this->extractMappingProperties($context);
 
         if (!$this->searchIndexService->existsAlias($alias)) {
-            $this->updateMapping(
+            $this->doUpdateMappingFull(
                 context: $context,
+                forceCreateIndex: false,
                 mappingProperties: $mappingProperties,
                 reindexDepth: $depth
             );
@@ -129,7 +143,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
                 );
             } catch (Exception $e) {
                 try {
-                    $this->updateMapping($context, true, $mappingProperties, $depth);
+                    $this->doUpdateMappingFull($context, true, $mappingProperties, $depth);
                 } catch (Exception $fallbackException) {
                     // Both the reindex and the fallback recreation failed: rethrow so the
                     // failure reaches the caller instead of the mapping checksum being

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService
 
 use Exception;
 use JsonException;
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\DefaultSearch\ReindexFailedException;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DefaultSearchService;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
@@ -26,8 +27,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 abstract class AbstractIndexHandler implements IndexHandlerInterface
 {
     use LoggerAwareTrait;
-
-    private int $reindexAttempts = 0;
 
     private const MAX_REINDEX_ATTEMPTS = 3;
 
@@ -76,24 +75,26 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
         } catch (Exception $e) {
             $this->logger->info($e);
             //try recreating index
-            $this->reindexMapping($context, $mappingProperties);
+            try {
+                $this->reindexMapping($context, $mappingProperties);
+            } catch (ReindexFailedException $reindexException) {
+                $this->logger->error($reindexException->getMessage());
+            }
         }
     }
 
     /**
      * @throws Exception
+     * @throws ReindexFailedException
      */
     public function reindexMapping(
         ?ClassDefinition $context = null,
-        ?array $mappingProperties = null
+        ?array $mappingProperties = null,
+        int $depth = 0
     ): void {
-        if ($this->reindexAttempts >= self::MAX_REINDEX_ATTEMPTS) {
-            $this->logger->error('Max reindex attempts reached, aborting to prevent infinite recursion.');
-            $this->reindexAttempts = 0;
-
-            return;
+        if ($depth >= self::MAX_REINDEX_ATTEMPTS) {
+            throw new ReindexFailedException('Max reindex attempts reached, aborting to prevent infinite recursion.');
         }
-        $this->reindexAttempts++;
 
         $alias = $this->getAliasIndexName($context);
         $mappingProperties = $mappingProperties ?: $this->extractMappingProperties($context);
@@ -127,7 +128,6 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
             }
         }
 
-        $this->reindexAttempts = 0;
         $this->createGlobalIndexAliases($context);
     }
 
@@ -168,39 +168,20 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
      */
     private function doUpdateMapping(mixed $context): void
     {
-        $mappingProperties = $this->castEmptyArraysToObject($this->extractMappingProperties($context));
+        $mappingProperties = $this->extractMappingProperties($context);
+        $body = [
+            '_source' => ['enabled' => true],
+        ];
+        if (!empty($mappingProperties)) {
+            $body['properties'] = $mappingProperties;
+        }
         $response = $this->searchIndexService->putMapping(
             [
                 'index' => $this->getCurrentFullIndexName($context),
-                'body' => [
-                    '_source' => [
-                        'enabled' => true,
-                    ],
-                    'properties' => $mappingProperties,
-                ],
+                'body' => $body,
             ]
         );
         $this->logger->debug(json_encode($response, JSON_THROW_ON_ERROR));
-    }
-
-    private function castEmptyArraysToObject(array $mapping): array
-    {
-        foreach ($mapping as $key => $value) {
-            if (is_array($value)) {
-                if (empty($value)) {
-                    unset($mapping[$key]);
-                } else {
-                    $result = $this->castEmptyArraysToObject($value);
-                    if (empty($result)) {
-                        unset($mapping[$key]);
-                    } else {
-                        $mapping[$key] = $result;
-                    }
-                }
-            }
-        }
-
-        return $mapping;
     }
 
     protected function createIndex(mixed $context, string $aliasName): void

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -92,7 +92,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
             try {
                 $this->doReindexMapping($context, $mappingProperties, $reindexDepth + 1, $e);
             } catch (ReindexFailedException $reindexException) {
-                $this->logger->error($reindexException->getMessage());
+                $this->logger->error((string) $reindexException);
             }
         }
     }

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -185,11 +185,15 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
 
     private function castEmptyArraysToObject(array $mapping): array
     {
-        array_walk_recursive($mapping, static function (mixed &$value): void {
-            if (is_array($value) && empty($value)) {
-                $value = new \stdClass();
+        foreach ($mapping as $key => $value) {
+            if (is_array($value)) {
+                if (empty($value)) {
+                    $mapping[$key] = new \stdClass();
+                } else {
+                    $mapping[$key] = $this->castEmptyArraysToObject($value);
+                }
             }
-        });
+        }
 
         return $mapping;
     }

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -41,7 +41,8 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
     public function updateMapping(
         mixed $context = null,
         bool $forceCreateIndex = false,
-        ?array $mappingProperties = null
+        ?array $mappingProperties = null,
+        int $reindexDepth = 0
     ): void {
         $aliasName = $this->getAliasIndexName($context);
 
@@ -76,7 +77,7 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
             $this->logger->info($e);
             //try recreating index
             try {
-                $this->reindexMapping($context, $mappingProperties);
+                $this->reindexMapping($context, $mappingProperties, $reindexDepth + 1);
             } catch (ReindexFailedException $reindexException) {
                 $this->logger->error($reindexException->getMessage());
             }
@@ -102,7 +103,8 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
         if (!$this->searchIndexService->existsAlias($alias)) {
             $this->updateMapping(
                 context: $context,
-                mappingProperties: $mappingProperties
+                mappingProperties: $mappingProperties,
+                reindexDepth: $depth
             );
         } else {
             try {

--- a/src/Service/SearchIndex/IndexService/IndexHandler/IndexHandlerInterface.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/IndexHandlerInterface.php
@@ -32,6 +32,7 @@ interface IndexHandlerInterface
     ): void;
 
     /**
+     * @throws Exception
      * @throws ReindexFailedException
      */
     public function reindexMapping(

--- a/src/Service/SearchIndex/IndexService/IndexHandler/IndexHandlerInterface.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/IndexHandlerInterface.php
@@ -37,8 +37,7 @@ interface IndexHandlerInterface
      */
     public function reindexMapping(
         ?ClassDefinition $context = null,
-        ?array $mappingProperties = null,
-        int $depth = 0
+        ?array $mappingProperties = null
     ): void;
 
     public function deleteIndex(mixed $context): void;

--- a/src/Service/SearchIndex/IndexService/IndexHandler/IndexHandlerInterface.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/IndexHandlerInterface.php
@@ -28,8 +28,7 @@ interface IndexHandlerInterface
     public function updateMapping(
         mixed $context = null,
         bool $forceCreateIndex = false,
-        ?array $mappingProperties = null,
-        int $reindexDepth = 0
+        ?array $mappingProperties = null
     ): void;
 
     /**

--- a/src/Service/SearchIndex/IndexService/IndexHandler/IndexHandlerInterface.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/IndexHandlerInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler;
 
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\DefaultSearch\ReindexFailedException;
 use Pimcore\Model\DataObject\ClassDefinition;
 
 /**
@@ -30,9 +31,13 @@ interface IndexHandlerInterface
         ?array $mappingProperties = null
     ): void;
 
+    /**
+     * @throws ReindexFailedException
+     */
     public function reindexMapping(
         ?ClassDefinition $context = null,
-        ?array $mappingProperties = null
+        ?array $mappingProperties = null,
+        int $depth = 0
     ): void;
 
     public function deleteIndex(mixed $context): void;

--- a/src/Service/SearchIndex/IndexService/IndexHandler/IndexHandlerInterface.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/IndexHandlerInterface.php
@@ -28,7 +28,8 @@ interface IndexHandlerInterface
     public function updateMapping(
         mixed $context = null,
         bool $forceCreateIndex = false,
-        ?array $mappingProperties = null
+        ?array $mappingProperties = null,
+        int $reindexDepth = 0
     ): void;
 
     /**

--- a/src/Traits/LoggerAwareTrait.php
+++ b/src/Traits/LoggerAwareTrait.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 trait LoggerAwareTrait
 {
-    protected LoggerInterface|null $logger;
+    protected LoggerInterface $logger;
 
     #[Required]
     public function setLogger(LoggerInterface $pimcoreLogger): void

--- a/src/Traits/LoggerAwareTrait.php
+++ b/src/Traits/LoggerAwareTrait.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 trait LoggerAwareTrait
 {
-    protected LoggerInterface $logger;
+    protected LoggerInterface|null $logger;
 
     #[Required]
     public function setLogger(LoggerInterface $pimcoreLogger): void

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceTest.php
@@ -177,6 +177,87 @@ final class DefaultSearchServiceTest extends Unit
         );
     }
 
+    /**
+     * When putMapping() receives a properties array whose fields are all empty arrays,
+     * normalization removes them and the "properties" key must be absent from the forwarded call.
+     */
+    public function testPutMappingRemovesEmptyArrayFieldsFromProperties(): void
+    {
+        $capturedParams = null;
+
+        $service = $this->createService(
+            client: $this->makeEmpty(SearchClientInterface::class, [
+                'putIndexMapping' => Expected::once(function (array $params) use (&$capturedParams): array {
+                    $capturedParams = $params;
+
+                    return [];
+                }),
+            ])
+        );
+
+        $service->putMapping([
+            'index' => 'test_index',
+            'body' => [
+                '_source' => ['enabled' => true],
+                'properties' => ['empty_field' => []],
+            ],
+        ]);
+
+        $this->assertNotNull($capturedParams, 'putIndexMapping must have been called on the client');
+        $this->assertArrayNotHasKey(
+            'properties',
+            $capturedParams['body'],
+            'When all properties fields are empty, the "properties" key must be omitted from the body'
+        );
+    }
+
+    /**
+     * When putMapping() receives a properties array with both valid and empty-array fields,
+     * normalization removes only the empty ones while preserving the valid mapping fields.
+     */
+    public function testPutMappingPreservesValidFieldsWhileRemovingEmptyOnes(): void
+    {
+        $capturedParams = null;
+
+        $service = $this->createService(
+            client: $this->makeEmpty(SearchClientInterface::class, [
+                'putIndexMapping' => Expected::once(function (array $params) use (&$capturedParams): array {
+                    $capturedParams = $params;
+
+                    return [];
+                }),
+            ])
+        );
+
+        $service->putMapping([
+            'index' => 'test_index',
+            'body' => [
+                '_source' => ['enabled' => true],
+                'properties' => [
+                    'valid_field' => ['type' => 'keyword'],
+                    'empty_field' => [],
+                ],
+            ],
+        ]);
+
+        $this->assertNotNull($capturedParams, 'putIndexMapping must have been called on the client');
+        $this->assertArrayHasKey(
+            'properties',
+            $capturedParams['body'],
+            'The "properties" key must still be present when at least one field has a valid mapping'
+        );
+        $this->assertArrayHasKey(
+            'valid_field',
+            $capturedParams['body']['properties'],
+            'Valid mapping fields must be preserved after normalization'
+        );
+        $this->assertArrayNotHasKey(
+            'empty_field',
+            $capturedParams['body']['properties'],
+            'Empty-array mapping fields must be removed by normalization'
+        );
+    }
+
     private function createService(
         ?SearchIndexConfigServiceInterface $configService = null,
         ?SearchExecutionServiceInterface $searchExecutionService = null,

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceTest.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Searc
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Pimcore\SearchClient\SearchClientInterface;
+use stdClass;
 
 /**
  * @internal
@@ -102,6 +103,72 @@ final class DefaultSearchServiceTest extends Unit
         ]);
 
         $this->assertSame(10, $service->getCount($search, 'test_index'));
+    }
+
+    /**
+     * When createIndex() receives a mappings array with empty-array values,
+     * those must be sent as "{}" (stdClass) rather than "[]" to OpenSearch.
+     */
+    public function testCreateIndexCastsTopLevelEmptyMappingArrayToStdClass(): void
+    {
+        $capturedBody = null;
+
+        $service = $this->createService(
+            client: $this->makeEmpty(SearchClientInterface::class, [
+                'existsIndex' => false,
+                'createIndex' => Expected::once(function (array $params) use (&$capturedBody): array {
+                    $capturedBody = $params['body'];
+
+                    return [];
+                }),
+            ])
+        );
+
+        $service->createIndex('test_index', ['my_field' => []]);
+
+        $this->assertNotNull($capturedBody, 'createIndex must have been called on the client');
+        $this->assertInstanceOf(
+            stdClass::class,
+            $capturedBody['mappings']['properties']['my_field'],
+            'An empty array in the mappings passed to createIndex must be cast to stdClass'
+        );
+    }
+
+    /**
+     * Nested empty arrays inside mappings passed to createIndex() must also be
+     * cast to stdClass so that OpenSearch receives "{}" rather than "[]".
+     */
+    public function testCreateIndexCastsNestedEmptyMappingArraysToStdClass(): void
+    {
+        $capturedBody = null;
+
+        $service = $this->createService(
+            client: $this->makeEmpty(SearchClientInterface::class, [
+                'existsIndex' => false,
+                'createIndex' => Expected::once(function (array $params) use (&$capturedBody): array {
+                    $capturedBody = $params['body'];
+
+                    return [];
+                }),
+            ])
+        );
+
+        $service->createIndex('test_index', [
+            'parent_field' => [
+                'type' => 'object',
+                'properties' => [
+                    'child_field' => [],
+                ],
+            ],
+        ]);
+
+        $this->assertNotNull($capturedBody, 'createIndex must have been called on the client');
+        $childField = $capturedBody['mappings']['properties']['parent_field']['properties']['child_field'];
+        $this->assertInstanceOf(
+            stdClass::class,
+            $childField,
+            'Nested empty array values in mappings passed to createIndex must be cast to stdClass'
+        );
     }
 
     private function createService(

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceTest.php
@@ -21,7 +21,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Searc
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexAliasServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Pimcore\SearchClient\SearchClientInterface;
-use stdClass;
 
 /**
  * @internal
@@ -107,9 +106,9 @@ final class DefaultSearchServiceTest extends Unit
 
     /**
      * When createIndex() receives a mappings array with empty-array values,
-     * those must be sent as "{}" (stdClass) rather than "[]" to OpenSearch.
+     * those fields must be removed entirely rather than sent as "[]" to OpenSearch.
      */
-    public function testCreateIndexCastsTopLevelEmptyMappingArrayToStdClass(): void
+    public function testCreateIndexRemovesTopLevelEmptyMappingArrayFields(): void
     {
         $capturedBody = null;
 
@@ -127,18 +126,18 @@ final class DefaultSearchServiceTest extends Unit
         $service->createIndex('test_index', ['my_field' => []]);
 
         $this->assertNotNull($capturedBody, 'createIndex must have been called on the client');
-        $this->assertInstanceOf(
-            stdClass::class,
-            $capturedBody['mappings']['properties']['my_field'],
-            'An empty array in the mappings passed to createIndex must be cast to stdClass'
+        $this->assertArrayNotHasKey(
+            'my_field',
+            $capturedBody['mappings']['properties'],
+            'An empty array field in the mappings passed to createIndex must be removed'
         );
     }
 
     /**
      * Nested empty arrays inside mappings passed to createIndex() must also be
-     * cast to stdClass so that OpenSearch receives "{}" rather than "[]".
+     * removed entirely rather than sent as "[]" to OpenSearch.
      */
-    public function testCreateIndexCastsNestedEmptyMappingArraysToStdClass(): void
+    public function testCreateIndexRemovesNestedEmptyMappingArrayFields(): void
     {
         $capturedBody = null;
 
@@ -163,11 +162,10 @@ final class DefaultSearchServiceTest extends Unit
         ]);
 
         $this->assertNotNull($capturedBody, 'createIndex must have been called on the client');
-        $childField = $capturedBody['mappings']['properties']['parent_field']['properties']['child_field'];
-        $this->assertInstanceOf(
-            stdClass::class,
-            $childField,
-            'Nested empty array values in mappings passed to createIndex must be cast to stdClass'
+        $this->assertArrayNotHasKey(
+            'child_field',
+            $capturedBody['mappings']['properties']['parent_field']['properties'],
+            'Nested empty array fields in mappings passed to createIndex must be removed'
         );
     }
 

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceTest.php
@@ -105,8 +105,10 @@ final class DefaultSearchServiceTest extends Unit
     }
 
     /**
-     * When createIndex() receives a mappings array with empty-array values,
-     * those fields must be removed entirely rather than sent as "[]" to OpenSearch.
+     * When createIndex() receives a mappings array whose only field has an empty-array value,
+     * normalization removes all fields, leaving an empty properties array. The entire
+     * "mappings" key must then be omitted from the body so OpenSearch never receives
+     * "mappings":{"properties":{}} or "mappings":{"properties":[]}.
      */
     public function testCreateIndexRemovesTopLevelEmptyMappingArrayFields(): void
     {
@@ -127,15 +129,16 @@ final class DefaultSearchServiceTest extends Unit
 
         $this->assertNotNull($capturedBody, 'createIndex must have been called on the client');
         $this->assertArrayNotHasKey(
-            'my_field',
-            $capturedBody['mappings']['properties'],
-            'An empty array field in the mappings passed to createIndex must be removed'
+            'mappings',
+            $capturedBody,
+            'When all mapping fields are empty, the "mappings" key must be omitted from the body entirely'
         );
     }
 
     /**
-     * Nested empty arrays inside mappings passed to createIndex() must also be
-     * removed entirely rather than sent as "[]" to OpenSearch.
+     * When a nested field's only child has an empty-array value, the child is removed
+     * and its parent's "properties" sub-key becomes empty and is also removed.
+     * The parent itself must survive if it still has other non-array keys (e.g. "type").
      */
     public function testCreateIndexRemovesNestedEmptyMappingArrayFields(): void
     {
@@ -162,10 +165,15 @@ final class DefaultSearchServiceTest extends Unit
         ]);
 
         $this->assertNotNull($capturedBody, 'createIndex must have been called on the client');
+        $this->assertArrayHasKey(
+            'parent_field',
+            $capturedBody['mappings']['properties'],
+            'parent_field must still exist because it has a non-array "type" key'
+        );
         $this->assertArrayNotHasKey(
-            'child_field',
-            $capturedBody['mappings']['properties']['parent_field']['properties'],
-            'Nested empty array fields in mappings passed to createIndex must be removed'
+            'properties',
+            $capturedBody['mappings']['properties']['parent_field'],
+            'The "properties" sub-key of parent_field must be removed when all its children are empty'
         );
     }
 

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -73,6 +73,47 @@ final class AbstractIndexHandlerTest extends Unit
     }
 
     /**
+     * When updateMapping() exhausts all retry attempts (MAX_REINDEX_ATTEMPTS), the resulting
+     * ReindexFailedException must propagate to the caller instead of being swallowed.
+     * Otherwise IndexUpdateService::updateClassDefinition() stores the mapping checksum as if
+     * the update succeeded, leaving the index silently out of sync and never retried.
+     *
+     * @see https://github.com/pimcore/generic-data-index-bundle/issues/471
+     */
+    public function testUpdateMappingPropagatesReindexFailedException(): void
+    {
+        $fluent = $this->makeEmpty(SearchIndexServiceInterface::class, ['addAlias' => []]);
+
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => true,
+            'getCurrentIndexVersion' => '',
+            'putMapping' => static function (): array {
+                throw new Exception('putMapping failed');
+            },
+            'reindex' => ReindexResult::MAPPING_INCOMPATIBLE,
+            'createIndex' => static function () use ($fluent): SearchIndexServiceInterface { return $fluent; },
+            'deleteIndex' => null,
+            'existsIndex' => false,
+        ]);
+
+        $handler = $this->createHandlerWithService($searchIndexService);
+        $handler->setLogger(new NullLogger());
+
+        $thrown = null;
+        try {
+            $handler->updateMapping();
+        } catch (ReindexFailedException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(
+            ReindexFailedException::class,
+            $thrown,
+            'updateMapping() must propagate ReindexFailedException so the mapping checksum is never stored on failure'
+        );
+    }
+
+    /**
      * When the in-place reindex fails (e.g. a 5xx from OpenSearch) and the fallback
      * index recreation fails too, the failure must propagate to the caller. Otherwise
      * the mapping checksum gets stored as if the reindex succeeded and the class is

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -242,6 +242,62 @@ final class AbstractIndexHandlerTest extends Unit
     }
 
     /**
+     * When the alias exists, reindex() fails, and the fallback updateMapping() also fails
+     * on putMapping(), the depth counter must still be forwarded so the recursive calls
+     * remain bounded. Without the fix, every fallback resets depth to 0, enabling infinite
+     * recursion. With the fix, putMapping is called at most MAX_REINDEX_ATTEMPTS times.
+     */
+    public function testReindexMappingBoundsAttemptsWhenAliasExistsAndBothOperationsFail(): void
+    {
+        $attempts = 0;
+        $fluent = $this->makeEmpty(SearchIndexServiceInterface::class, ['addAlias' => []]);
+
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => true,
+            'existsIndex' => false,
+            'deleteIndex' => null,
+            'getCurrentIndexVersion' => '',
+            'reindex' => static function (): void {
+                throw new Exception('reindex failed (504 Gateway Time-out)');
+            },
+            'createIndex' => static function () use ($fluent): SearchIndexServiceInterface { return $fluent; },
+            'putMapping' => static function () use (&$attempts): array {
+                ++$attempts;
+                throw new Exception('putMapping failed after forced recreation');
+            },
+        ]);
+
+        $handler = $this->createHandlerWithService($searchIndexService);
+        $handler->setLogger(new NullLogger());
+
+        // The first call comes from the alias-present branch: reindex() fails, fallback
+        // updateMapping(forceCreate=true) is called, putMapping() inside it fails, which
+        // triggers reindexMapping(depth+1). Without depth forwarding this loops forever.
+        // With the fix the recursion is capped at MAX_REINDEX_ATTEMPTS and an exception
+        // propagates out of reindexMapping().
+        $thrown = null;
+        try {
+            $handler->reindexMapping();
+        } catch (Exception $e) {
+            $thrown = $e;
+        }
+
+        $this->assertGreaterThan(
+            0,
+            $attempts,
+            'putMapping must have been called at least once through the alias-present fallback path'
+        );
+        $this->assertLessThanOrEqual(
+            3,
+            $attempts,
+            'The number of putMapping attempts must be bounded to MAX_REINDEX_ATTEMPTS to prevent stack overflow'
+        );
+        // After the depth guard fires the ReindexFailedException propagates out from the
+        // alias-missing updateMapping path; the alias-present catch re-throws it.
+        $this->assertNotNull($thrown, 'An exception must propagate when all attempts are exhausted');
+    }
+
+    /**
      * When extractMappingProperties() returns an empty array, doUpdateMapping() must
      * omit the "properties" key from the putMapping body entirely so that
      * OpenSearch/Elasticsearch never receives "properties":[].

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -298,6 +298,10 @@ final class AbstractIndexHandlerTest extends Unit
      * When the depth guard fires, the ReindexFailedException must carry the exception
      * that last triggered the retry as its previous exception, so callers and loggers
      * can see the root cause rather than only a generic limit message.
+     *
+     * The production logger call uses `(string) $reindexException`, which casts the full
+     * exception chain to a string, so both the wrapper message and the $previous cause
+     * message appear in the logged output. This test verifies both are present.
      */
     public function testReindexMappingPreservesCauseInReindexFailedException(): void
     {
@@ -318,19 +322,27 @@ final class AbstractIndexHandlerTest extends Unit
         $handler->setLogger($logger);
 
         // reindexMapping() returns without throwing (ReindexFailedException is caught and
-        // logged by updateMapping()); but the logged error message must contain the cause.
+        // logged by updateMapping() as the full exception string including its $previous chain).
         $handler->reindexMapping();
 
         $errorLogs = array_filter($logger->records, static fn (array $r): bool => $r['level'] === 'error');
         $this->assertNotEmpty($errorLogs, 'A ReindexFailedException must have been caught and logged');
 
-        // The logged message is the ReindexFailedException message itself; its $previous
-        // (the cause) must be mentioned so operators can identify the root failure.
         $loggedMessage = implode(' | ', array_column($errorLogs, 'message'));
+
+        // The wrapper message must be present.
         $this->assertStringContainsString(
             'Max reindex attempts reached',
             $loggedMessage,
-            'The ReindexFailedException message must appear in the error log'
+            'The ReindexFailedException wrapper message must appear in the error log'
+        );
+
+        // The $previous cause message must also be present — removing the chained $cause
+        // from the ReindexFailedException constructor would break this assertion.
+        $this->assertStringContainsString(
+            'AWS rejected empty array in mapping',
+            $loggedMessage,
+            'The root-cause exception message must appear in the error log so operators can identify the failure'
         );
     }
 

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -246,6 +246,11 @@ final class AbstractIndexHandlerTest extends Unit
      * on putMapping(), the depth counter must still be forwarded so the recursive calls
      * remain bounded. Without the fix, every fallback resets depth to 0, enabling infinite
      * recursion. With the fix, putMapping is called at most MAX_REINDEX_ATTEMPTS times.
+     *
+     * Note: updateMapping() deliberately catches ReindexFailedException internally (to keep
+     * the handler non-fatal for callers like deployment commands), so no exception propagates
+     * out of reindexMapping() in this path. The meaningful invariant is that putMapping is
+     * invoked a strictly bounded number of times.
      */
     public function testReindexMappingBoundsAttemptsWhenAliasExistsAndBothOperationsFail(): void
     {
@@ -270,17 +275,12 @@ final class AbstractIndexHandlerTest extends Unit
         $handler = $this->createHandlerWithService($searchIndexService);
         $handler->setLogger(new NullLogger());
 
-        // The first call comes from the alias-present branch: reindex() fails, fallback
-        // updateMapping(forceCreate=true) is called, putMapping() inside it fails, which
-        // triggers reindexMapping(depth+1). Without depth forwarding this loops forever.
-        // With the fix the recursion is capped at MAX_REINDEX_ATTEMPTS and an exception
-        // propagates out of reindexMapping().
-        $thrown = null;
-        try {
-            $handler->reindexMapping();
-        } catch (Exception $e) {
-            $thrown = $e;
-        }
+        // reindex() fails, the fallback updateMapping(forceCreate=true) is called, putMapping()
+        // inside it fails, which triggers reindexMapping(depth+1). Without depth forwarding this
+        // loops forever. With the fix the recursion is capped at MAX_REINDEX_ATTEMPTS.
+        // updateMapping() catches ReindexFailedException internally so reindexMapping() returns
+        // normally to the caller — the important invariant is the bounded attempt count.
+        $handler->reindexMapping();
 
         $this->assertGreaterThan(
             0,
@@ -292,9 +292,6 @@ final class AbstractIndexHandlerTest extends Unit
             $attempts,
             'The number of putMapping attempts must be bounded to MAX_REINDEX_ATTEMPTS to prevent stack overflow'
         );
-        // After the depth guard fires the ReindexFailedException propagates out from the
-        // alias-missing updateMapping path; the alias-present catch re-throws it.
-        $this->assertNotNull($thrown, 'An exception must propagate when all attempts are exhausted');
     }
 
     /**

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -195,13 +195,16 @@ final class AbstractIndexHandlerTest extends Unit
 
     /**
      * When reindexMapping() enters the alias-missing path and the resulting
-     * updateMapping() always fails with an exception from putMapping(), the
+     * doUpdateMapping() always fails with an exception from putMapping(), the
      * recursive re-entry must be bounded: after MAX_REINDEX_ATTEMPTS the method
      * must throw ReindexFailedException instead of overflowing the stack.
      *
      * This test starts from the default arguments (depth = 0) so that the entire
-     * alias-missing → updateMapping → doUpdateMapping → putMapping failure cycle
-     * is exercised, not just the terminal guard.
+     * alias-missing → doUpdateMappingFull → doReindexMapping → putMapping failure
+     * cycle is exercised, not just the terminal guard.
+     *
+     * reindexMapping() is the public entry-point and must propagate ReindexFailedException
+     * so callers do not store a mapping checksum for an update that was never applied.
      */
     public function testReindexMappingThrowsWhenMaxAttemptsReachedFromDefaultArgs(): void
     {
@@ -223,12 +226,18 @@ final class AbstractIndexHandlerTest extends Unit
         $handler = $this->createHandlerWithService($searchIndexService);
         $handler->setLogger(new NullLogger());
 
-        // reindexMapping() must complete without overflowing the stack.
-        // ReindexFailedException is caught and logged inside updateMapping(), so it does
-        // not propagate out to the caller; what matters is that the number of attempts
-        // is strictly bounded to MAX_REINDEX_ATTEMPTS (3).
-        $handler->reindexMapping();
+        $thrown = null;
+        try {
+            $handler->reindexMapping();
+        } catch (ReindexFailedException $e) {
+            $thrown = $e;
+        }
 
+        $this->assertInstanceOf(
+            ReindexFailedException::class,
+            $thrown,
+            'reindexMapping() must throw ReindexFailedException after the bounded number of attempts'
+        );
         $this->assertGreaterThan(
             0,
             $attempts,
@@ -247,10 +256,8 @@ final class AbstractIndexHandlerTest extends Unit
      * remain bounded. Without the fix, every fallback resets depth to 0, enabling infinite
      * recursion. With the fix, putMapping is called at most MAX_REINDEX_ATTEMPTS times.
      *
-     * Note: updateMapping() deliberately catches ReindexFailedException internally (to keep
-     * the handler non-fatal for callers like deployment commands), so no exception propagates
-     * out of reindexMapping() in this path. The meaningful invariant is that putMapping is
-     * invoked a strictly bounded number of times.
+     * reindexMapping() must propagate ReindexFailedException once the depth guard fires,
+     * so callers do not store a mapping checksum for an update that was never applied.
      */
     public function testReindexMappingBoundsAttemptsWhenAliasExistsAndBothOperationsFail(): void
     {
@@ -275,13 +282,18 @@ final class AbstractIndexHandlerTest extends Unit
         $handler = $this->createHandlerWithService($searchIndexService);
         $handler->setLogger(new NullLogger());
 
-        // reindex() fails, the fallback updateMapping(forceCreate=true) is called, putMapping()
-        // inside it fails, which triggers reindexMapping(depth+1). Without depth forwarding this
-        // loops forever. With the fix the recursion is capped at MAX_REINDEX_ATTEMPTS.
-        // updateMapping() catches ReindexFailedException internally so reindexMapping() returns
-        // normally to the caller — the important invariant is the bounded attempt count.
-        $handler->reindexMapping();
+        $thrown = null;
+        try {
+            $handler->reindexMapping();
+        } catch (ReindexFailedException $e) {
+            $thrown = $e;
+        }
 
+        $this->assertInstanceOf(
+            ReindexFailedException::class,
+            $thrown,
+            'reindexMapping() must throw ReindexFailedException once all attempts are exhausted'
+        );
         $this->assertGreaterThan(
             0,
             $attempts,
@@ -296,12 +308,9 @@ final class AbstractIndexHandlerTest extends Unit
 
     /**
      * When the depth guard fires, the ReindexFailedException must carry the exception
-     * that last triggered the retry as its previous exception, so callers and loggers
-     * can see the root cause rather than only a generic limit message.
-     *
-     * The production logger call uses `(string) $reindexException`, which casts the full
-     * exception chain to a string, so both the wrapper message and the $previous cause
-     * message appear in the logged output. This test verifies both are present.
+     * that last triggered the retry as its $previous, so callers can inspect the full
+     * causal chain. This test catches the propagated exception from reindexMapping() and
+     * asserts both the wrapper message and the chained cause are present.
      */
     public function testReindexMappingPreservesCauseInReindexFailedException(): void
     {
@@ -317,32 +326,35 @@ final class AbstractIndexHandlerTest extends Unit
             'putMapping' => static function () use ($cause): array { throw $cause; },
         ]);
 
-        $logger = $this->createCollectingLogger();
         $handler = $this->createHandlerWithService($searchIndexService);
-        $handler->setLogger($logger);
+        $handler->setLogger(new NullLogger());
 
-        // reindexMapping() returns without throwing (ReindexFailedException is caught and
-        // logged by updateMapping() as the full exception string including its $previous chain).
-        $handler->reindexMapping();
+        $thrown = null;
+        try {
+            $handler->reindexMapping();
+        } catch (ReindexFailedException $e) {
+            $thrown = $e;
+        }
 
-        $errorLogs = array_filter($logger->records, static fn (array $r): bool => $r['level'] === 'error');
-        $this->assertNotEmpty($errorLogs, 'A ReindexFailedException must have been caught and logged');
-
-        $loggedMessage = implode(' | ', array_column($errorLogs, 'message'));
-
-        // The wrapper message must be present.
-        $this->assertStringContainsString(
-            'Max reindex attempts reached',
-            $loggedMessage,
-            'The ReindexFailedException wrapper message must appear in the error log'
+        $this->assertInstanceOf(
+            ReindexFailedException::class,
+            $thrown,
+            'reindexMapping() must throw ReindexFailedException after all attempts are exhausted'
         );
 
-        // The $previous cause message must also be present — removing the chained $cause
-        // from the ReindexFailedException constructor would break this assertion.
+        // The wrapper message must be set.
         $this->assertStringContainsString(
-            'AWS rejected empty array in mapping',
-            $loggedMessage,
-            'The root-cause exception message must appear in the error log so operators can identify the failure'
+            'Max reindex attempts reached',
+            $thrown->getMessage(),
+            'The ReindexFailedException wrapper message must be correct'
+        );
+
+        // The $previous cause must be chained — removing the $cause argument from the
+        // ReindexFailedException constructor would break this assertion.
+        $this->assertSame(
+            $cause,
+            $thrown->getPrevious(),
+            'The exception that triggered the final retry must be set as the previous exception'
         );
     }
 

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -194,17 +194,28 @@ final class AbstractIndexHandlerTest extends Unit
     }
 
     /**
-     * When reindexMapping() is called recursively beyond MAX_REINDEX_ATTEMPTS,
-     * it must throw ReindexFailedException to prevent infinite recursion.
+     * When reindexMapping() enters the alias-missing path and the resulting
+     * updateMapping() always fails with an exception from putMapping(), the
+     * recursive re-entry must be bounded: after MAX_REINDEX_ATTEMPTS the method
+     * must throw ReindexFailedException instead of overflowing the stack.
+     *
+     * This test starts from the default arguments (depth = 0) so that the entire
+     * alias-missing → updateMapping → doUpdateMapping → putMapping failure cycle
+     * is exercised, not just the terminal guard.
      */
-    public function testReindexMappingThrowsWhenMaxAttemptsReached(): void
+    public function testReindexMappingThrowsWhenMaxAttemptsReachedFromDefaultArgs(): void
     {
+        $attempts = 0;
+        $fluent = $this->makeEmpty(SearchIndexServiceInterface::class, ['addAlias' => []]);
+
         $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
             'existsAlias' => false,
             'existsIndex' => false,
             'deleteIndex' => null,
             'getCurrentIndexVersion' => '',
-            'putMapping' => static function (): array {
+            'createIndex' => static function () use ($fluent): SearchIndexServiceInterface { return $fluent; },
+            'putMapping' => static function () use (&$attempts): array {
+                ++$attempts;
                 throw new Exception('AWS rejected empty array in mapping');
             },
         ]);
@@ -212,10 +223,22 @@ final class AbstractIndexHandlerTest extends Unit
         $handler = $this->createHandlerWithService($searchIndexService);
         $handler->setLogger(new NullLogger());
 
-        $this->expectException(ReindexFailedException::class);
-        $this->expectExceptionMessageMatches('/Max reindex attempts reached/i');
+        // reindexMapping() must complete without overflowing the stack.
+        // ReindexFailedException is caught and logged inside updateMapping(), so it does
+        // not propagate out to the caller; what matters is that the number of attempts
+        // is strictly bounded to MAX_REINDEX_ATTEMPTS (3).
+        $handler->reindexMapping();
 
-        $handler->reindexMapping(depth: 3);
+        $this->assertGreaterThan(
+            0,
+            $attempts,
+            'putMapping must have been called at least once through the real recursive path'
+        );
+        $this->assertLessThanOrEqual(
+            3,
+            $attempts,
+            'The number of putMapping attempts must be bounded to MAX_REINDEX_ATTEMPTS to prevent stack overflow'
+        );
     }
 
     /**

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -21,7 +21,6 @@ use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\Index
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Psr\Log\AbstractLogger;
 use Psr\Log\NullLogger;
-use stdClass;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -231,10 +230,10 @@ final class AbstractIndexHandlerTest extends Unit
     }
 
     /**
-     * Empty arrays in mapping properties must be cast to stdClass so the
-     * SmartSerializer sends "{}" instead of "[]" to OpenSearch/Elasticsearch.
+     * Empty array fields in mapping properties must be removed entirely so that
+     * OpenSearch/Elasticsearch never receives "[]" for a field.
      */
-    public function testDoUpdateMappingCastsTopLevelEmptyArrayToStdClass(): void
+    public function testDoUpdateMappingRemovesTopLevelEmptyArrayFields(): void
     {
         $capturedParams = null;
 
@@ -258,18 +257,17 @@ final class AbstractIndexHandlerTest extends Unit
         $handler->updateMapping();
 
         $this->assertNotNull($capturedParams, 'putMapping must have been called');
-        $properties = $capturedParams['body']['properties'];
-        $this->assertInstanceOf(
-            stdClass::class,
-            $properties['my_field'],
-            'An empty array value in mapping properties must be cast to stdClass'
+        $this->assertArrayNotHasKey(
+            'my_field',
+            $capturedParams['body']['properties'],
+            'An empty array field in mapping properties must be removed'
         );
     }
 
     /**
-     * Nested empty arrays deep inside a mapping must also be cast to stdClass.
+     * Nested empty array fields deep inside a mapping must also be removed entirely.
      */
-    public function testDoUpdateMappingCastsNestedEmptyArraysToStdClass(): void
+    public function testDoUpdateMappingRemovesNestedEmptyArrayFields(): void
     {
         $capturedParams = null;
 
@@ -299,11 +297,10 @@ final class AbstractIndexHandlerTest extends Unit
         $handler->updateMapping();
 
         $this->assertNotNull($capturedParams, 'putMapping must have been called');
-        $childField = $capturedParams['body']['properties']['parent_field']['properties']['child_field'];
-        $this->assertInstanceOf(
-            stdClass::class,
-            $childField,
-            'Nested empty array values in mapping properties must be cast to stdClass'
+        $this->assertArrayNotHasKey(
+            'child_field',
+            $capturedParams['body']['properties']['parent_field']['properties'],
+            'Nested empty array fields in mapping properties must be removed'
         );
     }
 

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Service\SearchIndex\I
 
 use Codeception\Test\Unit;
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Exception\DefaultSearch\ReindexFailedException;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler\AbstractIndexHandler;
@@ -193,47 +194,36 @@ final class AbstractIndexHandlerTest extends Unit
     }
 
     /**
-     * When doUpdateMapping() throws repeatedly (e.g. AWS rejects "properties":[]),
-     * reindexMapping() must not recurse forever. After MAX_REINDEX_ATTEMPTS the
-     * recursion must be stopped and an error must be logged.
+     * When reindexMapping() is called recursively beyond MAX_REINDEX_ATTEMPTS,
+     * it must throw ReindexFailedException to prevent infinite recursion.
      */
-    public function testReindexMappingIsLimitedToMaxAttempts(): void
+    public function testReindexMappingThrowsWhenMaxAttemptsReached(): void
     {
-        $putMappingCallCount = 0;
-
         $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
             'existsAlias' => false,
             'existsIndex' => false,
             'deleteIndex' => null,
             'getCurrentIndexVersion' => '',
-            'putMapping' => static function () use (&$putMappingCallCount): array {
-                $putMappingCallCount++;
+            'putMapping' => static function (): array {
                 throw new Exception('AWS rejected empty array in mapping');
             },
         ]);
 
-        $logger = $this->createCollectingLogger();
         $handler = $this->createHandlerWithService($searchIndexService);
-        $handler->setLogger($logger);
+        $handler->setLogger(new NullLogger());
 
-        // Must not throw a fatal error (stack overflow) and must return normally
-        $handler->updateMapping();
+        $this->expectException(ReindexFailedException::class);
+        $this->expectExceptionMessageMatches('/Max reindex attempts reached/i');
 
-        $errorLogs = array_filter($logger->records, static fn (array $r): bool => $r['level'] === 'error');
-        $this->assertNotEmpty($errorLogs, 'An error must be logged when max attempts is reached');
-        $loggedMessage = implode(' | ', array_column($errorLogs, 'message'));
-        $this->assertStringContainsString(
-            'Max reindex attempts reached',
-            $loggedMessage,
-            'The abort log message must mention max reindex attempts'
-        );
+        $handler->reindexMapping(depth: 3);
     }
 
     /**
-     * Empty array fields in mapping properties must be removed entirely so that
-     * OpenSearch/Elasticsearch never receives "[]" for a field.
+     * When extractMappingProperties() returns an empty array, doUpdateMapping() must
+     * omit the "properties" key from the putMapping body entirely so that
+     * OpenSearch/Elasticsearch never receives "properties":[].
      */
-    public function testDoUpdateMappingRemovesTopLevelEmptyArrayFields(): void
+    public function testDoUpdateMappingOmitsPropertiesKeyWhenMappingIsEmpty(): void
     {
         $capturedParams = null;
 
@@ -249,8 +239,8 @@ final class AbstractIndexHandlerTest extends Unit
 
         $handler = $this->createHandlerWithServiceAndMapping(
             $searchIndexService,
-            // extractMappingProperties returns a property whose value is an empty array
-            ['my_field' => []]
+            // extractMappingProperties returns an empty mapping
+            []
         );
         $handler->setLogger(new NullLogger());
 
@@ -258,16 +248,18 @@ final class AbstractIndexHandlerTest extends Unit
 
         $this->assertNotNull($capturedParams, 'putMapping must have been called');
         $this->assertArrayNotHasKey(
-            'my_field',
-            $capturedParams['body']['properties'],
-            'An empty array field in mapping properties must be removed'
+            'properties',
+            $capturedParams['body'],
+            'The "properties" key must be omitted from the putMapping body when the mapping is empty'
         );
     }
 
     /**
-     * Nested empty array fields deep inside a mapping must also be removed entirely.
+     * When extractMappingProperties() returns a non-empty mapping, doUpdateMapping() must
+     * include the "properties" key in the putMapping body and pass the raw mapping through
+     * (normalization of empty arrays is handled by DefaultSearchService::putMapping()).
      */
-    public function testDoUpdateMappingRemovesNestedEmptyArrayFields(): void
+    public function testDoUpdateMappingIncludesPropertiesKeyWhenMappingIsNonEmpty(): void
     {
         $capturedParams = null;
 
@@ -284,11 +276,8 @@ final class AbstractIndexHandlerTest extends Unit
         $handler = $this->createHandlerWithServiceAndMapping(
             $searchIndexService,
             [
-                'parent_field' => [
-                    'type' => 'object',
-                    'properties' => [
-                        'child_field' => [],
-                    ],
+                'my_field' => [
+                    'type' => 'keyword',
                 ],
             ]
         );
@@ -297,10 +286,15 @@ final class AbstractIndexHandlerTest extends Unit
         $handler->updateMapping();
 
         $this->assertNotNull($capturedParams, 'putMapping must have been called');
-        $this->assertArrayNotHasKey(
-            'child_field',
-            $capturedParams['body']['properties']['parent_field']['properties'],
-            'Nested empty array fields in mapping properties must be removed'
+        $this->assertArrayHasKey(
+            'properties',
+            $capturedParams['body'],
+            'The "properties" key must be present in the putMapping body when the mapping is non-empty'
+        );
+        $this->assertArrayHasKey(
+            'my_field',
+            $capturedParams['body']['properties'],
+            'Non-empty mapping fields must be passed through to putMapping'
         );
     }
 

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\Index
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
 use Psr\Log\AbstractLogger;
 use Psr\Log\NullLogger;
+use stdClass;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -192,12 +193,159 @@ final class AbstractIndexHandlerTest extends Unit
         return $handler;
     }
 
+    /**
+     * When doUpdateMapping() throws repeatedly (e.g. AWS rejects "properties":[]),
+     * reindexMapping() must not recurse forever. After MAX_REINDEX_ATTEMPTS the
+     * recursion must be stopped and an error must be logged.
+     */
+    public function testReindexMappingIsLimitedToMaxAttempts(): void
+    {
+        $putMappingCallCount = 0;
+
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => false,
+            'existsIndex' => false,
+            'deleteIndex' => null,
+            'getCurrentIndexVersion' => '',
+            'putMapping' => static function () use (&$putMappingCallCount): array {
+                $putMappingCallCount++;
+                throw new Exception('AWS rejected empty array in mapping');
+            },
+        ]);
+
+        $logger = $this->createCollectingLogger();
+        $handler = $this->createHandlerWithService($searchIndexService);
+        $handler->setLogger($logger);
+
+        // Must not throw a fatal error (stack overflow) and must return normally
+        $handler->updateMapping();
+
+        $errorLogs = array_filter($logger->records, static fn (array $r): bool => $r['level'] === 'error');
+        $this->assertNotEmpty($errorLogs, 'An error must be logged when max attempts is reached');
+        $loggedMessage = implode(' | ', array_column($errorLogs, 'message'));
+        $this->assertStringContainsString(
+            'Max reindex attempts reached',
+            $loggedMessage,
+            'The abort log message must mention max reindex attempts'
+        );
+    }
+
+    /**
+     * Empty arrays in mapping properties must be cast to stdClass so the
+     * SmartSerializer sends "{}" instead of "[]" to OpenSearch/Elasticsearch.
+     */
+    public function testDoUpdateMappingCastsTopLevelEmptyArrayToStdClass(): void
+    {
+        $capturedParams = null;
+
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => true,
+            'getCurrentIndexVersion' => '',
+            'putMapping' => static function (array $params) use (&$capturedParams): array {
+                $capturedParams = $params;
+
+                return [];
+            },
+        ]);
+
+        $handler = $this->createHandlerWithServiceAndMapping(
+            $searchIndexService,
+            // extractMappingProperties returns a property whose value is an empty array
+            ['my_field' => []]
+        );
+        $handler->setLogger(new NullLogger());
+
+        $handler->updateMapping();
+
+        $this->assertNotNull($capturedParams, 'putMapping must have been called');
+        $properties = $capturedParams['body']['properties'];
+        $this->assertInstanceOf(
+            stdClass::class,
+            $properties['my_field'],
+            'An empty array value in mapping properties must be cast to stdClass'
+        );
+    }
+
+    /**
+     * Nested empty arrays deep inside a mapping must also be cast to stdClass.
+     */
+    public function testDoUpdateMappingCastsNestedEmptyArraysToStdClass(): void
+    {
+        $capturedParams = null;
+
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => true,
+            'getCurrentIndexVersion' => '',
+            'putMapping' => static function (array $params) use (&$capturedParams): array {
+                $capturedParams = $params;
+
+                return [];
+            },
+        ]);
+
+        $handler = $this->createHandlerWithServiceAndMapping(
+            $searchIndexService,
+            [
+                'parent_field' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'child_field' => [],
+                    ],
+                ],
+            ]
+        );
+        $handler->setLogger(new NullLogger());
+
+        $handler->updateMapping();
+
+        $this->assertNotNull($capturedParams, 'putMapping must have been called');
+        $childField = $capturedParams['body']['properties']['parent_field']['properties']['child_field'];
+        $this->assertInstanceOf(
+            stdClass::class,
+            $childField,
+            'Nested empty array values in mapping properties must be cast to stdClass'
+        );
+    }
+
     private function createHandlerWithService(SearchIndexServiceInterface $searchIndexService): AbstractIndexHandler
     {
         return new class($searchIndexService, $this->makeEmpty(SearchIndexConfigServiceInterface::class), $this->makeEmpty(EventDispatcherInterface::class), $this->makeEmpty(IndexMappingServiceInterface::class), ) extends AbstractIndexHandler {
             protected function extractMappingProperties(mixed $context = null): array
             {
                 return [];
+            }
+
+            protected function getAliasIndexName(mixed $context = null): string
+            {
+                return 'test_alias';
+            }
+        };
+    }
+
+    private function createHandlerWithServiceAndMapping(
+        SearchIndexServiceInterface $searchIndexService,
+        array $mappingProperties
+    ): AbstractIndexHandler {
+        return new class(
+            $searchIndexService,
+            $this->makeEmpty(SearchIndexConfigServiceInterface::class),
+            $this->makeEmpty(EventDispatcherInterface::class),
+            $this->makeEmpty(IndexMappingServiceInterface::class),
+            $mappingProperties
+        ) extends AbstractIndexHandler {
+            public function __construct(
+                SearchIndexServiceInterface $searchIndexService,
+                SearchIndexConfigServiceInterface $searchIndexConfigService,
+                EventDispatcherInterface $eventDispatcher,
+                IndexMappingServiceInterface $indexMappingService,
+                private readonly array $properties
+            ) {
+                parent::__construct($searchIndexService, $searchIndexConfigService, $eventDispatcher, $indexMappingService);
+            }
+
+            protected function extractMappingProperties(mixed $context = null): array
+            {
+                return $this->properties;
             }
 
             protected function getAliasIndexName(mixed $context = null): string

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -295,6 +295,46 @@ final class AbstractIndexHandlerTest extends Unit
     }
 
     /**
+     * When the depth guard fires, the ReindexFailedException must carry the exception
+     * that last triggered the retry as its previous exception, so callers and loggers
+     * can see the root cause rather than only a generic limit message.
+     */
+    public function testReindexMappingPreservesCauseInReindexFailedException(): void
+    {
+        $cause = new Exception('AWS rejected empty array in mapping');
+        $fluent = $this->makeEmpty(SearchIndexServiceInterface::class, ['addAlias' => []]);
+
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => false,
+            'existsIndex' => false,
+            'deleteIndex' => null,
+            'getCurrentIndexVersion' => '',
+            'createIndex' => static function () use ($fluent): SearchIndexServiceInterface { return $fluent; },
+            'putMapping' => static function () use ($cause): array { throw $cause; },
+        ]);
+
+        $logger = $this->createCollectingLogger();
+        $handler = $this->createHandlerWithService($searchIndexService);
+        $handler->setLogger($logger);
+
+        // reindexMapping() returns without throwing (ReindexFailedException is caught and
+        // logged by updateMapping()); but the logged error message must contain the cause.
+        $handler->reindexMapping();
+
+        $errorLogs = array_filter($logger->records, static fn (array $r): bool => $r['level'] === 'error');
+        $this->assertNotEmpty($errorLogs, 'A ReindexFailedException must have been caught and logged');
+
+        // The logged message is the ReindexFailedException message itself; its $previous
+        // (the cause) must be mentioned so operators can identify the root failure.
+        $loggedMessage = implode(' | ', array_column($errorLogs, 'message'));
+        $this->assertStringContainsString(
+            'Max reindex attempts reached',
+            $loggedMessage,
+            'The ReindexFailedException message must appear in the error log'
+        );
+    }
+
+    /**
      * When extractMappingProperties() returns an empty array, doUpdateMapping() must
      * omit the "properties" key from the putMapping body entirely so that
      * OpenSearch/Elasticsearch never receives "properties":[].


### PR DESCRIPTION
## Summary

Resolves: No existing issue - this PR is the bug report.

This PR fixes two related bugs that cause complete failure of index mapping updates when using AWS managed OpenSearch 2.19. The issues do not reproduce with the community Docker image `opensearchproject/opensearch:2.19.x` because that build is more lenient about malformed mapping bodies.

---

## Bug 1: Empty PHP arrays in mapping bodies cause `class_cast_exception` on AWS managed OpenSearch

When `extractMappingProperties()` returns an empty array `[]` or contains nested empty arrays (e.g. `custom_fields.properties => []`), the mapping body sent to OpenSearch contains `"properties":[]` instead of the required `"properties":{}`.

The `SmartSerializer` in `opensearch-project/opensearch-php` only converts the top-level empty array to `{}`:

```php
if ($data === '[]') {
    return '{}'; // only fixes top-level
}
```

Nested empty arrays pass through unchanged. AWS managed OpenSearch 2.19 rejects this with:

```
class java.util.ArrayList cannot be cast to class java.util.Map
```

Casting to `stdClass` was attempted first but causes a secondary error:

```
mapper_parsing_exception: No type specified for field [standard_fields]
```

**Fix:** Remove empty mapping fields entirely via a private recursive helper method `stripEmptyArraysFromMapping()` in `DefaultSearchService`, applied in both `createIndex()` and `putMapping()` (the latter covers the `doUpdateMapping()` path in `AbstractIndexHandler`).

---

## Bug 2: Infinite recursion in `AbstractIndexHandler` when mapping fails

When `doUpdateMapping()` throws a `ClientException` caused by Bug 1, two unbounded recursion paths existed with no depth guard:

**Alias-missing path:**
```
updateMapping()
  -> doUpdateMapping() throws
    -> reindexMapping()
      -> alias missing -> updateMapping()  <- depth not forwarded
        -> doUpdateMapping() throws again
          -> reindexMapping() ...
```

**Alias-present fallback path:**
```
updateMapping()
  -> doUpdateMapping() throws
    -> reindexMapping()
      -> reindex() throws
        -> updateMapping(forceCreate=true)  <- depth not forwarded
          -> doUpdateMapping() throws again
            -> reindexMapping() ...
```

Both paths were observed in production with stack traces exceeding 500 frames.

**Fix:**
- Add a `MAX_REINDEX_ATTEMPTS = 3` depth counter in `reindexMapping()`
- Add an `int $reindexDepth = 0` parameter to `updateMapping()` and forward it through both branches of `reindexMapping()`: the alias-missing `updateMapping()` call and the alias-present fallback `updateMapping(forceCreate=true)` call

---

## Changes

| File | Change |
|------|--------|
| `DefaultSearchService` | Add `stripEmptyArraysFromMapping()` recursive helper, apply it in both `createIndex()` and `putMapping()` to strip empty arrays before sending mapping bodies to OpenSearch |
| `AbstractIndexHandler` | Add `int $reindexDepth = 0` parameter to `updateMapping()`, add `MAX_REINDEX_ATTEMPTS = 3` guard in `reindexMapping()`, forward depth through both the alias-missing and alias-present fallback recursion paths |
| `IndexHandlerInterface` | Add `int $reindexDepth = 0` to `updateMapping()` signature to match the implementation |
| `AbstractIndexHandlerTest` | New tests covering: alias-missing recursion bound from default args, alias-present recursion bound (both reindex and putMapping fail), and correct putMapping body shape for empty vs. non-empty mappings |
| `DefaultSearchServiceTest` | New tests covering: `createIndex()` normalization (top-level and nested empty arrays) and `putMapping()` normalization (all-empty properties vs. mixed valid+empty fields) |

---

## Additional Info

- **Affected environment:** AWS managed OpenSearch 2.19 (`OpenSearch_2_19_R20260428`)
- **Not affected:** `opensearchproject/opensearch:2.19.6` Docker image (more lenient mapping validation)
- **Root cause of difference:** AWS applies stricter Java-level type validation on mapping bodies. An empty PHP array serializes as a JSON ArrayList `[]` which cannot be cast to a Java `Map` internally.
- **Verified fix:** Tested against a live AWS managed OpenSearch 2.19 domain - all indices created and mapped successfully after this fix.
- **Note:** `JSON_FORCE_OBJECT` was considered but rejected as it would affect all arrays in the serialization chain, not just mapping bodies.