### PR TITLE
Gate fork-PR codeception behind the fork-PR security gate

### DIFF
--- a/.github/workflows/elastic-search-codeception.yaml
+++ b/.github/workflows/elastic-search-codeception.yaml
@@ -5,6 +5,7 @@ on:
         - cron: "0 3 * * 1,3,5"
     workflow_dispatch:
     pull_request_target:
+        types: [opened, synchronize, reopened, labeled]
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
@@ -22,7 +23,15 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    security-gate:
+        permissions:
+            contents: read
+            pull-requests: write
+            models: read
+        uses: pimcore/workflows-collection-public/.github/workflows/reusable-fork-pr-security-gate.yaml@workflow_gate
+
     setup-matrix:
+        needs: security-gate
         runs-on: ubuntu-latest
         outputs:
             php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
@@ -65,11 +74,12 @@ jobs:
                   echo "matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
 
     codeception-tests:
-        needs: setup-matrix
+        needs: [security-gate, setup-matrix]
         strategy:
             matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-tests-centralized.yaml@main
         with:
+            allow_fork_pr_checkout: true
             APP_ENV: test
             PIMCORE_TEST: "1"
             PRIVATE_REPO: "false"

--- a/.github/workflows/open-search-codeception.yaml
+++ b/.github/workflows/open-search-codeception.yaml
@@ -5,6 +5,7 @@ on:
         - cron: "0 3 * * 1,3,5"
     workflow_dispatch:
     pull_request_target:
+        types: [opened, synchronize, reopened, labeled]
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
@@ -23,7 +24,15 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    security-gate:
+        permissions:
+            contents: read
+            pull-requests: write
+            models: read
+        uses: pimcore/workflows-collection-public/.github/workflows/reusable-fork-pr-security-gate.yaml@workflow_gate
+
     setup-matrix:
+        needs: security-gate
         runs-on: ubuntu-latest
         outputs:
             php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
@@ -66,11 +75,12 @@ jobs:
                   echo "matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
 
     codeception-tests:
-        needs: setup-matrix
+        needs: [security-gate, setup-matrix]
         strategy:
             matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-tests-centralized.yaml@main
         with:
+            allow_fork_pr_checkout: true
             APP_ENV: test
             PIMCORE_TEST: "1"
             PRIVATE_REPO: "false"


### PR DESCRIPTION
## Draft — blocked on workflows-collection-public#133

Fixes fork-PR codeception, which currently dies at **Checkout code** (`actions/checkout` refuses fork PR code under `pull_request_target` — pwn-request guardrail). Observed: run 29804774980 (fork branch `patch-1`).

**Why not just downgrade to `pull_request`:** the tests require secrets — a fork PR under `pull_request` fails at bootstrap with `` `pimcore.encryption.secret` is not set `` (PR #376 by an external contributor). So the workflow must stay `pull_request_target` and be gated.

**What this does** (mirrors the pattern piloted in `payment-provider-mpay24-seamless`):
- adds a `security-gate` job (`reusable-fork-pr-security-gate.yaml@workflow_gate`) — classifies fork PRs, deterministic high-risk-path rules + AI diff scan, maintainer `safe-to-test` override, fails closed;
- gates `setup-matrix` and `codeception-tests` on it;
- passes `allow_fork_pr_checkout: true` so the reusable re-enables the checkout **only** on the gate-approved path (the input added in #133);
- adds the `labeled` event so a maintainer's `safe-to-test` label re-runs it.

**Dependencies / order:**
1. Merge `reusable-fork-pr-security-gate.yaml` `workflow_gate` → `main` (so `@workflow_gate` can move to `@main`).
2. Merge workflows-collection-public#133 (adds `allow_fork_pr_checkout`).
3. Then this PR can be un-drafted; verify on a real fork PR: gate ✅ → checkout ✅ → tests run; a rejected fork PR must NOT reach checkout.

**Base:** `2.5` (oldest active line, per the #460 pattern) — merge up 2.5 → 2026.1 → 2026.2 → 2026.x after review.

Context: product-management#1311 §5, #1303.
