### PR TITLE
Fix: percent-encode paths when rewriting cached Portal Engine thumbnail URLs after a move (backport #458 to 2.5)

### DIFF
--- a/src/SearchIndexAdapter/DefaultSearch/PathService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/PathService.php
@@ -124,6 +124,12 @@ final class PathService implements PathServiceInterface
                     'params' => [
                         'currentPath' => $currentPath . '/',
                         'newPath' => $newPath . '/',
+                        // Portal Engine's frontend thumbnail URLs are built via
+                        // urlencode_ignore_slash() (rawurlencode() per path segment), so accented
+                        // and other non-unreserved characters end up percent-encoded there. Provide
+                        // the equivalently-encoded path so the script can match/replace that form too.
+                        'currentPathEncoded' => $this->encodePathSegments($currentPath) . '/',
+                        'newPathEncoded' => $this->encodePathSegments($newPath) . '/',
                         'now' => date('c'),
                     ],
                 ],
@@ -188,15 +194,14 @@ final class PathService implements PathServiceInterface
                                 }
                             }
                             
-                            String encodedCurrentPath = params.currentPath.replace(" ", "%20");
                             String thumbPath = thumb.substring(pathStart);
-                            
-                            if(thumbPath.startsWith(encodedCurrentPath) || thumbPath.startsWith(params.currentPath)) {
-                                String matchedPath = thumbPath.startsWith(encodedCurrentPath) ? 
-                                    encodedCurrentPath : params.currentPath;
+
+                            if(thumbPath.startsWith(params.currentPathEncoded) || thumbPath.startsWith(params.currentPath)) {
+                                boolean matchedEncoded = thumbPath.startsWith(params.currentPathEncoded);
+                                String matchedPath = matchedEncoded ? params.currentPathEncoded : params.currentPath;
                                 String remainingPath = thumbPath.substring(matchedPath.length());
-                                String encodedNewPath = params.newPath.replace(" ", "%20");
-                                customFields.thumbnail = prefix + encodedNewPath + remainingPath;
+                                String replacementPath = matchedEncoded ? params.newPathEncoded : params.newPath;
+                                customFields.thumbnail = prefix + replacementPath + remainingPath;
                             }
 
                         }
@@ -216,6 +221,15 @@ final class PathService implements PathServiceInterface
                 }
                 ctx._source.system_fields.modificationDate = params.now;
                 ctx._source.system_fields.checksum = 0';
+    }
+
+    /**
+     * Mirrors urlencode_ignore_slash() (rawurlencode() applied per path segment), which is how
+     * Portal Engine builds its frontend thumbnail URLs (ThumbnailService::getThumbnailPath()).
+     */
+    private function encodePathSegments(string $path): string
+    {
+        return implode('/', array_map('rawurlencode', explode('/', $path)));
     }
 
     private function countDocumentsByPath(string $indexName, string $path): int

--- a/src/SearchIndexAdapter/DefaultSearch/PathService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/PathService.php
@@ -229,7 +229,7 @@ final class PathService implements PathServiceInterface
      */
     private function encodePathSegments(string $path): string
     {
-        return implode('/', array_map('rawurlencode', explode('/', $path)));
+        return \urlencode_ignore_slash($path);
     }
 
     private function countDocumentsByPath(string $indexName, string $path): int

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/PathServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/PathServiceTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\SearchIndexAdapter\DefaultSearch;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\PathService;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\ElementTypeAdapter\AdapterServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\SearchClient\SearchClientInterface;
+use ReflectionMethod;
+
+/**
+ * Regression coverage for PEES-1245: Portal Engine's frontend thumbnail URLs are built via
+ * urlencode_ignore_slash() (rawurlencode() per path segment), so a path containing accented or
+ * other non-unreserved characters is stored percent-encoded in the search index. When such a
+ * folder is moved, rewriteChildrenIndexPaths() must be able to match and rewrite that encoded
+ * form as well as the plain form, otherwise the cached thumbnail URL is left stale.
+ *
+ * @internal
+ */
+final class PathServiceTest extends Unit
+{
+    public function testEncodePathSegmentsEncodesAccentedCharactersButKeepsSlashes(): void
+    {
+        $this->assertSame(
+            '/caf%C3%A9/sub-folder',
+            $this->encodePathSegments('/café/sub-folder')
+        );
+    }
+
+    public function testEncodePathSegmentsEncodesSpaces(): void
+    {
+        $this->assertSame(
+            '/my%20folder/asset',
+            $this->encodePathSegments('/my folder/asset')
+        );
+    }
+
+    public function testEncodePathSegmentsLeavesUnreservedCharactersUntouched(): void
+    {
+        $this->assertSame(
+            '/Folder-1/asset_2.jpg',
+            $this->encodePathSegments('/Folder-1/asset_2.jpg')
+        );
+    }
+
+    private function encodePathSegments(string $path): string
+    {
+        $service = new PathService(
+            $this->makeEmpty(SearchClientInterface::class),
+            $this->makeEmpty(AdapterServiceInterface::class),
+            $this->makeEmpty(SearchIndexConfigServiceInterface::class),
+        );
+
+        $method = new ReflectionMethod(PathService::class, 'encodePathSegments');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $path);
+    }
+}


### PR DESCRIPTION
Cherry-pick of #458 (merged into `2026.2`) onto `2.5`.

partially resolves https://github.com/pimcore/service-operations/issues/932

## Original description

Moving an asset folder whose name (or a descendant's name) contains accented characters breaks image thumbnails afterwards — but only in Portal Engine, not in the Studio backend. Moving the folder back makes the thumbnails reappear without any regeneration.

Portal Engine reads a cached thumbnail URL stored in the OpenSearch index. When a folder moves, `PathService::rewriteChildrenIndexPaths()` runs a Painless script to rewrite that cached field's path prefix — but it only special-cased spaces, not other percent-encoded characters (e.g. accented characters), so the rewrite silently failed for those paths.

### Fix

`PathService::updatePath()` now also passes a fully percent-encoded variant of the old/new path into the script, matching/replacing against that as a fallback alongside the plain path.

### Testing

Added `PathServiceTest::testEncodePathSegments*()` covering the new percent-encoding helper.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>