### PR TITLE
Map calculated value fields according to their configured element type

### DIFF
--- a/config/services/search/data-object/field-definition-adapters.yml
+++ b/config/services/search/data-object/field-definition-adapters.yml
@@ -12,7 +12,6 @@ services:
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "select" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "multiselect" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "input" }
-            - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "calculatedValue" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "country" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "countrymultiselect" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "language" }
@@ -23,6 +22,11 @@ services:
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "lastname" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "email" }
             - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "gender" }
+
+    Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DataObject\FieldDefinitionAdapter\CalculatedValueAdapter:
+        shared: false
+        tags:
+            - { name: "pimcore.generic_data_index.data-object.search_index_field_definition", type: "calculatedValue" }
 
     Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DataObject\FieldDefinitionAdapter\NumericAdapter:
         shared: false

--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/CalculatedValueAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/CalculatedValueAdapter.php
@@ -83,7 +83,10 @@ final class CalculatedValueAdapter extends AbstractAdapter
             return $value;
         }
 
-        return (bool) $value;
+        // Calculators may return loosely typed values; only recognized boolean
+        // representations are indexed, anything else becomes null instead of
+        // silently reversing filters (e.g. 'false' must not turn into true).
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
     }
 
     private function normalizeText(mixed $value): mixed

--- a/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/CalculatedValueAdapter.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DataObject/FieldDefinitionAdapter/CalculatedValueAdapter.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DataObject\FieldDefinitionAdapter;
+
+use DateTimeInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\DefaultSearch\AttributeType;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject\FieldDefinitionServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\Model\DataObject\ClassDefinition\Data\CalculatedValue;
+
+/**
+ * Maps calculated value fields based on their configured element type instead of
+ * always falling back to a text mapping, so that boolean/numeric/date calculated
+ * values stay filterable and aggregatable in the search index.
+ *
+ * @internal
+ */
+final class CalculatedValueAdapter extends AbstractAdapter
+{
+    private const ELEMENT_TYPE_BOOLEAN = 'boolean';
+
+    private const ELEMENT_TYPE_NUMERIC = 'numeric';
+
+    private const ELEMENT_TYPE_DATE = 'date';
+
+    public function __construct(
+        protected SearchIndexConfigServiceInterface $searchIndexConfigService,
+        protected FieldDefinitionServiceInterface $fieldDefinitionService,
+        private readonly IndexMappingServiceInterface $indexMappingService,
+    ) {
+        parent::__construct(
+            $searchIndexConfigService,
+            $fieldDefinitionService
+        );
+    }
+
+    public function getIndexMapping(): array
+    {
+        return match ($this->getElementType()) {
+            self::ELEMENT_TYPE_BOOLEAN => [
+                'type' => AttributeType::BOOLEAN->value,
+            ],
+            self::ELEMENT_TYPE_NUMERIC => [
+                'type' => AttributeType::FLOAT->value,
+            ],
+            self::ELEMENT_TYPE_DATE => [
+                'type' => AttributeType::DATE->value,
+                'format' => 'strict_date_time_no_millis',
+            ],
+            default => $this->indexMappingService->getMappingForTextKeyword(
+                $this->searchIndexConfigService->getSearchAnalyzerAttributes()
+            ),
+        };
+    }
+
+    public function normalize(mixed $value): mixed
+    {
+        return match ($this->getElementType()) {
+            self::ELEMENT_TYPE_BOOLEAN => $this->normalizeBoolean($value),
+            self::ELEMENT_TYPE_NUMERIC => is_numeric($value) ? (float) $value : null,
+            self::ELEMENT_TYPE_DATE => $value instanceof DateTimeInterface
+                ? $value->format(DateTimeInterface::ATOM)
+                : null,
+            default => $this->normalizeText($value),
+        };
+    }
+
+    private function normalizeBoolean(mixed $value): ?bool
+    {
+        if ($value === null || is_bool($value)) {
+            return $value;
+        }
+
+        return (bool) $value;
+    }
+
+    private function normalizeText(mixed $value): mixed
+    {
+        if (is_string($value) && $value !== '') {
+            return preg_replace("/src=(['\"])data:[^;]+;base64,.+?\\1/", '', $value);
+        }
+
+        return parent::normalize($value);
+    }
+
+    private function getElementType(): ?string
+    {
+        $fieldDefinition = $this->getFieldDefinition();
+        if (!$fieldDefinition instanceof CalculatedValue) {
+            return null;
+        }
+
+        return $fieldDefinition->getElementType();
+    }
+}

--- a/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/CalculatedValueAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/CalculatedValueAdapterTest.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\SearchIndexAdapter\DataObject\FieldDefinitionAdapter;
+
+use Carbon\Carbon;
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DataObject\FieldDefinitionServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DataObject\FieldDefinitionAdapter\CalculatedValueAdapter;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\Model\DataObject\ClassDefinition\Data\CalculatedValue;
+
+/**
+ * @internal
+ */
+final class CalculatedValueAdapterTest extends Unit
+{
+    public function testGetSearchIndexMappingForBooleanElementType(): void
+    {
+        $adapter = $this->createAdapter('boolean');
+
+        $this->assertSame([
+            'type' => 'boolean',
+        ], $adapter->getIndexMapping());
+    }
+
+    public function testGetSearchIndexMappingForNumericElementType(): void
+    {
+        $adapter = $this->createAdapter('numeric');
+
+        $this->assertSame([
+            'type' => 'float',
+        ], $adapter->getIndexMapping());
+    }
+
+    public function testGetSearchIndexMappingForDateElementType(): void
+    {
+        $adapter = $this->createAdapter('date');
+
+        $this->assertSame([
+            'type' => 'date',
+            'format' => 'strict_date_time_no_millis',
+        ], $adapter->getIndexMapping());
+    }
+
+    public function testGetSearchIndexMappingFallsBackToTextKeyword(): void
+    {
+        $textKeywordMapping = [
+            'type' => 'text',
+            'fields' => [
+                'keyword' => [
+                    'type' => 'keyword',
+                    'ignore_above' => 1024,
+                ],
+            ],
+        ];
+
+        foreach (['input', 'textarea', 'html'] as $elementType) {
+            $adapter = $this->createAdapter($elementType, $textKeywordMapping);
+
+            $this->assertSame($textKeywordMapping, $adapter->getIndexMapping());
+        }
+    }
+
+    /**
+     * Calculators are free to return loosely typed values (e.g. '0'/'1' from
+     * expression results), which a boolean index mapping would reject.
+     */
+    public function testNormalizeCastsBooleanElementTypeValues(): void
+    {
+        $adapter = $this->createAdapter('boolean');
+
+        $this->assertTrue($adapter->normalize(true));
+        $this->assertFalse($adapter->normalize(false));
+        $this->assertTrue($adapter->normalize('1'));
+        $this->assertFalse($adapter->normalize('0'));
+        $this->assertTrue($adapter->normalize(1));
+        $this->assertFalse($adapter->normalize(0));
+        $this->assertNull($adapter->normalize(null));
+    }
+
+    public function testNormalizeCastsNumericElementTypeValues(): void
+    {
+        $adapter = $this->createAdapter('numeric');
+
+        $this->assertSame(1.5, $adapter->normalize(1.5));
+        $this->assertSame(3.0, $adapter->normalize(3));
+        $this->assertSame(2.25, $adapter->normalize('2.25'));
+        $this->assertNull($adapter->normalize('not a number'));
+        $this->assertNull($adapter->normalize(null));
+    }
+
+    public function testNormalizeFormatsDateElementTypeValues(): void
+    {
+        $adapter = $this->createAdapter('date');
+
+        $this->assertSame(
+            '2024-06-15T10:30:00+00:00',
+            $adapter->normalize(Carbon::create(2024, 6, 15, 10, 30, 0, 'UTC'))
+        );
+        $this->assertNull($adapter->normalize('2024-06-15'));
+        $this->assertNull($adapter->normalize(null));
+    }
+
+    public function testNormalizeKeepsTextElementTypeBehavior(): void
+    {
+        $adapter = $this->createAdapter('html');
+
+        $this->assertSame(
+            '<img  alt="test">',
+            $adapter->normalize('<img src="data:image/png;base64,iVBORw0KGgo=" alt="test">')
+        );
+        $this->assertSame('plain text', $adapter->normalize('plain text'));
+    }
+
+    private function createAdapter(string $elementType, array $textKeywordMapping = []): CalculatedValueAdapter
+    {
+        $indexMappingServiceMock = $this->makeEmpty(IndexMappingServiceInterface::class, [
+            'getMappingForTextKeyword' => $textKeywordMapping,
+        ]);
+
+        $adapter = new CalculatedValueAdapter(
+            $this->makeEmpty(SearchIndexConfigServiceInterface::class),
+            $this->makeEmpty(FieldDefinitionServiceInterface::class),
+            $indexMappingServiceMock
+        );
+
+        $fieldDefinition = new CalculatedValue();
+        $fieldDefinition->setElementType($elementType);
+        $adapter->setFieldDefinition($fieldDefinition);
+
+        return $adapter;
+    }
+}

--- a/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/CalculatedValueAdapterTest.php
+++ b/tests/Unit/SearchIndexAdapter/DataObject/FieldDefinitionAdapter/CalculatedValueAdapterTest.php
@@ -87,6 +87,11 @@ final class CalculatedValueAdapterTest extends Unit
         $this->assertFalse($adapter->normalize('0'));
         $this->assertTrue($adapter->normalize(1));
         $this->assertFalse($adapter->normalize(0));
+        $this->assertTrue($adapter->normalize('true'));
+        $this->assertFalse($adapter->normalize('false'));
+        $this->assertTrue($adapter->normalize('yes'));
+        $this->assertFalse($adapter->normalize('no'));
+        $this->assertNull($adapter->normalize('not a boolean'));
         $this->assertNull($adapter->normalize(null));
     }
 


### PR DESCRIPTION
Fixes pimcore/platform-version#293

### Problem

Calculated value fields are always indexed with the generic text/keyword mapping, regardless of their configured element type (`calculatedValue` is registered on `TextKeywordAdapter` in `field-definition-adapters.yml`).

For a `CalculatedValue` field with `elementType: 'boolean'` this creates a `text` mapping with ngram/keyword/sort subfields in the search index. Term queries, aggregations and boolean filters on the field then behave like text search, and the Studio data object grid boolean filter on such a field stops working.

#### Reproduction

1. Class definition with a `CalculatedValue` field configured with `elementType: 'boolean'`
2. Run `bin/console generic-data-index:update:index`
3. `GET <index>/_mapping/field/standard_fields.<fieldname>` returns `text` (with ngram/keyword/sort subfields) instead of `boolean`

### Solution

Add a dedicated `CalculatedValueAdapter` that maps the field according to its configured element type:

| elementType | index mapping |
| --- | --- |
| `boolean` | `boolean` |
| `numeric` | `float` |
| `date` | `date` (`strict_date_time_no_millis`) |
| `input` / `textarea` / `html` (default) | text/keyword (behavior unchanged) |

Values are normalized per element type, since calculators are free to return loosely typed values (e.g. `'0'`/`'1'` strings from expression results, which a boolean mapping would reject). For the text-based element types the existing `TextKeywordAdapter` normalization (base64 `src` stripping) is preserved.

Covered by unit tests (`CalculatedValueAdapterTest`). Verified end-to-end on Elasticsearch 8.19: after this change `generic-data-index:update:index` creates the new index version with a `boolean` mapping and reindexing succeeds.
