### PR TITLE
Cap executed search debug history in debug mode

### DIFF
--- a/src/SearchIndexAdapter/DefaultSearch/Search/SearchExecutionService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/Search/SearchExecutionService.php
@@ -28,6 +28,8 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 final class SearchExecutionService implements SearchExecutionServiceInterface
 {
+    private const MAX_EXECUTED_SEARCHES = 500;
+
     /**
      * @var SearchInformation[]
      */
@@ -76,7 +78,7 @@ final class SearchExecutionService implements SearchExecutionServiceInterface
             );
 
             if ($this->debugMode) {
-                $this->executedSearches[] = $searchInformation;
+                $this->addExecutedSearch($searchInformation);
             }
 
             if ($this->isWindowTooLarge($e)) {
@@ -101,13 +103,13 @@ final class SearchExecutionService implements SearchExecutionServiceInterface
         }
 
         if ($this->debugMode) {
-            $this->executedSearches[] = new SearchInformation(
+            $this->addExecutedSearch(new SearchInformation(
                 $search,
                 true,
                 $defaultSearchResult,
                 $executionTime,
                 debug_backtrace(),
-            );
+            ));
         }
 
         return $this->searchResultDenormalizer->denormalize(
@@ -121,6 +123,16 @@ final class SearchExecutionService implements SearchExecutionServiceInterface
     public function getExecutedSearches(): array
     {
         return $this->executedSearches;
+    }
+
+    private function addExecutedSearch(SearchInformation $searchInformation): void
+    {
+        $this->executedSearches[] = $searchInformation;
+
+        $excess = count($this->executedSearches) - self::MAX_EXECUTED_SEARCHES;
+        if ($excess > 0) {
+            array_splice($this->executedSearches, 0, $excess);
+        }
     }
 
     private function isWindowTooLarge(Exception $e): bool

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/Search/SearchExecutionServiceTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/Search/SearchExecutionServiceTest.php
@@ -43,6 +43,27 @@ final class SearchExecutionServiceTest extends Unit
         $this->assertNotEmpty($searchInformation->getStackTrace());
     }
 
+    public function testExecutedSearchHistoryIsCappedInDebugMode(): void
+    {
+        $maxExecutedSearches = 500;
+        $service = $this->createService(debugMode: true);
+
+        $searches = [];
+        for ($i = 0; $i < $maxExecutedSearches + 5; $i++) {
+            $searches[] = $search = $this->createSearch();
+            $service->executeSearch($search, 'test_index');
+        }
+
+        $executedSearches = $service->getExecutedSearches();
+        $this->assertCount($maxExecutedSearches, $executedSearches);
+        // the oldest entries are dropped, the most recent ones are kept
+        $this->assertSame($searches[5], $executedSearches[0]->getSearch());
+        $this->assertSame(
+            $searches[$maxExecutedSearches + 4],
+            $executedSearches[$maxExecutedSearches - 1]->getSearch()
+        );
+    }
+
     public function testExecutedSearchesAreNotCollectedOutsideDebugMode(): void
     {
         $service = $this->createService(debugMode: false);


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/platform-version/issues/285

Follow-up to #418 (original report: #417), as discussed in [this comment](https://github.com/pimcore/generic-data-index-bundle/pull/418#issuecomment-5088996143).

#418 stops `$executedSearches` from accumulating outside debug mode. With debug mode enabled the array still grows unbounded — every search appends a `SearchInformation` holding the full response and a `debug_backtrace()` payload, so long-running CLI commands (imports, re-indexing) eventually exhaust memory in dev environments.

This PR bounds the history to the 500 most recent entries (`MAX_EXECUTED_SEARCHES`); when exceeded, the oldest entries are dropped via `array_splice`. The `DebugSubscriber` consuming the history is request-scoped and only needs the most recent entries, so profiler output is unaffected. No API change.

Added `testExecutedSearchHistoryIsCappedInDebugMode` to `SearchExecutionServiceTest` asserting the cap holds and the oldest entries are dropped first.

## Additional info
Reference numbers from the import where we hit this (1374 entities, debug mode): with only the #418 guard the command OOM'd after ~20 entities at a 1024M limit; with a capped history the full import completes. (Remaining growth in our profiling came from other components, outside the scope of this bundle.)
