### PR TITLE
Restrict PR Guardrails to the three tokens (drop secrets: inherit)

### DIFF
--- a/.github/workflows/pr-guardrails.yml
+++ b/.github/workflows/pr-guardrails.yml
@@ -24,4 +24,7 @@ concurrency:
 jobs:
   guardrails:
     uses: pimcore/workflows-collection-public/.github/workflows/parent-pr-guardrails.yml@main
-    secrets: inherit
+    secrets:
+      MEMBERSHIP_GUARD_TOKEN: ${{ secrets.MEMBERSHIP_GUARD_TOKEN }}
+      ISSUE_LINK_GUARD_TOKEN: ${{ secrets.ISSUE_LINK_GUARD_TOKEN }}
+      CI_GUARD_TOKEN: ${{ secrets.CI_GUARD_TOKEN }}


### PR DESCRIPTION
Follow-up to the merged PR Guardrails rollout (platform-version#226).

Replaces `secrets: inherit` with the three explicit guardrail tokens. `inherit` forwards every repo/org secret to the centrally-referenced `@main` workflow; passing only the declared tokens is least-privilege. Matches advanced-object-search#318.