### PR TITLE
TEST (do not merge): codeception on pull_request with no secrets

### DIFF
--- a/.github/workflows/elastic-search-codeception.yaml
+++ b/.github/workflows/elastic-search-codeception.yaml
@@ -4,7 +4,7 @@ on:
     schedule:
         - cron: "0 3 * * 1,3,5"
     workflow_dispatch:
-    pull_request_target:
+    pull_request:
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
@@ -68,7 +68,7 @@ jobs:
         needs: setup-matrix
         strategy:
             matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
-        uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-tests-centralized.yaml@main
+        uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-tests-centralized.yaml@feat/codeception-no-secret-fork-tests
         with:
             APP_ENV: test
             PIMCORE_TEST: "1"
@@ -83,9 +83,3 @@ jobs:
             PIMCORE_ELASTIC_SEARCH_VERSION: "8.5.3"
             ENABLE_ELASTICSEARCH: true
             COVERAGE: "xdebug"
-        secrets:
-            SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
-            COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
-            PIMCORE_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
-            PIMCORE_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
-            PIMCORE_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}

--- a/.github/workflows/open-search-codeception.yaml
+++ b/.github/workflows/open-search-codeception.yaml
@@ -4,7 +4,7 @@ on:
     schedule:
         - cron: "0 3 * * 1,3,5"
     workflow_dispatch:
-    pull_request_target:
+    pull_request:
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
@@ -69,7 +69,7 @@ jobs:
         needs: setup-matrix
         strategy:
             matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
-        uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-tests-centralized.yaml@main
+        uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-tests-centralized.yaml@feat/codeception-no-secret-fork-tests
         with:
             APP_ENV: test
             PIMCORE_TEST: "1"
@@ -84,9 +84,3 @@ jobs:
             PIMCORE_OPENSEARCH_VERSION: "2"
             ENABLE_ELASTICSEARCH: false
             COVERAGE: "xdebug"
-        secrets:
-            SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
-            COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
-            PIMCORE_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
-            PIMCORE_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
-            PIMCORE_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}


### PR DESCRIPTION
Proof-of-concept for the secure approach (Herbert's direction): run codeception on plain `pull_request`, generate a throwaway encryption key at runtime, and pass **no secrets** to the reusable (simulating a fork PR). If the codeception jobs go green, it proves fork PRs can run tests with nothing sensitive in scope — no gate, no allow-unsafe. Uses reusable branch `feat/codeception-no-secret-fork-tests`. Temporary — do not merge.