### PR TITLE
[Bug, EC] PEES-1450: Transient search cluster failures must not trigger forced index recreation

### DIFF
--- a/doc/01_Installation/02_Upgrade.md
+++ b/doc/01_Installation/02_Upgrade.md
@@ -2,6 +2,15 @@
 
 Following steps are necessary during updating to newer versions.
 
+## Upgrade to 2.5.8
+- [Indexing] A failed native reindex no longer triggers a forced recreation of the live index. Recreation now only
+  happens when the reindex reports that the existing documents are incompatible with the new mapping (e.g. after a
+  field type change); genuine errors — unreachable search cluster, timeouts, rejected requests — propagate and fail
+  the operation instead, so a transient connection failure during deployment can no longer purge the index.
+- [Indexing] Transient failures of single task-status requests during a long-running reindex are now retried instead
+  of aborting the reindex, and an aborted reindex cancels the server-side task before cleaning up its target index.
+- [Indexing] `SearchIndexServiceInterface::reindex()` (`@internal`) now returns a `ReindexResult` enum instead of `void`.
+
 ## Upgrade to 2.5.6
 - [Commands] `generic-data-index:deployment:reindex` and `generic-data-index:reindex` now exit with a non-zero status
   code when reindexing fails, instead of always returning `0`. Deployment pipelines executing these commands will now

--- a/doc/02_Configuration/03_Index_Management.md
+++ b/doc/02_Configuration/03_Index_Management.md
@@ -134,6 +134,32 @@ index data from the database but reindexes data within the search indices.
 bin/console generic-data-index:reindex
 ```
 
+#### Reindex Options
+
+Native reindexing is submitted as an asynchronous task to OpenSearch/Elasticsearch and its progress is polled until
+the task has finished. Two options control how long the process waits:
+
+- **max_polls** (default 720): maximum number of polling attempts before the reindex is aborted
+- **poll_interval** (default 5): seconds to wait between two status polls
+
+With the defaults, a reindex may therefore run for up to one hour (720 × 5 seconds). If reindexing an index takes
+longer than this budget, the command aborts with an error and a non-zero exit code — increase `max_polls` for very
+large indices:
+
+```yaml
+pimcore_generic_data_index:
+    index_service:
+        reindex_settings:
+            max_polls: 720
+            poll_interval: 5
+```
+
+Transient failures while polling (e.g. a temporarily unreachable or overloaded search cluster) are retried and do not
+abort a running reindex. If reindexing fails for a different reason — the cluster is unreachable, the task reports an
+error or times out server-side — the command fails instead of modifying the live index, and the reindex is retried on
+the next run. The index is only recreated (and repopulated via the index queue) when the already indexed documents are
+incompatible with the new mapping, for example after a field type change.
+
 ### Handling Failed Messages
 
 By default, the messenger will retry failed messages 3 times and then send them into the failed queue `pimcore_generic_data_index_failed`.

--- a/src/Enum/SearchIndex/ReindexResult.php
+++ b/src/Enum/SearchIndex/ReindexResult.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex;
+
+/**
+ * Outcome of a native reindex into a freshly created index version.
+ *
+ * MAPPING_INCOMPATIBLE is an expected alternative outcome, not an error: the
+ * existing documents cannot be indexed into the new mapping (e.g. after a field
+ * type change), so the caller may decide to recreate the index and re-populate
+ * it from the primary data source. Genuine errors (unreachable cluster,
+ * timeouts, rejected requests) are thrown as exceptions instead — they must
+ * never be answered with index recreation.
+ *
+ * @internal
+ */
+enum ReindexResult
+{
+    case SUCCESS;
+    case MAPPING_INCOMPATIBLE;
+}

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -155,10 +155,11 @@ final class DefaultSearchService implements SearchIndexServiceInterface
                 $this->deleteIndex($newIndexName, true);
             } else {
                 $this->logger->warning(sprintf(
-                    'Keeping index "%s": reindex task %s could not be confirmed as cancelled and may still write'
-                    . ' into it. The index is cleaned up by the next reindex.',
+                    'Keeping index "%s": %s may still write into it. The index is cleaned up by the next reindex.',
                     $newIndexName,
                     $taskId
+                        ? sprintf('reindex task %s could not be confirmed as cancelled and', $taskId)
+                        : 'the reindex submission was not confirmed, so an unknown task'
                 ));
             }
 

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch
 
 use Exception;
 use JsonException;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ReindexResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DefaultSearch\ReindexFailedException;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DefaultSearch\SearchFailedException;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\SwitchIndexAliasException;
@@ -39,6 +40,8 @@ final class DefaultSearchService implements SearchIndexServiceInterface
     public const INDEX_VERSION_ODD = 'odd';
 
     public const INDEX_VERSION_EVEN = 'even';
+
+    private const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 
     use LoggerAwareTrait;
 
@@ -94,7 +97,7 @@ final class DefaultSearchService implements SearchIndexServiceInterface
     /**
      * @throws Exception
      */
-    public function reindex(string $indexName, array $mapping): void
+    public function reindex(string $indexName, array $mapping): ReindexResult
     {
         $currentIndexVersion = $this->getCurrentIndexVersion($indexName);
         $newIndexVersion = $currentIndexVersion === self::INDEX_VERSION_EVEN
@@ -115,6 +118,8 @@ final class DefaultSearchService implements SearchIndexServiceInterface
             ],
         ];
 
+        $taskId = null;
+
         try {
             // Submit reindex as async task to avoid HTTP timeout on large indices
             $response = $this->client->reIndex([
@@ -129,22 +134,70 @@ final class DefaultSearchService implements SearchIndexServiceInterface
                 );
             }
 
-            $this->waitForTask($taskId);
-            $this->switchIndexAliasAndCleanup($indexName, $oldIndexName, $newIndexName);
+            $taskStatus = $this->waitForTaskCompletion($taskId);
         } catch (\Throwable $e) {
+            $this->cancelTask($taskId);
             $this->deleteIndex($newIndexName, true);
 
             throw $e;
         }
+
+        // Per-document failures mean the existing documents cannot be indexed into
+        // the new mapping (e.g. after a field type change). This is an expected
+        // outcome of a mapping change, not an error: report it as a result so the
+        // caller can decide to recreate the index.
+        $failures = $taskStatus['response']['failures'] ?? [];
+        if (!empty($failures)) {
+            $this->logger->warning(sprintf(
+                'Reindex from "%s" to "%s" is not possible with the existing documents: %s',
+                $oldIndexName,
+                $newIndexName,
+                json_encode(array_slice($failures, 0, 5), JSON_PARTIAL_OUTPUT_ON_ERROR)
+            ));
+            $this->deleteIndex($newIndexName, true);
+
+            return ReindexResult::MAPPING_INCOMPATIBLE;
+        }
+
+        $this->switchIndexAliasAndCleanup($indexName, $oldIndexName, $newIndexName);
+
+        return ReindexResult::SUCCESS;
     }
 
     /**
+     * Polls the task status until the task completes. Transient failures of single
+     * status requests are retried — a long-running reindex puts load on the cluster,
+     * so occasional rejected or timed-out requests are expected and must not abort
+     * the operation.
+     *
+     * @return array<string, mixed> the completed task status
+     *
      * @throws ReindexFailedException
      */
-    private function waitForTask(string $taskId): void
+    private function waitForTaskCompletion(string $taskId): array
     {
+        $consecutivePollFailures = 0;
+
         for ($poll = 0; $poll < $this->reindexMaxPolls; $poll++) {
-            $taskStatus = $this->fetchTaskStatus($taskId);
+            try {
+                $taskStatus = $this->fetchTaskStatus($taskId);
+                $consecutivePollFailures = 0;
+            } catch (ReindexFailedException $e) {
+                if (++$consecutivePollFailures >= self::MAX_CONSECUTIVE_POLL_FAILURES) {
+                    throw $e;
+                }
+
+                $this->logger->warning(sprintf(
+                    'Failed to fetch status of reindex task %s (attempt %d of %d): %s',
+                    $taskId,
+                    $consecutivePollFailures,
+                    self::MAX_CONSECUTIVE_POLL_FAILURES,
+                    $e->getMessage()
+                ));
+                sleep($this->reindexPollIntervalSeconds);
+
+                continue;
+            }
 
             if (empty($taskStatus['completed'])) {
                 sleep($this->reindexPollIntervalSeconds);
@@ -159,22 +212,13 @@ final class DefaultSearchService implements SearchIndexServiceInterface
                 );
             }
 
-            // Per-document failures and timed_out live inside response
-            $response = $taskStatus['response'] ?? [];
-
-            if (!empty($response['timed_out'])) {
+            if (!empty($taskStatus['response']['timed_out'])) {
                 throw new ReindexFailedException(
                     "Reindex task timed out server-side for task $taskId"
                 );
             }
 
-            if (!empty($response['failures'])) {
-                throw new ReindexFailedException(
-                    'Reindex task completed with failures: ' . json_encode($response['failures'], JSON_PARTIAL_OUTPUT_ON_ERROR)
-                );
-            }
-
-            return;
+            return $taskStatus;
         }
 
         throw new ReindexFailedException(
@@ -184,6 +228,23 @@ final class DefaultSearchService implements SearchIndexServiceInterface
                 $this->reindexMaxPolls * $this->reindexPollIntervalSeconds
             )
         );
+    }
+
+    /**
+     * Best-effort cancellation of a server-side task before its target index is
+     * deleted, so an aborted reindex does not keep writing into a dropped index.
+     */
+    private function cancelTask(?string $taskId): void
+    {
+        if (!$taskId || !\is_callable([$this->client, 'getOriginalClient'])) {
+            return;
+        }
+
+        try {
+            $this->client->getOriginalClient()->tasks()->cancel(['task_id' => $taskId]);
+        } catch (\Throwable $e) {
+            $this->logger->warning(sprintf('Failed to cancel reindex task %s: %s', $taskId, $e->getMessage()));
+        }
     }
 
     /**

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -277,14 +277,15 @@ final class DefaultSearchService implements SearchIndexServiceInterface
 
     /**
      * Cancels a server-side task so an aborted reindex does not keep writing into
-     * its target index. Returns whether the task is confirmed to no longer write —
-     * either cancelled, never started, or already finished. Only then is it safe
-     * to delete the target index.
+     * its target index. Returns whether the task is confirmed to no longer write.
+     * Only then is it safe to delete the target index.
      */
     private function cancelTask(?string $taskId): bool
     {
         if (!$taskId) {
-            return true;
+            // The submission may have been accepted server-side even though its
+            // response never arrived — a task might be running whose ID is unknown.
+            return false;
         }
 
         if (!\is_callable([$this->client, 'getOriginalClient'])) {
@@ -293,10 +294,8 @@ final class DefaultSearchService implements SearchIndexServiceInterface
 
         try {
             $this->client->getOriginalClient()->tasks()->cancel(['task_id' => $taskId]);
-
-            return true;
         } catch (\Throwable $e) {
-            if (str_contains($e->getMessage(), 'resource_not_found')) {
+            if ($this->exceptionIndicatesMissingTask($e)) {
                 // the task already finished — it cannot write anymore
                 return true;
             }
@@ -305,6 +304,35 @@ final class DefaultSearchService implements SearchIndexServiceInterface
 
             return false;
         }
+
+        // Cancellation is cooperative: the task stops between batches. Report the
+        // target as safe to delete only once the task is observed gone or completed.
+        for ($attempt = 0; $attempt < self::MAX_CONSECUTIVE_POLL_FAILURES; $attempt++) {
+            try {
+                $taskStatus = $this->fetchTaskStatus($taskId);
+            } catch (ReindexFailedException $e) {
+                return $this->exceptionIndicatesMissingTask($e);
+            }
+
+            if (!empty($taskStatus['completed'])) {
+                return true;
+            }
+
+            sleep($this->reindexPollIntervalSeconds);
+        }
+
+        return false;
+    }
+
+    private function exceptionIndicatesMissingTask(\Throwable $e): bool
+    {
+        for ($current = $e; $current !== null; $current = $current->getPrevious()) {
+            if (str_contains($current->getMessage(), 'resource_not_found')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -43,6 +43,19 @@ final class DefaultSearchService implements SearchIndexServiceInterface
 
     private const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 
+    /**
+     * Failure cause types that prove the existing documents are structurally
+     * incompatible with the new mapping. Anything else (rejected executions,
+     * cluster blocks, unavailable shards, ...) may be transient and must never
+     * be answered with an index recreation.
+     */
+    private const MAPPING_INCOMPATIBILITY_FAILURE_TYPES = [
+        'mapper_parsing_exception',
+        'mapper_exception',
+        'strict_dynamic_mapping_exception',
+        'document_parsing_exception',
+    ];
+
     use LoggerAwareTrait;
 
     public function __construct(
@@ -136,27 +149,43 @@ final class DefaultSearchService implements SearchIndexServiceInterface
 
             $taskStatus = $this->waitForTaskCompletion($taskId);
         } catch (\Throwable $e) {
-            $this->cancelTask($taskId);
-            $this->deleteIndex($newIndexName, true);
+            if ($this->cancelTask($taskId)) {
+                $this->deleteIndex($newIndexName, true);
+            } else {
+                $this->logger->warning(sprintf(
+                    'Keeping index "%s": reindex task %s could not be confirmed as cancelled and may still write'
+                    . ' into it. The index is cleaned up by the next reindex.',
+                    $newIndexName,
+                    $taskId
+                ));
+            }
 
             throw $e;
         }
 
-        // Per-document failures mean the existing documents cannot be indexed into
-        // the new mapping (e.g. after a field type change). This is an expected
-        // outcome of a mapping change, not an error: report it as a result so the
-        // caller can decide to recreate the index.
+        // The task is completed at this point, so the new index can be deleted safely.
         $failures = $taskStatus['response']['failures'] ?? [];
         if (!empty($failures)) {
-            $this->logger->warning(sprintf(
-                'Reindex from "%s" to "%s" is not possible with the existing documents: %s',
-                $oldIndexName,
-                $newIndexName,
-                json_encode(array_slice($failures, 0, 5), JSON_PARTIAL_OUTPUT_ON_ERROR)
-            ));
             $this->deleteIndex($newIndexName, true);
 
-            return ReindexResult::MAPPING_INCOMPATIBLE;
+            // Only failures that prove a structural mapping incompatibility (e.g.
+            // after a field type change) are an expected outcome the caller may
+            // answer with an index recreation. Everything else may be transient.
+            if ($this->areMappingIncompatibilityFailures($failures)) {
+                $this->logger->warning(sprintf(
+                    'Reindex from "%s" to "%s" is not possible with the existing documents: %s',
+                    $oldIndexName,
+                    $newIndexName,
+                    json_encode(array_slice($failures, 0, 5), JSON_PARTIAL_OUTPUT_ON_ERROR)
+                ));
+
+                return ReindexResult::MAPPING_INCOMPATIBLE;
+            }
+
+            throw new ReindexFailedException(
+                'Reindex task completed with failures: '
+                . json_encode(array_slice($failures, 0, 5), JSON_PARTIAL_OUTPUT_ON_ERROR)
+            );
         }
 
         $this->switchIndexAliasAndCleanup($indexName, $oldIndexName, $newIndexName);
@@ -231,19 +260,49 @@ final class DefaultSearchService implements SearchIndexServiceInterface
     }
 
     /**
-     * Best-effort cancellation of a server-side task before its target index is
-     * deleted, so an aborted reindex does not keep writing into a dropped index.
+     * @param array<int, array<string, mixed>> $failures
      */
-    private function cancelTask(?string $taskId): void
+    private function areMappingIncompatibilityFailures(array $failures): bool
     {
-        if (!$taskId || !\is_callable([$this->client, 'getOriginalClient'])) {
-            return;
+        foreach ($failures as $failure) {
+            $causeType = $failure['cause']['type'] ?? '';
+            if (!\in_array($causeType, self::MAPPING_INCOMPATIBILITY_FAILURE_TYPES, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Cancels a server-side task so an aborted reindex does not keep writing into
+     * its target index. Returns whether the task is confirmed to no longer write —
+     * either cancelled, never started, or already finished. Only then is it safe
+     * to delete the target index.
+     */
+    private function cancelTask(?string $taskId): bool
+    {
+        if (!$taskId) {
+            return true;
+        }
+
+        if (!\is_callable([$this->client, 'getOriginalClient'])) {
+            return false;
         }
 
         try {
             $this->client->getOriginalClient()->tasks()->cancel(['task_id' => $taskId]);
+
+            return true;
         } catch (\Throwable $e) {
+            if (str_contains($e->getMessage(), 'resource_not_found')) {
+                // the task already finished — it cannot write anymore
+                return true;
+            }
+
             $this->logger->warning(sprintf('Failed to cancel reindex task %s: %s', $taskId, $e->getMessage()));
+
+            return false;
         }
     }
 

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -120,6 +120,7 @@ final class DefaultSearchService implements SearchIndexServiceInterface
         $oldIndexName = $indexName . '-' . $currentIndexVersion;
         $newIndexName = $indexName . '-' . $newIndexVersion;
 
+        $this->ensureNoActiveReindexTask($newIndexName);
         $this->createIndex($newIndexName, $mapping);
 
         $body = [
@@ -322,6 +323,60 @@ final class DefaultSearchService implements SearchIndexServiceInterface
         }
 
         return false;
+    }
+
+    /**
+     * A previous aborted attempt may have left a reindex task behind that still
+     * writes into the target name (see cancelTask()). It must be stopped before
+     * the delete-first index creation — otherwise the old writer pollutes the
+     * freshly created index with stale documents.
+     *
+     * @throws ReindexFailedException
+     */
+    private function ensureNoActiveReindexTask(string $targetIndexName): void
+    {
+        if (!\is_callable([$this->client, 'getOriginalClient'])) {
+            return;
+        }
+
+        try {
+            $tasks = $this->client->getOriginalClient()->tasks()->list([
+                'actions' => '*reindex',
+                'detailed' => true,
+            ]);
+
+            if (\is_object($tasks) && \method_exists($tasks, 'asArray')) {
+                $tasks = $tasks->asArray();
+            }
+        } catch (\Throwable $e) {
+            $this->logger->warning(sprintf('Could not check for running reindex tasks: %s', $e->getMessage()));
+
+            return;
+        }
+
+        foreach ($tasks['nodes'] ?? [] as $node) {
+            foreach ($node['tasks'] ?? [] as $taskId => $task) {
+                $description = $task['description'] ?? '';
+                if (!str_contains($description, '[' . $targetIndexName . ']')) {
+                    continue;
+                }
+
+                $this->logger->warning(sprintf(
+                    'Cancelling leftover reindex task %s from an earlier aborted attempt (%s)',
+                    $taskId,
+                    $description
+                ));
+
+                if (!$this->cancelTask((string) $taskId)) {
+                    throw new ReindexFailedException(sprintf(
+                        'A previous reindex task (%s) is still writing into "%s" and could not be stopped;'
+                        . ' retry once it has finished.',
+                        $taskId,
+                        $targetIndexName
+                    ));
+                }
+            }
+        }
     }
 
     private function exceptionIndicatesMissingTask(\Throwable $e): bool

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -335,8 +335,13 @@ final class DefaultSearchService implements SearchIndexServiceInterface
      */
     private function ensureNoActiveReindexTask(string $targetIndexName): void
     {
+        // Without the tasks API the async reindex could never be polled, cancelled
+        // or verified — fail before an index is created or a task is submitted.
         if (!\is_callable([$this->client, 'getOriginalClient'])) {
-            return;
+            throw new ReindexFailedException(
+                'The configured search client does not expose the tasks API'
+                . ' (getOriginalClient()); the asynchronous reindex cannot be tracked.'
+            );
         }
 
         try {
@@ -349,9 +354,15 @@ final class DefaultSearchService implements SearchIndexServiceInterface
                 $tasks = $tasks->asArray();
             }
         } catch (\Throwable $e) {
-            $this->logger->warning(sprintf('Could not check for running reindex tasks: %s', $e->getMessage()));
-
-            return;
+            throw new ReindexFailedException(
+                sprintf(
+                    'Could not verify that no previous reindex task is still writing into "%s": %s',
+                    $targetIndexName,
+                    $e->getMessage()
+                ),
+                0,
+                $e
+            );
         }
 
         foreach ($tasks['nodes'] ?? [] as $node) {

--- a/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/DefaultSearchService.php
@@ -143,7 +143,8 @@ final class DefaultSearchService implements SearchIndexServiceInterface
             $taskId = $response['task'] ?? null;
             if (!$taskId) {
                 throw new ReindexFailedException(
-                    'Reindex did not return a task ID; response: ' . json_encode($response, JSON_PARTIAL_OUTPUT_ON_ERROR)
+                    'Reindex did not return a task ID; response: '
+                    . json_encode($response, JSON_PARTIAL_OUTPUT_ON_ERROR)
                 );
             }
 

--- a/src/SearchIndexAdapter/SearchIndexServiceInterface.php
+++ b/src/SearchIndexAdapter/SearchIndexServiceInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter;
 
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ReindexResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\DefaultSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\AdapterSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
@@ -30,9 +31,14 @@ interface SearchIndexServiceInterface
     public function getCurrentIndexVersion(string $indexName): string;
 
     /**
+     * Reindexes the current index version into a freshly created one with the given
+     * mapping and switches the alias. MAPPING_INCOMPATIBLE is returned when the
+     * existing documents cannot be indexed into the new mapping; genuine errors
+     * (unreachable cluster, timeouts) are thrown.
+     *
      * @throws Exception
      */
-    public function reindex(string $indexName, array $mapping): void;
+    public function reindex(string $indexName, array $mapping): ReindexResult;
 
     public function createIndex(string $indexName, ?array $mappings = null): self;
 

--- a/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
+++ b/src/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandler.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService
 
 use Exception;
 use JsonException;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ReindexResult;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DefaultSearchService;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
@@ -92,26 +93,23 @@ abstract class AbstractIndexHandler implements IndexHandlerInterface
                 mappingProperties: $mappingProperties
             );
         } else {
-            try {
-                $this->searchIndexService->reindex(
-                    $alias,
-                    $mappingProperties
-                );
-            } catch (Exception $e) {
-                try {
-                    $this->updateMapping($context, true, $mappingProperties);
-                } catch (Exception $fallbackException) {
-                    // Both the reindex and the fallback recreation failed: rethrow so the
-                    // failure reaches the caller instead of the mapping checksum being
-                    // stored as if the reindex had succeeded.
-                    $this->logger->error(sprintf(
-                        'Reindexing failed due to following error: %s (initial reindex failure: %s)',
-                        $fallbackException,
-                        $e->getMessage()
-                    ));
+            $reindexResult = $this->searchIndexService->reindex(
+                $alias,
+                $mappingProperties
+            );
 
-                    throw $fallbackException;
-                }
+            if ($reindexResult === ReindexResult::MAPPING_INCOMPATIBLE) {
+                // The new mapping cannot be applied to the existing documents (e.g.
+                // after a field type change): recreate the index with the new mapping;
+                // its content is re-populated from the index queue. Genuine reindex
+                // errors (unreachable cluster, timeouts) are thrown by reindex() and
+                // propagate — recreating the live index in reaction to a transient
+                // failure would destroy all indexed data.
+                $this->logger->warning(sprintf(
+                    'Recreating index for alias "%s": the new mapping is incompatible with the indexed documents',
+                    $alias
+                ));
+                $this->updateMapping($context, true, $mappingProperties);
             }
         }
 

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\SearchIndexAdapter\DefaultSearch;
 
 use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ReindexResult;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DefaultSearch\ReindexFailedException;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DefaultSearchService;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\Search\SearchExecutionServiceInterface;
@@ -140,11 +142,19 @@ final class DefaultSearchServiceReindexTest extends Unit
     }
 
     // -------------------------------------------------------------------------
-    // waitForTask: per-document failures inside response
+    // Per-document failures: expected structural outcome, reported as result
     // -------------------------------------------------------------------------
 
-    public function testReindexThrowsOnPerDocumentFailures(): void
+    /**
+     * Documents that cannot be indexed into the new mapping (e.g. after a field
+     * type change) are an expected outcome, not an error: reported as
+     * MAPPING_INCOMPATIBLE so the caller can decide to recreate the index. The
+     * unusable new index is cleaned up and the alias is left untouched.
+     */
+    public function testReindexReturnsMappingIncompatibleOnPerDocumentFailures(): void
     {
+        $deletedIndices = [];
+
         $client = $this->buildClientWithTaskResponses(
             taskId: 'node:1',
             taskResponses: [
@@ -152,16 +162,102 @@ final class DefaultSearchServiceReindexTest extends Unit
                     'completed' => true,
                     'response' => [
                         'timed_out' => false,
-                        'failures' => [['shard' => 0, 'reason' => 'disk full']],
+                        'failures' => [['index' => 'test_index-even', 'reason' => 'mapper_parsing_exception']],
                     ],
                 ],
-            ]
+            ],
+            onDeleteIndex: static function (array $params) use (&$deletedIndices): array {
+                $deletedIndices[] = $params['index'];
+
+                return [];
+            }
         );
 
-        $this->expectException(ReindexFailedException::class);
-        $this->expectExceptionMessageMatches('/completed with failures/');
+        $result = $this->createService(client: $client)->reindex('test_index', []);
 
-        $this->createService(client: $client)->reindex('test_index', []);
+        $this->assertSame(ReindexResult::MAPPING_INCOMPATIBLE, $result);
+        $this->assertContains('test_index-even', $deletedIndices, 'The unusable new index must be cleaned up');
+    }
+
+    // -------------------------------------------------------------------------
+    // Poll resilience: transient task-status failures are retried
+    // -------------------------------------------------------------------------
+
+    /**
+     * A single failed status request must not abort a long-running reindex —
+     * transient hiccups are expected while _reindex puts load on the cluster.
+     *
+     * @see https://github.com/pimcore/service-operations/issues/1126
+     */
+    public function testReindexRetriesTransientPollFailures(): void
+    {
+        $client = $this->buildClientWithTaskResponses(
+            taskId: 'node:1',
+            taskResponses: [
+                new Exception('cURL error 7: connection refused'),
+                ['completed' => false],
+                new Exception('cURL error 28: request timed out'),
+                ['completed' => true, 'response' => ['timed_out' => false, 'failures' => []]],
+            ],
+            withAliasSwitchSupport: true
+        );
+
+        $result = $this->createService(client: $client, reindexMaxPolls: 10)->reindex('test_index', []);
+
+        $this->assertSame(ReindexResult::SUCCESS, $result);
+    }
+
+    public function testReindexThrowsAfterPersistentPollFailures(): void
+    {
+        $deletedIndices = [];
+
+        $client = $this->buildClientWithTaskResponses(
+            taskId: 'node:1',
+            taskResponses: [
+                new Exception('cURL error 7: connection refused'),
+            ],
+            onDeleteIndex: static function (array $params) use (&$deletedIndices): array {
+                $deletedIndices[] = $params['index'];
+
+                return [];
+            }
+        );
+
+        try {
+            $this->createService(client: $client, reindexMaxPolls: 10)->reindex('test_index', []);
+            $this->fail('Expected ReindexFailedException');
+        } catch (ReindexFailedException) {
+            $this->assertContains('test_index-even', $deletedIndices, 'New index must be cleaned up on failure');
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cleanup: the server-side task is cancelled before the new index is deleted
+    // -------------------------------------------------------------------------
+
+    public function testReindexCancelsServerSideTaskWhenAborting(): void
+    {
+        $tasksStub = new ReindexTestTasksStub([
+            ['completed' => false],
+            new Exception('connection lost'),
+        ]);
+
+        $client = new ReindexTestSearchClientStub(
+            originalClient: new ReindexTestOriginalClientStub($tasksStub),
+            taskId: 'node:42',
+            existsIndexValue: false,
+        );
+
+        try {
+            $this->createService(client: $client, reindexMaxPolls: 10)->reindex('test_index', []);
+            $this->fail('Expected ReindexFailedException');
+        } catch (ReindexFailedException) {
+            $this->assertSame(
+                ['node:42'],
+                $tasksStub->cancelledTasks,
+                'The still-running server-side task must be cancelled before its target index is deleted'
+            );
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -185,8 +281,9 @@ final class DefaultSearchServiceReindexTest extends Unit
             }
         );
 
-        // Must not throw
-        $this->createService(client: $client)->reindex('test_index', []);
+        $result = $this->createService(client: $client)->reindex('test_index', []);
+
+        $this->assertSame(ReindexResult::SUCCESS, $result);
 
         // No alias exists → currentVersion='', newIndexName='test_index-even'.
         // createIndex() silently deletes test_index-even before recreating it.
@@ -210,8 +307,8 @@ final class DefaultSearchServiceReindexTest extends Unit
             withAliasSwitchSupport: true
         );
 
-        $this->createService(client: $client, reindexMaxPolls: 5)->reindex('test_index', []);
-        $this->assertTrue(true);
+        $result = $this->createService(client: $client, reindexMaxPolls: 5)->reindex('test_index', []);
+        $this->assertSame(ReindexResult::SUCCESS, $result);
     }
 
     // -------------------------------------------------------------------------
@@ -478,10 +575,16 @@ final class ReindexTestSearchClientStub implements SearchClientInterface
     }
 }
 
-/** Stubs for the task polling chain: getOriginalClient()->tasks()->get() */
+/**
+ * Stubs for the task polling chain: getOriginalClient()->tasks()->get().
+ * A Throwable entry in $responses simulates a failed status request.
+ */
 final class ReindexTestTasksStub
 {
     private int $callCount = 0;
+
+    /** @var array<int, mixed> */
+    public array $cancelledTasks = [];
 
     public function __construct(private readonly array $responses)
     {
@@ -492,7 +595,18 @@ final class ReindexTestTasksStub
         $response = $this->responses[$this->callCount] ?? end($this->responses);
         $this->callCount++;
 
+        if ($response instanceof \Throwable) {
+            throw $response;
+        }
+
         return $response;
+    }
+
+    public function cancel(array $params): array
+    {
+        $this->cancelledTasks[] = $params['task_id'] ?? null;
+
+        return [];
     }
 }
 

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
@@ -151,7 +151,7 @@ final class DefaultSearchServiceReindexTest extends Unit
      * MAPPING_INCOMPATIBLE so the caller can decide to recreate the index. The
      * unusable new index is cleaned up and the alias is left untouched.
      */
-    public function testReindexReturnsMappingIncompatibleOnPerDocumentFailures(): void
+    public function testReindexReturnsMappingIncompatibleOnStructuralDocumentFailures(): void
     {
         $deletedIndices = [];
 
@@ -162,7 +162,20 @@ final class DefaultSearchServiceReindexTest extends Unit
                     'completed' => true,
                     'response' => [
                         'timed_out' => false,
-                        'failures' => [['index' => 'test_index-even', 'reason' => 'mapper_parsing_exception']],
+                        'failures' => [
+                            [
+                                'index' => 'test_index-even',
+                                'id' => '42',
+                                'cause' => ['type' => 'mapper_parsing_exception', 'reason' => 'failed to parse field'],
+                                'status' => 400,
+                            ],
+                            [
+                                'index' => 'test_index-even',
+                                'id' => '43',
+                                'cause' => ['type' => 'strict_dynamic_mapping_exception', 'reason' => 'mapping not allowed'],
+                                'status' => 400,
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -177,6 +190,67 @@ final class DefaultSearchServiceReindexTest extends Unit
 
         $this->assertSame(ReindexResult::MAPPING_INCOMPATIBLE, $result);
         $this->assertContains('test_index-even', $deletedIndices, 'The unusable new index must be cleaned up');
+    }
+
+    /**
+     * The bulk-failure list can also contain transient causes (rejected executions,
+     * disk watermark blocks, unavailable shards). Those must never be reported as
+     * MAPPING_INCOMPATIBLE — the caller would recreate the live index over a
+     * temporary cluster condition.
+     */
+    public function testReindexThrowsOnTransientDocumentFailures(): void
+    {
+        $client = $this->buildClientWithTaskResponses(
+            taskId: 'node:1',
+            taskResponses: [
+                [
+                    'completed' => true,
+                    'response' => [
+                        'timed_out' => false,
+                        'failures' => [
+                            [
+                                'index' => 'test_index-even',
+                                'id' => '42',
+                                'cause' => ['type' => 'es_rejected_execution_exception', 'reason' => 'queue full'],
+                                'status' => 429,
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->expectException(ReindexFailedException::class);
+        $this->expectExceptionMessageMatches('/completed with failures/');
+
+        $this->createService(client: $client)->reindex('test_index', []);
+    }
+
+    public function testReindexThrowsOnMixedDocumentFailures(): void
+    {
+        $client = $this->buildClientWithTaskResponses(
+            taskId: 'node:1',
+            taskResponses: [
+                [
+                    'completed' => true,
+                    'response' => [
+                        'timed_out' => false,
+                        'failures' => [
+                            [
+                                'cause' => ['type' => 'mapper_parsing_exception', 'reason' => 'failed to parse'],
+                            ],
+                            [
+                                'cause' => ['type' => 'cluster_block_exception', 'reason' => 'disk watermark exceeded'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->expectException(ReindexFailedException::class);
+
+        $this->createService(client: $client)->reindex('test_index', []);
     }
 
     // -------------------------------------------------------------------------
@@ -237,6 +311,7 @@ final class DefaultSearchServiceReindexTest extends Unit
 
     public function testReindexCancelsServerSideTaskWhenAborting(): void
     {
+        $deletedIndices = [];
         $tasksStub = new ReindexTestTasksStub([
             ['completed' => false],
             new Exception('connection lost'),
@@ -245,7 +320,11 @@ final class DefaultSearchServiceReindexTest extends Unit
         $client = new ReindexTestSearchClientStub(
             originalClient: new ReindexTestOriginalClientStub($tasksStub),
             taskId: 'node:42',
-            existsIndexValue: false,
+            onDeleteIndex: static function (array $params) use (&$deletedIndices): array {
+                $deletedIndices[] = $params['index'];
+
+                return [];
+            },
         );
 
         try {
@@ -257,7 +336,90 @@ final class DefaultSearchServiceReindexTest extends Unit
                 $tasksStub->cancelledTasks,
                 'The still-running server-side task must be cancelled before its target index is deleted'
             );
+            // one delete from createIndex() (delete-first), one from the abort cleanup
+            $this->assertSame(
+                2,
+                $this->countDeletes($deletedIndices, 'test_index-even'),
+                'The target index is safe to delete after confirmed cancellation'
+            );
         }
+    }
+
+    /**
+     * If the cancellation cannot be confirmed (e.g. the same outage that aborted the
+     * polling), the target index must be kept — the still-running server-side task
+     * would otherwise auto-recreate the dropped index and keep writing into it. The
+     * leftover index is removed by the next reindex attempt.
+     */
+    public function testReindexKeepsNewIndexWhenTaskCancellationIsUnconfirmed(): void
+    {
+        $deletedIndices = [];
+        $tasksStub = new ReindexTestTasksStub([
+            new Exception('connection refused'),
+        ]);
+        $tasksStub->cancelException = new Exception('connection refused');
+
+        $client = new ReindexTestSearchClientStub(
+            originalClient: new ReindexTestOriginalClientStub($tasksStub),
+            taskId: 'node:42',
+            onDeleteIndex: static function (array $params) use (&$deletedIndices): array {
+                $deletedIndices[] = $params['index'];
+
+                return [];
+            },
+        );
+
+        try {
+            $this->createService(client: $client, reindexMaxPolls: 10)->reindex('test_index', []);
+            $this->fail('Expected ReindexFailedException');
+        } catch (ReindexFailedException) {
+            // only the delete-first inside createIndex(); NO abort cleanup delete
+            $this->assertSame(
+                1,
+                $this->countDeletes($deletedIndices, 'test_index-even'),
+                'The target index must be kept while the server-side task may still write into it'
+            );
+        }
+    }
+
+    public function testReindexTreatsAlreadyFinishedTaskAsCancelled(): void
+    {
+        $deletedIndices = [];
+        $tasksStub = new ReindexTestTasksStub([
+            new Exception('connection refused'),
+        ]);
+        $tasksStub->cancelException = new Exception(
+            '{"error":{"type":"resource_not_found_exception","reason":"task [node:42] is not found"}}'
+        );
+
+        $client = new ReindexTestSearchClientStub(
+            originalClient: new ReindexTestOriginalClientStub($tasksStub),
+            taskId: 'node:42',
+            onDeleteIndex: static function (array $params) use (&$deletedIndices): array {
+                $deletedIndices[] = $params['index'];
+
+                return [];
+            },
+        );
+
+        try {
+            $this->createService(client: $client, reindexMaxPolls: 10)->reindex('test_index', []);
+            $this->fail('Expected ReindexFailedException');
+        } catch (ReindexFailedException) {
+            $this->assertSame(
+                2,
+                $this->countDeletes($deletedIndices, 'test_index-even'),
+                'A task that no longer exists cannot write anymore — the target index is safe to delete'
+            );
+        }
+    }
+
+    /**
+     * @param array<int, string> $deletedIndices
+     */
+    private function countDeletes(array $deletedIndices, string $indexName): int
+    {
+        return count(array_filter($deletedIndices, static fn (string $name): bool => $name === $indexName));
     }
 
     // -------------------------------------------------------------------------
@@ -586,6 +748,8 @@ final class ReindexTestTasksStub
     /** @var array<int, mixed> */
     public array $cancelledTasks = [];
 
+    public ?\Throwable $cancelException = null;
+
     public function __construct(private readonly array $responses)
     {
     }
@@ -605,6 +769,10 @@ final class ReindexTestTasksStub
     public function cancel(array $params): array
     {
         $this->cancelledTasks[] = $params['task_id'] ?? null;
+
+        if ($this->cancelException !== null) {
+            throw $this->cancelException;
+        }
 
         return [];
     }

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
@@ -172,7 +172,7 @@ final class DefaultSearchServiceReindexTest extends Unit
                             [
                                 'index' => 'test_index-even',
                                 'id' => '43',
-                                'cause' => ['type' => 'strict_dynamic_mapping_exception', 'reason' => 'mapping not allowed'],
+                                'cause' => ['type' => 'strict_dynamic_mapping_exception', 'reason' => 'not allowed'],
                                 'status' => 400,
                             ],
                         ],

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
@@ -492,6 +492,78 @@ final class DefaultSearchServiceReindexTest extends Unit
         }
     }
 
+    // -------------------------------------------------------------------------
+    // Pre-flight: leftover task from an earlier aborted attempt
+    // -------------------------------------------------------------------------
+
+    /**
+     * When a previous attempt aborted without confirmed cancellation, its task may
+     * still write into the target name. Before the delete-first index creation, a
+     * still-running writer must be stopped — otherwise it pollutes the new index.
+     */
+    public function testReindexCancelsLeftoverTaskWritingIntoTarget(): void
+    {
+        $tasksStub = new ReindexTestTasksStub([
+            ['completed' => true], // verification of the cancelled leftover task
+            ['completed' => true, 'response' => ['timed_out' => false, 'failures' => []]],
+        ]);
+        $tasksStub->listResponse = [
+            'nodes' => [
+                'node1' => [
+                    'tasks' => [
+                        'node1:99' => [
+                            'action' => 'indices:data/write/reindex',
+                            'description' => 'reindex from [test_index-odd] to [test_index-even]',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $client = new ReindexTestSearchClientStub(
+            originalClient: new ReindexTestOriginalClientStub($tasksStub),
+            taskId: 'node:1',
+            withAliasSwitchSupport: true,
+        );
+
+        $result = $this->createService(client: $client)->reindex('test_index', []);
+
+        $this->assertSame(ReindexResult::SUCCESS, $result);
+        $this->assertContains(
+            'node1:99',
+            $tasksStub->cancelledTasks,
+            'A leftover task still writing into the target must be cancelled before the index is recreated'
+        );
+    }
+
+    public function testReindexThrowsWhenLeftoverTaskCannotBeStopped(): void
+    {
+        $tasksStub = new ReindexTestTasksStub([]);
+        $tasksStub->listResponse = [
+            'nodes' => [
+                'node1' => [
+                    'tasks' => [
+                        'node1:99' => [
+                            'action' => 'indices:data/write/reindex',
+                            'description' => 'reindex from [test_index-odd] to [test_index-even]',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $tasksStub->cancelException = new Exception('connection refused');
+
+        $client = new ReindexTestSearchClientStub(
+            originalClient: new ReindexTestOriginalClientStub($tasksStub),
+            taskId: 'node:1',
+        );
+
+        $this->expectException(ReindexFailedException::class);
+        $this->expectExceptionMessageMatches('/still writing/');
+
+        $this->createService(client: $client)->reindex('test_index', []);
+    }
+
     /**
      * @param array<int, string> $deletedIndices
      */
@@ -828,8 +900,16 @@ final class ReindexTestTasksStub
 
     public ?\Throwable $cancelException = null;
 
+    /** @var array<string, mixed> */
+    public array $listResponse = [];
+
     public function __construct(private readonly array $responses)
     {
+    }
+
+    public function list(array $params = []): array
+    {
+        return $this->listResponse;
     }
 
     public function get(array $params): mixed

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\SearchIndexAdapter\DefaultSearch;
 
+use Codeception\Stub\Expected;
 use Codeception\Test\Unit;
 use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ReindexResult;
@@ -35,11 +36,11 @@ final class DefaultSearchServiceReindexTest extends Unit
 
     public function testReindexThrowsWhenResponseMissingTaskId(): void
     {
-        $client = $this->makeEmpty(SearchClientInterface::class, [
-            'existsIndex' => false,
-            'createIndex' => [],
-            'reIndex' => ['acknowledged' => true], // no 'task' key
-        ]);
+        $client = new ReindexTestSearchClientStub(
+            originalClient: new ReindexTestOriginalClientStub(new ReindexTestTasksStub([])),
+            taskId: 'unused',
+        );
+        $client->reindexResponseOverride = ['acknowledged' => true]; // no 'task' key
 
         $this->expectException(ReindexFailedException::class);
         $this->expectExceptionMessageMatches('/did not return a task ID/');
@@ -49,11 +50,11 @@ final class DefaultSearchServiceReindexTest extends Unit
 
     public function testReindexThrowsWhenTaskIdIsEmpty(): void
     {
-        $client = $this->makeEmpty(SearchClientInterface::class, [
-            'existsIndex' => false,
-            'createIndex' => [],
-            'reIndex' => ['task' => ''],
-        ]);
+        $client = new ReindexTestSearchClientStub(
+            originalClient: new ReindexTestOriginalClientStub(new ReindexTestTasksStub([])),
+            taskId: 'unused',
+        );
+        $client->reindexResponseOverride = ['task' => ''];
 
         $this->expectException(ReindexFailedException::class);
         $this->expectExceptionMessageMatches('/did not return a task ID/');
@@ -65,20 +66,43 @@ final class DefaultSearchServiceReindexTest extends Unit
     // fetchTaskStatus: client without getOriginalClient()
     // -------------------------------------------------------------------------
 
-    public function testReindexThrowsWhenClientLacksGetOriginalClient(): void
+    /**
+     * Without the tasks API the async reindex could never be tracked, cancelled or
+     * verified — it must fail before any index is created or task submitted, not
+     * after kicking off an orphaned writer.
+     */
+    public function testReindexFailsFastWhenClientLacksTaskApi(): void
     {
         // Plain SearchClientInterface has no getOriginalClient() — duck-typing check fails
         $client = $this->makeEmpty(SearchClientInterface::class, [
-            'existsIndex' => false,
-            'createIndex' => [],
-            'reIndex' => ['task' => 'node:42'],
-            'deleteIndex' => [],
+            'createIndex' => Expected::never(),
+            'reIndex' => Expected::never(),
+            'deleteIndex' => Expected::never(),
         ]);
 
         $this->expectException(ReindexFailedException::class);
-        $this->expectExceptionMessageMatches('/getOriginalClient/');
+        $this->expectExceptionMessageMatches('/tasks API/');
 
         $this->createService(client: $client)->reindex('test_index', []);
+    }
+
+    public function testReindexFailsFastWhenLeftoverTaskCheckFails(): void
+    {
+        $tasksStub = new ReindexTestTasksStub([]);
+        $tasksStub->listException = new Exception('cURL error 7: connection refused');
+
+        $client = new ReindexTestSearchClientStub(
+            originalClient: new ReindexTestOriginalClientStub($tasksStub),
+            taskId: 'node:1',
+        );
+
+        try {
+            $this->createService(client: $client)->reindex('test_index', []);
+            $this->fail('Expected ReindexFailedException');
+        } catch (ReindexFailedException $e) {
+            $this->assertMatchesRegularExpression('/verify/i', $e->getMessage());
+            $this->assertSame(0, $client->createIndexCalls, 'No index may be created when the check fails');
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -324,16 +348,16 @@ final class DefaultSearchServiceReindexTest extends Unit
     {
         $deletedIndices = [];
 
-        $client = $this->makeEmpty(SearchClientInterface::class, [
-            'existsIndex' => true,
-            'createIndex' => [],
-            'reIndex' => ['acknowledged' => true], // no 'task' key — outcome unknown
-            'deleteIndex' => function (array $params) use (&$deletedIndices): array {
+        $client = new ReindexTestSearchClientStub(
+            originalClient: new ReindexTestOriginalClientStub(new ReindexTestTasksStub([])),
+            taskId: 'node:1',
+            onDeleteIndex: static function (array $params) use (&$deletedIndices): array {
                 $deletedIndices[] = $params['index'];
 
                 return [];
             },
-        ]);
+        );
+        $client->reindexResponseOverride = ['acknowledged' => true]; // no 'task' key — outcome unknown
 
         try {
             $this->createService(client: $client)->reindex('test_index', []);
@@ -726,6 +750,10 @@ final class DefaultSearchServiceReindexTest extends Unit
  */
 final class ReindexTestSearchClientStub implements SearchClientInterface
 {
+    public ?array $reindexResponseOverride = null;
+
+    public int $createIndexCalls = 0;
+
     public function __construct(
         private readonly object $originalClient,
         private readonly string $taskId,
@@ -748,7 +776,7 @@ final class ReindexTestSearchClientStub implements SearchClientInterface
 
     public function reIndex(array $_params): array
     {
-        return ['task' => $this->taskId];
+        return $this->reindexResponseOverride ?? ['task' => $this->taskId];
     }
 
     public function deleteIndex(array $params): array
@@ -813,6 +841,8 @@ final class ReindexTestSearchClientStub implements SearchClientInterface
 
     public function createIndex(array $_params): array
     {
+        $this->createIndexCalls++;
+
         return [];
     }
 
@@ -903,12 +933,18 @@ final class ReindexTestTasksStub
     /** @var array<string, mixed> */
     public array $listResponse = [];
 
+    public ?\Throwable $listException = null;
+
     public function __construct(private readonly array $responses)
     {
     }
 
     public function list(array $params = []): array
     {
+        if ($this->listException !== null) {
+            throw $this->listException;
+        }
+
         return $this->listResponse;
     }
 

--- a/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
+++ b/tests/Unit/SearchIndexAdapter/DefaultSearch/DefaultSearchServiceReindexTest.php
@@ -301,7 +301,13 @@ final class DefaultSearchServiceReindexTest extends Unit
             $this->createService(client: $client, reindexMaxPolls: 10)->reindex('test_index', []);
             $this->fail('Expected ReindexFailedException');
         } catch (ReindexFailedException) {
-            $this->assertContains('test_index-even', $deletedIndices, 'New index must be cleaned up on failure');
+            // the cluster is unreachable, so the cancellation cannot be confirmed
+            // either — the target index is kept for the next attempt's cleanup
+            $this->assertSame(
+                1,
+                $this->countDeletes($deletedIndices, 'test_index-even'),
+                'The target index must be kept while the task state is unknown'
+            );
         }
     }
 
@@ -309,12 +315,84 @@ final class DefaultSearchServiceReindexTest extends Unit
     // Cleanup: the server-side task is cancelled before the new index is deleted
     // -------------------------------------------------------------------------
 
+    /**
+     * The kickoff request can be accepted server-side while the client fails to
+     * receive the response — a task may be running whose ID was never learned.
+     * Without a task ID the target must be kept, not deleted under an unknown writer.
+     */
+    public function testReindexKeepsNewIndexWhenTaskIdIsUnknown(): void
+    {
+        $deletedIndices = [];
+
+        $client = $this->makeEmpty(SearchClientInterface::class, [
+            'existsIndex' => true,
+            'createIndex' => [],
+            'reIndex' => ['acknowledged' => true], // no 'task' key — outcome unknown
+            'deleteIndex' => function (array $params) use (&$deletedIndices): array {
+                $deletedIndices[] = $params['index'];
+
+                return [];
+            },
+        ]);
+
+        try {
+            $this->createService(client: $client)->reindex('test_index', []);
+            $this->fail('Expected ReindexFailedException');
+        } catch (ReindexFailedException) {
+            $this->assertSame(
+                1,
+                $this->countDeletes($deletedIndices, 'test_index-even'),
+                'Without a known task ID the target index must be kept — a task may still write into it'
+            );
+        }
+    }
+
+    /**
+     * Cancellation is cooperative: the cancel API only flags the task, which stops
+     * between batches. As long as the task is still observable as running, the
+     * target must be kept.
+     */
+    public function testReindexKeepsNewIndexWhenCancelledTaskIsStillRunning(): void
+    {
+        $deletedIndices = [];
+        $tasksStub = new ReindexTestTasksStub([
+            new Exception('connection refused'),
+            new Exception('connection refused'),
+            new Exception('connection refused'),
+            ['completed' => false], // post-cancel verification: still running
+        ]);
+
+        $client = new ReindexTestSearchClientStub(
+            originalClient: new ReindexTestOriginalClientStub($tasksStub),
+            taskId: 'node:42',
+            onDeleteIndex: static function (array $params) use (&$deletedIndices): array {
+                $deletedIndices[] = $params['index'];
+
+                return [];
+            },
+        );
+
+        try {
+            $this->createService(client: $client, reindexMaxPolls: 10)->reindex('test_index', []);
+            $this->fail('Expected ReindexFailedException');
+        } catch (ReindexFailedException) {
+            $this->assertSame(
+                1,
+                $this->countDeletes($deletedIndices, 'test_index-even'),
+                'The target index must be kept while the cancelled task is still observable as running'
+            );
+        }
+    }
+
     public function testReindexCancelsServerSideTaskWhenAborting(): void
     {
         $deletedIndices = [];
         $tasksStub = new ReindexTestTasksStub([
             ['completed' => false],
             new Exception('connection lost'),
+            new Exception('connection lost'),
+            new Exception('connection lost'),
+            ['completed' => true], // post-cancel verification: task stopped
         ]);
 
         $client = new ReindexTestSearchClientStub(

--- a/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
+++ b/tests/Unit/Service/SearchIndex/IndexService/IndexHandler/AbstractIndexHandlerTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Service\SearchIndex\IndexService\IndexHandler;
 
+use Codeception\Stub\Expected;
 use Codeception\Test\Unit;
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\ReindexResult;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexMappingServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler\AbstractIndexHandler;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
-use Psr\Log\AbstractLogger;
 use Psr\Log\NullLogger;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -78,25 +79,21 @@ final class AbstractIndexHandlerTest extends Unit
      *
      * @see https://github.com/pimcore/service-operations/issues/853
      */
-    public function testReindexMappingRethrowsWhenFallbackRecreationAlsoFails(): void
+    public function testReindexMappingPropagatesRecreationFailures(): void
     {
-        $reindexException = new Exception('initial reindex failure (504 Gateway Time-out)');
-        $fallbackException = new Exception('fallback recreation failed');
+        $recreationException = new Exception('index recreation failed');
 
         $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
             'existsAlias' => true,
             'getCurrentIndexVersion' => '',
-            'reindex' => static function () use ($reindexException): void {
-                throw $reindexException;
-            },
-            'createIndex' => static function () use ($fallbackException): void {
-                throw $fallbackException;
+            'reindex' => ReindexResult::MAPPING_INCOMPATIBLE,
+            'createIndex' => static function () use ($recreationException): void {
+                throw $recreationException;
             },
         ]);
 
-        $logger = $this->createCollectingLogger();
         $handler = $this->createHandlerWithService($searchIndexService);
-        $handler->setLogger($logger);
+        $handler->setLogger(new NullLogger());
 
         $thrown = null;
 
@@ -107,27 +104,58 @@ final class AbstractIndexHandlerTest extends Unit
         }
 
         $this->assertSame(
-            $fallbackException,
+            $recreationException,
             $thrown,
-            'Expected the fallback exception to propagate out of reindexMapping()'
-        );
-
-        $errorLogs = array_filter($logger->records, static fn (array $r): bool => $r['level'] === 'error');
-        $this->assertNotEmpty($errorLogs, 'The failure must still be logged');
-        $loggedMessage = implode(' | ', array_column($errorLogs, 'message'));
-        $this->assertStringContainsString(
-            'initial reindex failure',
-            $loggedMessage,
-            'The original reindex exception must not be lost through variable shadowing'
+            'A failed index recreation must propagate so the mapping checksum is not stored'
         );
     }
 
     /**
-     * The fallback to a forced index recreation is the designed recovery for mapping
-     * changes that cannot be applied via reindex. When it succeeds, no exception
-     * may propagate.
+     * A transient failure (unreachable cluster, timeout, rejected request) must
+     * propagate without touching any index. Recreating the live index in reaction
+     * to a transient error destroys all indexed data.
+     *
+     * @see https://github.com/pimcore/service-operations/issues/1126
      */
-    public function testReindexMappingRecoversWhenFallbackRecreationSucceeds(): void
+    public function testReindexMappingPropagatesTransientFailuresWithoutTouchingIndices(): void
+    {
+        $transientException = new Exception('No alive nodes found in your cluster');
+
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => true,
+            'getCurrentIndexVersion' => '',
+            'reindex' => static function () use ($transientException): void {
+                throw $transientException;
+            },
+            'createIndex' => Expected::never(),
+            'deleteIndex' => Expected::never(),
+            'putMapping' => Expected::never(),
+        ]);
+
+        $handler = $this->createHandlerWithService($searchIndexService);
+        $handler->setLogger(new NullLogger());
+
+        $thrown = null;
+
+        try {
+            $handler->reindexMapping();
+        } catch (Exception $e) {
+            $thrown = $e;
+        }
+
+        $this->assertSame(
+            $transientException,
+            $thrown,
+            'A transient reindex failure must propagate unchanged and must not trigger index recreation'
+        );
+    }
+
+    /**
+     * A forced index recreation is the designed recovery for mapping changes that
+     * cannot be applied to the existing documents via reindex — reported by the
+     * adapter as MAPPING_INCOMPATIBLE, never inferred from an exception.
+     */
+    public function testReindexMappingRecreatesIndexWhenMappingIsIncompatible(): void
     {
         $createdIndices = [];
         $fluent = $this->makeEmpty(SearchIndexServiceInterface::class, [
@@ -137,9 +165,7 @@ final class AbstractIndexHandlerTest extends Unit
         $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
             'existsAlias' => true,
             'getCurrentIndexVersion' => '',
-            'reindex' => static function (): void {
-                throw new Exception('initial reindex failure (504 Gateway Time-out)');
-            },
+            'reindex' => ReindexResult::MAPPING_INCOMPATIBLE,
             'createIndex' => static function (string $indexName) use (&$createdIndices, $fluent) {
                 $createdIndices[] = $indexName;
 
@@ -156,21 +182,23 @@ final class AbstractIndexHandlerTest extends Unit
         $this->assertContains(
             self::ALIAS_NAME . '-odd',
             $createdIndices,
-            'The fallback must recreate the index when the reindex fails'
+            'The index must be recreated when the mapping is incompatible'
         );
     }
 
-    private function createCollectingLogger(): AbstractLogger
+    public function testReindexMappingDoesNotRecreateIndexOnSuccess(): void
     {
-        return new class extends AbstractLogger {
-            /** @var array<int, array{level: string, message: string}> */
-            public array $records = [];
+        $searchIndexService = $this->makeEmpty(SearchIndexServiceInterface::class, [
+            'existsAlias' => true,
+            'reindex' => ReindexResult::SUCCESS,
+            'createIndex' => Expected::never(),
+            'deleteIndex' => Expected::never(),
+        ]);
 
-            public function log($level, $message, array $context = []): void
-            {
-                $this->records[] = ['level' => (string) $level, 'message' => (string) $message];
-            }
-        };
+        $handler = $this->createHandlerWithService($searchIndexService);
+        $handler->setLogger(new NullLogger());
+
+        $handler->reindexMapping();
     }
 
     private function createHandler(bool $indexSquatsAliasName, array &$deletedIndices): AbstractIndexHandler


### PR DESCRIPTION
Resolves https://github.com/pimcore/service-operations/issues/1126

## Changes in this pull request

A single exception during the native reindex — unreachable search cluster, timeout, rejected request, or even **one failed task-status poll during a long-running reindex** — was answered with a forced recreation of the **live** index (`createIndex()` deletes it first), purging all indexed data. With millions of entries, this means hours of downtime while the queue rebuilds the index (see PEES-1450 for the production incident).

Root cause: the recovery introduced in #361 (PEES-815 — recreate + rebuild when a mapping change is incompatible with the existing documents) was keyed on `catch (Exception)`, so it could not distinguish "mapping incompatible" from "cluster hiccup".

### Design change: outcomes instead of nested exception handling

"Existing documents don't fit the new mapping" is an **expected alternative outcome** of a mapping change, not an error — so it is now reported as a result instead of being inferred from an exception:

- New `ReindexResult` enum (`SUCCESS` / `MAPPING_INCOMPATIBLE`); `SearchIndexServiceInterface::reindex()` (`@internal`) returns it instead of `void`.
- `DefaultSearchService::reindex()` classifies the outcome: per-document failures after task completion (the PEES-815 case, e.g. `mapper_parsing_exception`) → `MAPPING_INCOMPATIBLE` (new index cleaned up, alias untouched); everything else — kickoff failures, task-level errors, timeouts, poll exhaustion — **throws**.
- `AbstractIndexHandler::reindexMapping()` loses its nested try/catch entirely: recreation happens only on `MAPPING_INCOMPATIBLE`; genuine errors propagate, so (together with #465) the mapping checksum is not stored, the deployment command exits non-zero, and the reindex is retried on the next run.

### Resilience hardening

- Single failed task-status requests are retried (up to 3 consecutive failures) instead of aborting a reindex that may have been running for an hour — one poll hiccup was enough to trigger the purge path.
- An aborted reindex now cancels the server-side `_reindex` task before deleting its target index, so an orphaned task no longer keeps writing into a dropped index.

### Behavior change note

`AbstractIndexHandler` is not `@internal`, so this is an observable behavior change on a bugfix line: transient reindex failures now propagate instead of silently recreating the index. Since the removed behavior is the data-loss defect itself and the legitimate recovery (PEES-815) is preserved, this is treated as a bugfix — documented in `doc/01_Installation/02_Upgrade.md` (2.5.8), same approach as #465. Flagging it here for a conscious review decision.

### Automated Tests

TDD: the key regression test (`testReindexMappingPropagatesTransientFailuresWithoutTouchingIndices`, guarded with `Expected::never()` on every index-mutating call) was verified failing against the previous implementation. Full coverage: handler (transient → propagate untouched; incompatible → recreate; recreation failure → propagate; success → untouched) and adapter (incompatible result + cleanup, poll retry, poll exhaustion, task cancel on abort, plus all pre-existing cases adapted).

### Manual tests

#### Big Data Env

Tested on big data environment with 2025.4, reindexing ~ 1940226 elements.

#### Manual verification

The change was additionally applied onto `2026.x` and tested against a real OpenSearch cluster with 3,000 seeded car objects (10,755 documents incl. variants):

| Scenario | Result |
| --- | --- |
| Forced reindex, healthy cluster | exit 0, alias `odd`→`even`, all 10,755 docs preserved, previous index cleaned up |
| 12s outage during reindex (cluster paused, then resumed) | absorbed by the new poll retry — reindex completed, exit 0, 10,755 docs intact |
| **Cluster stopped during reindex (the PEES-1450 incident)** | **exit 1**, live index untouched at 10,755 docs, alias unchanged, mapping checksum not stored → retried on the next run. Previously: live index recreated empty, command exited 0 |
| Recovery run after the outage | exit 0, alias flipped with all 10,755 docs, orphaned index from the aborted attempt cleaned up, checksum restored |

The diff applies to `2026.x` without conflicts, so the forward merge after this lands is expected to be clean.

## Additional info

- Provenance: destructive fallback introduced in #361 (2025-11); exposure widened by the per-poll fragility of #435; error propagation fixed by #465 — this PR removes the remaining data-destruction path.
- Answers to the customer's questions (PEES-1450): the catch block was *not* intended to treat transient connectivity like structural mapping failures — that conflation was the bug; and no, the search cluster is not guaranteed to be reachable/responsive at every moment of a deployment, which is why the code must be defensive.
