### PR TITLE
Fix image gallery asset ids in search index normalization

### DIFF
--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/ImageGalleryAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/ImageGalleryAdapter.php
@@ -63,8 +63,10 @@ final class ImageGalleryAdapter extends AbstractAdapter
         $normalizedValues = $fieldDefinition->normalize($value);
         if (is_array($normalizedValues)) {
             foreach ($normalizedValues as $normalizedValue) {
-                if ($normalizedValue['image']['id']) {
-                    $returnValue['assets'][] = $normalizedValue['image']['id'];
+                $imageId = $normalizedValue['image']['id'] ?? null;
+
+                if ($imageId !== null) {
+                    $returnValue['assets'][] = $imageId;
                 }
             }
             $returnValue['details'] = $normalizedValues;

--- a/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/ImageGalleryAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/ImageGalleryAdapterTest.php
@@ -62,4 +62,68 @@ final class ImageGalleryAdapterTest extends Unit
             ],
         ], $adapter->getIndexMapping());
     }
+
+    public function testNormalizeCollectsAssetIdsAndSkipsGalleryItemsWithoutImageId(): void
+    {
+        $searchIndexConfigService = $this->makeEmpty(
+            SearchIndexConfigServiceInterface::class
+        );
+
+        $fieldDefinitionService = $this->makeEmpty(FieldDefinitionServiceInterface::class);
+
+        $indexMappingService = $this->makeEmpty(
+            IndexMappingServiceInterface::class
+        );
+
+        $adapter = new ImageGalleryAdapter(
+            $searchIndexConfigService,
+            $fieldDefinitionService,
+            $indexMappingService
+        );
+
+        $gallery = new class extends ImageGallery {
+            public function normalize(mixed $value, array $params = []): array 
+            {
+                return [
+                    [
+                        'image' => [
+                            'id' => 123,
+                        ],
+                        'hotspots' => [],
+                    ],
+                    [
+                        'image' => [],
+                        'hotspots' => [],
+                    ],
+                ];
+            }
+        };
+
+        $adapter->setFieldDefinition($gallery);
+
+        $result = $adapter->normalize([]);
+
+        $this->assertSame(
+            [
+                123,
+            ],
+            $result['assets']
+        );
+
+        $this->assertSame(
+            [
+                [
+                    'image' => [
+                        'id' => 123,
+                    ],
+                    'hotspots' => [],
+                ],
+                [
+                    'image' => [],
+                    'hotspots' => [],
+                ],
+            ],
+            $result['details']
+        );
+    }
 }

--- a/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/ImageGalleryAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/ImageGalleryAdapterTest.php
@@ -28,27 +28,31 @@ final class ImageGalleryAdapterTest extends Unit
 {
     public function testGetSearchIndexMapping(): void
     {
-        $searchIndexConfigServiceInterfaceMock = $this->makeEmpty(SearchIndexConfigServiceInterface::class);
-        $fieldDefinitionServiceInterfaceMock = $this->makeEmpty(FieldDefinitionServiceInterface::class);
-        $indexMappingServiceInterfaceMock = $this->makeEmpty(IndexMappingServiceInterface::class,
-            ['getMappingForTextKeyword' => [
-                'type' => 'text',
-                'fields' => [
-                    'keyword' => [
-                        'type' => 'keyword',
-                    ],
-                ],
-            ]]
+        $searchIndexConfigService = $this->makeEmpty(
+            SearchIndexConfigServiceInterface::class,
+            [
+                'getSearchAnalyzerAttributes' => [],
+            ]
+        );
+
+        $fieldDefinitionService = $this->makeEmpty(FieldDefinitionServiceInterface::class);
+
+        $indexMappingService = $this->makeEmpty(
+            IndexMappingServiceInterface::class,
+            [
+                'getMappingForAdvancedImage' => [],
+            ]
         );
 
         $adapter = new ImageGalleryAdapter(
-            $searchIndexConfigServiceInterfaceMock,
-            $fieldDefinitionServiceInterfaceMock,
-            $indexMappingServiceInterfaceMock
+            $searchIndexConfigService,
+            $fieldDefinitionService,
+            $indexMappingService
         );
 
         $gallery = new ImageGallery();
         $adapter->setFieldDefinition($gallery);
+
         $this->assertSame([
             'properties' => [
                 'assets' => [


### PR DESCRIPTION
Resolves: https://github.com/pimcore/platform-version/issues/240

## Changes

Fix ImageGallery asset ID normalization for search indexing.

## Problem

When indexing objects containing an ImageGallery (for us, as part of a fieldcollection) field, the normalized image gallery data did not expose the referenced asset IDs in the expected `assets` structure.

This could result in missing asset references during indexing and lead to errors such as:

> Undefined array key "asset" 

when the expected asset information was not available in the normalized output.

## Solution

The ImageGallery adapter now extracts the referenced image IDs from the normalized gallery values and stores them in the `assets` array.

The existing normalized gallery data remains unchanged and is still available through the `details` field.

Additionally, the normalization now safely handles missing image IDs to avoid accessing undefined array keys.