### PR TITLE
Compare paths on segment boundaries in isSubPath()

### DIFF
--- a/src/Service/PathService.php
+++ b/src/Service/PathService.php
@@ -23,7 +23,11 @@ final class PathService implements PathServiceInterface
 {
     public function isSubPath(string $path, string $parentPath): bool
     {
-        return $path !== $parentPath && str_starts_with($path, $parentPath);
+        // Compare on segment boundaries, otherwise a sibling whose name merely starts with the
+        // parent path's last segment counts as a child (e.g. "/Catalog_Archive" under "/Catalog").
+        // For the root path the rtrim leaves "/", which every absolute path starts with.
+        return $path !== $parentPath
+            && str_starts_with($path, rtrim($parentPath, '/') . '/');
     }
 
     public function containsSubPath(string $path, array $paths): bool

--- a/tests/Unit/Service/PathServiceTest.php
+++ b/tests/Unit/Service/PathServiceTest.php
@@ -32,6 +32,12 @@ final class PathServiceTest extends Unit
         $this->assertFalse($pathService->isSubPath('/', '/foo'));
         $this->assertFalse($pathService->isSubPath('/foo', '/foo/bar'));
         $this->assertFalse($pathService->isSubPath('/foo', '/asdf'));
+
+        // a sibling whose name starts with the parent path is not a sub path
+        $this->assertFalse($pathService->isSubPath('/foobar', '/foo'));
+        $this->assertFalse($pathService->isSubPath('/foo_bar', '/foo'));
+        $this->assertFalse($pathService->isSubPath('/foo/barbaz', '/foo/bar'));
+        $this->assertTrue($pathService->isSubPath('/foobar', '/'));
     }
 
     public function testContainsSubPath(): void
@@ -79,6 +85,11 @@ final class PathServiceTest extends Unit
         $this->assertEquals(
             ['/asdf', '/foo/bar'],
             $pathService->removeSubPaths(['/foo/bar', '/asdf'])
+        );
+        // a sibling sharing a leading string with another path must be kept
+        $this->assertEquals(
+            ['/foo', '/foo_bar'],
+            $pathService->removeSubPaths(['/foo', '/foo_bar'])
         );
     }
 


### PR DESCRIPTION
Fixes pimcore/platform-version#314

## Problem

`PathService::isSubPath()` compares with a plain `str_starts_with()`:

```php
return $path !== $parentPath && str_starts_with($path, $parentPath);
```

There is no `/` boundary, so a sibling whose name merely starts with another path counts as its child — `/Catalog_Archive` is treated as a child of `/Catalog`.

`QueryService::addQueryByMainPath()` runs the allowed workspace paths through `removeSubPaths()`, which therefore drops `/Catalog_Archive` from `$allowedMainPaths`. The resulting `terms` filter on `system_fields.fullPath` covers a path and its descendants (`path_hierarchy` tokenizer, splitting on `/`), and `/Catalog` does not match `/Catalog_Archive` — it is a sibling, not a descendant.

Effect for the user: a folder with `list` granted on exactly its own path is missing from the element tree, while sibling folders without a prefix neighbour show up normally. Only the tree is affected, since it reads from the index; the SQL-level permission check reports the same folder as visible.

`isSubPath()` also backs `containsSubPath()`, `getContainedSubPaths()` and `keepDeclinedPathsWithinAllowed()`, which all want real hierarchy as well.

This is the index-side counterpart of pimcore/platform-version#214, where the same missing boundary was fixed for the SQL permission conditions in the core.

## Fix

Compare against the parent path plus its separator:

```php
return $path !== $parentPath
    && str_starts_with($path, rtrim($parentPath, '/') . '/');
```

Strictly narrowing — only the previous false positives disappear. The root path stays intact: `rtrim('/', '/') . '/'` is `/`, which every absolute path starts with.

## Tests

Extended `tests/Unit/Service/PathServiceTest.php`:

- `testIsSubPath()` — prefix siblings are not sub paths (`/foobar` and `/foo_bar` under `/foo`, `/foo/barbaz` under `/foo/bar`), and `/foobar` is still a sub path of `/`.
- `testRemoveSubPaths()` — `['/foo', '/foo_bar']` is kept as-is instead of collapsing to `['/foo']`.

All pre-existing assertions in that file stay unchanged and green.
