### PR TITLE
[Task]: Improve Generic Data Index traceability (logging, exit code, status command)

### DIFF
--- a/doc/01_Installation/02_Upgrade.md
+++ b/doc/01_Installation/02_Upgrade.md
@@ -12,8 +12,9 @@ Following steps are necessary during updating to newer versions.
   items are still pending dispatch), every live index with its document count and size, and a warning for any index
   present in both the `-even` and `-odd` version at once (the fingerprint of an interrupted reindex).
 - [Logging] Generic Data Index now logs to a dedicated `pimcore_generic_data_index` Monolog channel, so its output
-  can be filtered, raised to debug, or routed separately. The channel is still handled by the application's existing
-  handlers — no configuration change is required.
+  can be filtered, raised to debug, or routed separately. Handlers without a channel restriction pick it up
+  automatically; if you restrict a handler to an explicit channel allow-list (e.g. `channels: ["pimcore"]`), add
+  `pimcore_generic_data_index` to that list so its records are not dropped.
 - [Logging] Failure paths (index checksum read, queue enqueue, dispatch handler) now log with structured context and
   the original exception, a claimed queue batch's dispatch id is logged across dispatch and processing for
   correlation, and the per-class mapping-checksum reindex decision (skip vs. reindex, with stored vs. current

--- a/doc/01_Installation/02_Upgrade.md
+++ b/doc/01_Installation/02_Upgrade.md
@@ -2,6 +2,23 @@
 
 Following steps are necessary during updating to newer versions.
 
+## Upgrade to 2.5.9
+- [Commands] `generic-data-index:update:index` now exits with a non-zero status code when one or more of its
+  update sections (class definition, asset index, full update) fail, instead of always returning `0`. All sections
+  are still attempted and the queue is still dispatched; the command only reports the failure at the end. Deployment
+  pipelines that treated a partial failure as success will now fail visibly — this mirrors the same change made for
+  `generic-data-index:deployment:reindex` and `generic-data-index:reindex` in 2.5.6.
+- [Commands] Added a read-only `generic-data-index:status` command that reports the index queue depth (and whether
+  items are still pending dispatch), every live index with its document count and size, and a warning for any index
+  present in both the `-even` and `-odd` version at once (the fingerprint of an interrupted reindex).
+- [Logging] Generic Data Index now logs to a dedicated `pimcore_generic_data_index` Monolog channel, so its output
+  can be filtered, raised to debug, or routed separately. The channel is still handled by the application's existing
+  handlers — no configuration change is required.
+- [Logging] Failure paths (index checksum read, queue enqueue, dispatch handler) now log with structured context and
+  the original exception, a claimed queue batch's dispatch id is logged across dispatch and processing for
+  correlation, and the per-class mapping-checksum reindex decision (skip vs. reindex, with stored vs. current
+  checksum) is logged.
+
 ## Upgrade to 2.5.8
 - [Indexing] A failed native reindex no longer triggers a forced recreation of the live index. Recreation now only
   happens when the reindex reports that the existing documents are incompatible with the new mapping (e.g. after a

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Command;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Repository\IndexQueueRepository;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\DefaultSearch\DefaultSearchService;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexStatsServiceInterface;
+use Pimcore\Console\AbstractCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Read-only diagnostic overview of the Generic Data Index: queue depth and the live indices
+ * with their document counts, plus a warning for any index that has both blue/green versions
+ * present at once (the fingerprint of an interrupted reindex).
+ *
+ * @internal
+ */
+final class StatusCommand extends AbstractCommand
+{
+    public function __construct(
+        private readonly IndexStatsServiceInterface $indexStatsService,
+        private readonly IndexQueueRepository $indexQueueRepository,
+        ?string $name = null,
+    ) {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('generic-data-index:status')
+            ->setDescription(
+                'Read-only overview of the search index: queue depth, indices and their document '
+                . 'counts, and interrupted-reindex leftovers.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $stats = $this->indexStatsService->getStats();
+
+        $io->section('Index queue');
+        $io->definitionList(
+            ['entries' => (string) $stats->getCountIndexQueueEntries()],
+            ['pending dispatch' => $this->indexQueueRepository->dispatchableItemExists() ? 'yes' : 'no'],
+        );
+
+        $indices = $stats->getIndices();
+        $io->section(sprintf('Indices (%d)', count($indices)));
+
+        if ($indices === []) {
+            $io->warning('No indices found. Has the index been built?');
+
+            return self::SUCCESS;
+        }
+
+        $rows = [];
+        foreach ($indices as $index) {
+            $rows[] = [$index->getIndexName(), $index->getItemsCount(), $index->getSizeInKb()];
+        }
+        $io->table(['Index', 'Documents', 'Size (KB)'], $rows);
+
+        $leftovers = $this->detectBlueGreenLeftovers(array_map(
+            static fn ($index) => $index->getIndexName(),
+            $indices
+        ));
+
+        if ($leftovers !== []) {
+            $io->warning(sprintf(
+                "The following indices have both '-%s' and '-%s' versions present at once, which "
+                . "usually indicates an interrupted reindex:\n  %s",
+                DefaultSearchService::INDEX_VERSION_EVEN,
+                DefaultSearchService::INDEX_VERSION_ODD,
+                implode("\n  ", $leftovers)
+            ));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Base index names that appear with BOTH the -even and -odd suffix in the index list.
+     *
+     * @param string[] $indexNames
+     *
+     * @return string[]
+     */
+    private function detectBlueGreenLeftovers(array $indexNames): array
+    {
+        $seenEven = [];
+        $seenOdd = [];
+        foreach ($indexNames as $name) {
+            if (str_ends_with($name, '-' . DefaultSearchService::INDEX_VERSION_EVEN)) {
+                $seenEven[substr($name, 0, -strlen('-' . DefaultSearchService::INDEX_VERSION_EVEN))] = true;
+            } elseif (str_ends_with($name, '-' . DefaultSearchService::INDEX_VERSION_ODD)) {
+                $seenOdd[substr($name, 0, -strlen('-' . DefaultSearchService::INDEX_VERSION_ODD))] = true;
+            }
+        }
+
+        return array_values(array_keys(array_intersect_key($seenEven, $seenOdd)));
+    }
+}

--- a/src/Command/Update/IndexUpdateCommand.php
+++ b/src/Command/Update/IndexUpdateCommand.php
@@ -125,6 +125,7 @@ final class IndexUpdateCommand extends AbstractCommand
         $this->indexUpdateService->setReCreateIndex($input->getOption(self::OPTION_RECREATE_INDEX));
 
         $updateAll = true;
+        $failed = false;
 
         /** @var string|null $classDefinitionId */
         $classDefinitionId = $input->getOption(self::OPTION_CLASS_DEFINITION_ID);
@@ -152,7 +153,8 @@ final class IndexUpdateCommand extends AbstractCommand
                     ->indexUpdateService
                     ->updateClassDefinition($classDefinition);
             } catch (Exception $e) {
-                $this->output->writeln('<error>' . $e->getMessage() . '</error>');
+                $failed = true;
+                $this->writeSectionError(sprintf('Updating ClassDefinition %s', $classDefinitionId), $e);
             }
         }
 
@@ -169,7 +171,8 @@ final class IndexUpdateCommand extends AbstractCommand
                     ->indexUpdateService
                     ->updateAssets();
             } catch (Exception $e) {
-                $this->output->writeln($e->getMessage());
+                $failed = true;
+                $this->writeSectionError('Updating asset index', $e);
             }
         }
 
@@ -184,7 +187,8 @@ final class IndexUpdateCommand extends AbstractCommand
                     ->indexUpdateService
                     ->updateAll();
             } catch (Exception $e) {
-                $this->output->writeln('<error>' . $e->getMessage() . '</error>');
+                $failed = true;
+                $this->writeSectionError('Updating all mappings and indices', $e);
             }
         }
 
@@ -198,9 +202,38 @@ final class IndexUpdateCommand extends AbstractCommand
 
         $this->release();
 
+        if ($failed) {
+            // One or more sections failed. Return a non-zero exit code so callers (deployment
+            // pipelines, CI) see the failure instead of a false success. All sections are still
+            // attempted first, so a single failure does not hide the others.
+            $this->output->writeln(
+                '<error>Finished with errors - see above. The index may be incomplete.</error>'
+            );
+
+            return self::FAILURE;
+        }
+
         $this->output->writeln('<info>Finished</info>', OutputInterface::VERBOSITY_NORMAL);
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Writes a section failure including the exception type and its cause chain, so the actual
+     * reason is visible and not reduced to a bare message.
+     */
+    private function writeSectionError(string $context, Exception $e): void
+    {
+        $this->output->writeln(sprintf(
+            '<error>%s failed: %s: %s</error>',
+            $context,
+            $e::class,
+            $e->getMessage()
+        ));
+
+        for ($previous = $e->getPrevious(); $previous !== null; $previous = $previous->getPrevious()) {
+            $this->output->writeln(sprintf('<error>  caused by %s: %s</error>', $previous::class, $previous->getMessage()));
+        }
     }
 
     private function updateGlobalIndexAliases(): void

--- a/src/Command/Update/IndexUpdateCommand.php
+++ b/src/Command/Update/IndexUpdateCommand.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexUpdateService
 use Pimcore\Console\AbstractCommand;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -224,15 +225,23 @@ final class IndexUpdateCommand extends AbstractCommand
      */
     private function writeSectionError(string $context, Exception $e): void
     {
+        // Escape dynamic values before wrapping them in <error> markup: an exception message (or the
+        // class id in $context) containing something like "<field>" would otherwise be parsed as a
+        // console style tag and could throw from OutputFormatter - aborting the error reporting, the
+        // remaining sections and the queue dispatch, which is exactly what this command must avoid.
         $this->output->writeln(sprintf(
             '<error>%s failed: %s: %s</error>',
-            $context,
+            OutputFormatter::escape($context),
             $e::class,
-            $e->getMessage()
+            OutputFormatter::escape($e->getMessage())
         ));
 
         for ($previous = $e->getPrevious(); $previous !== null; $previous = $previous->getPrevious()) {
-            $this->output->writeln(sprintf('<error>  caused by %s: %s</error>', $previous::class, $previous->getMessage()));
+            $this->output->writeln(sprintf(
+                '<error>  caused by %s: %s</error>',
+                $previous::class,
+                OutputFormatter::escape($previous->getMessage())
+            ));
         }
     }
 

--- a/src/DependencyInjection/PimcoreGenericDataIndexExtension.php
+++ b/src/DependencyInjection/PimcoreGenericDataIndexExtension.php
@@ -72,6 +72,15 @@ class PimcoreGenericDataIndexExtension extends Extension implements PrependExten
         $config = $this->getParsedConfig(__DIR__ . '/../../config/doctrine.yaml');
 
         $container->prependExtensionConfig('doctrine', $config['doctrine']);
+
+        // Dedicated log channel so Generic Data Index logs can be filtered, raised to debug, or
+        // routed separately from the rest of the application. Additive: the channel is still
+        // handled by the application's existing handlers, it is only tagged distinctly.
+        if ($container->hasExtension('monolog')) {
+            $container->prependExtensionConfig('monolog', [
+                'channels' => ['pimcore_generic_data_index'],
+            ]);
+        }
     }
 
     private function registerIndexServiceParams(ContainerBuilder $container, array $indexSettings): void

--- a/src/MessageHandler/DispatchQueueMessagesHandler.php
+++ b/src/MessageHandler/DispatchQueueMessagesHandler.php
@@ -57,7 +57,7 @@ final class DispatchQueueMessagesHandler
                 $realMaxBatchSize
             );
         } catch (Exception $e) {
-            $this->logger->warning('Dispatching Queue Message failed: ' . $e);
+            $this->logger->warning('Dispatching queue messages failed', ['exception' => $e]);
         } finally {
             $this->queueMessagesDispatcher->clearPendingState();
         }

--- a/src/SearchIndexAdapter/DefaultSearch/IndexStatsService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/IndexStatsService.php
@@ -63,10 +63,11 @@ final class IndexStatsService implements IndexStatsServiceInterface
             ],
         ]);
 
-        // The terms aggregation on _index has no bucket for an index that holds zero documents,
-        // so it alone would silently drop empty indices. Enumerate every index reported by _stats
-        // instead - which does list empty ones - and take the accurate searchable doc count from
-        // the aggregation where present, defaulting to 0 for the empty ones.
+        // The terms aggregation on _index has no bucket for a zero-document index and is capped at
+        // 10000 buckets, so it alone would drop empty indices and, on very large installs, omit any
+        // index beyond the cap. Enumerate every index from _stats instead (it lists them all),
+        // preferring the aggregation's accurate searchable doc count and falling back to the _stats
+        // document count where the aggregation has no bucket - so an uncapped index never reports 0.
         $docCountByIndex = [];
         foreach ($aggregationResult['aggregations']['indices']['buckets'] as $bucket) {
             $docCountByIndex[$bucket['key']] = $bucket['doc_count'];
@@ -80,7 +81,7 @@ final class IndexStatsService implements IndexStatsServiceInterface
             $sizeInBytes = (int)($indexStats['total']['store']['size_in_bytes'] ?? 0);
             $indices[] = new IndexStatsIndex(
                 indexName: $indexName,
-                itemsCount: $docCountByIndex[$indexName] ?? 0,
+                itemsCount: $docCountByIndex[$indexName] ?? (int)($indexStats['total']['docs']['count'] ?? 0),
                 sizeInKb: round(($sizeInBytes / 1024), 2)
             );
         }

--- a/src/SearchIndexAdapter/DefaultSearch/IndexStatsService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/IndexStatsService.php
@@ -63,17 +63,19 @@ final class IndexStatsService implements IndexStatsServiceInterface
             ],
         ]);
 
-        // The terms aggregation on _index has no bucket for a zero-document index and is capped at
-        // 10000 buckets, so it alone would drop empty indices and, on very large installs, omit any
-        // index beyond the cap. Enumerate every index from _stats instead (it lists them all),
-        // preferring the aggregation's accurate searchable doc count and falling back to the _stats
-        // PRIMARY-shard document count where the aggregation has no bucket - primaries (not total)
-        // so replicas don't inflate the logical count, and an uncapped index never reports 0.
+        // Document counts come from the terms aggregation on _index, which counts top-level
+        // (searchable) documents - the element count we want. Index stats are deliberately NOT used
+        // for the count: their docs.count is a raw Lucene total that would be inflated by nested
+        // block/table sub-documents and by replica shards. Every index that holds documents appears
+        // in the aggregation (its 10000-bucket cap is far above any realistic number of GDI indices),
+        // so an index absent from it is empty and correctly counts as 0.
         $docCountByIndex = [];
         foreach ($aggregationResult['aggregations']['indices']['buckets'] as $bucket) {
             $docCountByIndex[$bucket['key']] = $bucket['doc_count'];
         }
 
+        // Enumerate every index from _stats - it lists empty indices too, which the aggregation
+        // omits - so an empty live index is still reported (with a 0 count) rather than dropped.
         $allIndexStats = $allStats['indices'] ?? [];
         ksort($allIndexStats);
 
@@ -82,7 +84,7 @@ final class IndexStatsService implements IndexStatsServiceInterface
             $sizeInBytes = (int)($indexStats['total']['store']['size_in_bytes'] ?? 0);
             $indices[] = new IndexStatsIndex(
                 indexName: $indexName,
-                itemsCount: $docCountByIndex[$indexName] ?? (int)($indexStats['primaries']['docs']['count'] ?? 0),
+                itemsCount: $docCountByIndex[$indexName] ?? 0,
                 sizeInKb: round(($sizeInBytes / 1024), 2)
             );
         }

--- a/src/SearchIndexAdapter/DefaultSearch/IndexStatsService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/IndexStatsService.php
@@ -67,7 +67,8 @@ final class IndexStatsService implements IndexStatsServiceInterface
         // 10000 buckets, so it alone would drop empty indices and, on very large installs, omit any
         // index beyond the cap. Enumerate every index from _stats instead (it lists them all),
         // preferring the aggregation's accurate searchable doc count and falling back to the _stats
-        // document count where the aggregation has no bucket - so an uncapped index never reports 0.
+        // PRIMARY-shard document count where the aggregation has no bucket - primaries (not total)
+        // so replicas don't inflate the logical count, and an uncapped index never reports 0.
         $docCountByIndex = [];
         foreach ($aggregationResult['aggregations']['indices']['buckets'] as $bucket) {
             $docCountByIndex[$bucket['key']] = $bucket['doc_count'];
@@ -81,7 +82,7 @@ final class IndexStatsService implements IndexStatsServiceInterface
             $sizeInBytes = (int)($indexStats['total']['store']['size_in_bytes'] ?? 0);
             $indices[] = new IndexStatsIndex(
                 indexName: $indexName,
-                itemsCount: $docCountByIndex[$indexName] ?? (int)($indexStats['total']['docs']['count'] ?? 0),
+                itemsCount: $docCountByIndex[$indexName] ?? (int)($indexStats['primaries']['docs']['count'] ?? 0),
                 sizeInKb: round(($sizeInBytes / 1024), 2)
             );
         }

--- a/src/SearchIndexAdapter/DefaultSearch/IndexStatsService.php
+++ b/src/SearchIndexAdapter/DefaultSearch/IndexStatsService.php
@@ -63,12 +63,24 @@ final class IndexStatsService implements IndexStatsServiceInterface
             ],
         ]);
 
-        $indices = [];
+        // The terms aggregation on _index has no bucket for an index that holds zero documents,
+        // so it alone would silently drop empty indices. Enumerate every index reported by _stats
+        // instead - which does list empty ones - and take the accurate searchable doc count from
+        // the aggregation where present, defaulting to 0 for the empty ones.
+        $docCountByIndex = [];
         foreach ($aggregationResult['aggregations']['indices']['buckets'] as $bucket) {
-            $sizeInBytes = (int)($allStats['indices'][$bucket['key']]['total']['store']['size_in_bytes'] ?? 0);
+            $docCountByIndex[$bucket['key']] = $bucket['doc_count'];
+        }
+
+        $allIndexStats = $allStats['indices'] ?? [];
+        ksort($allIndexStats);
+
+        $indices = [];
+        foreach ($allIndexStats as $indexName => $indexStats) {
+            $sizeInBytes = (int)($indexStats['total']['store']['size_in_bytes'] ?? 0);
             $indices[] = new IndexStatsIndex(
-                indexName: $bucket['key'],
-                itemsCount: $bucket['doc_count'],
+                indexName: $indexName,
+                itemsCount: $docCountByIndex[$indexName] ?? 0,
                 sizeInKb: round(($sizeInBytes / 1024), 2)
             );
         }

--- a/src/Service/SearchIndex/ClassDefinition/ClassDefinitionReindexService.php
+++ b/src/Service/SearchIndex/ClassDefinition/ClassDefinitionReindexService.php
@@ -87,7 +87,10 @@ final readonly class ClassDefinitionReindexService implements ClassDefinitionRei
             return false;
         }
 
-        $this->pimcoreGenericDataIndexLogger->info('Mapping changed, reindexing class', [
+        // Reached both when the mapping actually changed and when a caller forces a reindex
+        // ($skipIfClassNotChanged === false) despite equal checksums, so the message states the
+        // decision without asserting a change - the stored vs current checksum tell that story.
+        $this->pimcoreGenericDataIndexLogger->info('Reindexing class mapping', [
             'class' => $classDefinition->getName(),
             'classId' => $classDefinition->getId(),
             'storedChecksum' => $storedCheckSum,

--- a/src/Service/SearchIndex/ClassDefinition/ClassDefinitionReindexService.php
+++ b/src/Service/SearchIndex/ClassDefinition/ClassDefinitionReindexService.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexQueue\Enqueue
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexService\IndexHandler\DataObjectIndexHandler;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SettingsStoreServiceInterface;
 use Pimcore\Model\DataObject\ClassDefinition;
+use Psr\Log\LoggerInterface;
 
 /**
  * @internal
@@ -31,6 +32,7 @@ final readonly class ClassDefinitionReindexService implements ClassDefinitionRei
         private EnqueueServiceInterface $enqueueService,
         private SettingsStoreServiceInterface $settingsStoreService,
         private IndexIconUpdateServiceInterface $indexIconUpdateService,
+        private LoggerInterface $pimcoreGenericDataIndexLogger,
     ) {
     }
 
@@ -76,8 +78,21 @@ final readonly class ClassDefinitionReindexService implements ClassDefinitionRei
         $storedCheckSum = $this->settingsStoreService->getClassMappingCheckSum($classDefinition->getId());
 
         if ($skipIfClassNotChanged && $storedCheckSum === $currentCheckSum) {
+            $this->pimcoreGenericDataIndexLogger->debug('Mapping unchanged, skipping reindex', [
+                'class' => $classDefinition->getName(),
+                'classId' => $classDefinition->getId(),
+                'checksum' => $currentCheckSum,
+            ]);
+
             return false;
         }
+
+        $this->pimcoreGenericDataIndexLogger->info('Mapping changed, reindexing class', [
+            'class' => $classDefinition->getName(),
+            'classId' => $classDefinition->getId(),
+            'storedChecksum' => $storedCheckSum,
+            'currentChecksum' => $currentCheckSum,
+        ]);
 
         $this->dataObjectIndexHandler
             ->reindexMapping(

--- a/src/Service/SearchIndex/ClassDefinition/ClassDefinitionReindexService.php
+++ b/src/Service/SearchIndex/ClassDefinition/ClassDefinitionReindexService.php
@@ -78,10 +78,13 @@ final readonly class ClassDefinitionReindexService implements ClassDefinitionRei
         $storedCheckSum = $this->settingsStoreService->getClassMappingCheckSum($classDefinition->getId());
 
         if ($skipIfClassNotChanged && $storedCheckSum === $currentCheckSum) {
+            // Same structured keys as the reindex branch below (here they are equal by definition),
+            // so a log query on storedChecksum/currentChecksum includes skipped classes too.
             $this->pimcoreGenericDataIndexLogger->debug('Mapping unchanged, skipping reindex', [
                 'class' => $classDefinition->getName(),
                 'classId' => $classDefinition->getId(),
-                'checksum' => $currentCheckSum,
+                'storedChecksum' => $storedCheckSum,
+                'currentChecksum' => $currentCheckSum,
             ]);
 
             return false;

--- a/src/Service/SearchIndex/IndexQueue/QueueMessageService.php
+++ b/src/Service/SearchIndex/IndexQueue/QueueMessageService.php
@@ -43,15 +43,25 @@ final class QueueMessageService implements QueueMessageServiceInterface
             );
             $amountOfEntries = count($entries);
             if ($amountOfEntries > 0) {
+                // The dispatch id was just stamped on this claimed batch by getUnhandledIndexQueueEntries().
+                // Logging it here - on the dispatch side - lets a batch be correlated with the matching
+                // "Processing index queue batch" log even when the message is never handled (worker died,
+                // transport dropped it), which the processing-side log alone cannot show.
+                $dispatchId = $entries[0]['dispatched'] ?? null;
+
                 try {
+                    $this->logger->info('Dispatching index queue batch', [
+                        'dispatchId' => $dispatchId,
+                        'entries' => $amountOfEntries,
+                    ]);
                     $this->messageBus->dispatch(new IndexUpdateQueueMessage($entries));
                 } catch (Exception $exception) {
-                    $this->logger->error(
-                        'Dispatching IndexUpdateQueueMessage failed! ' .
-                        get_class($exception) . ': ' . $exception->getMessage()
-                    );
+                    $this->logger->error('Dispatching IndexUpdateQueueMessage failed', [
+                        'dispatchId' => $dispatchId,
+                        'entries' => $amountOfEntries,
+                        'exception' => $exception,
+                    ]);
 
-                    $dispatchId = $entries[0]['dispatched'] ?? null;
                     if ($dispatchId !== null) {
                         $this->indexQueueRepository->resetDispatchedItems($dispatchId);
                     }

--- a/src/Service/SearchIndex/IndexQueueService.php
+++ b/src/Service/SearchIndex/IndexQueueService.php
@@ -111,16 +111,29 @@ final class IndexQueueService implements IndexQueueServiceInterface
      */
     public function handleIndexQueueEntries(array $entries): void
     {
+        if ($entries === []) {
+            return;
+        }
+
+        // The dispatch id is stamped on every row of a claimed batch, so logging it lets a whole
+        // batch's fate be correlated across dispatch and processing with a single grep.
+        $dispatchId = $entries[array_key_first($entries)]->getDispatched();
+
+        $this->logger->info('Processing index queue batch', [
+            'dispatchId' => $dispatchId,
+            'entries' => count($entries),
+        ]);
+
         try {
 
             foreach ($entries as $entry) {
-                $this->logger->debug(
-                    sprintf(
-                        '%s updating index for element %s and type %s',
-                        IndexQueue::TABLE,
-                        $entry->getElementId(),
-                        $entry->getElementType()
-                    ));
+                $this->logger->debug('Updating index for element', [
+                    'dispatchId' => $dispatchId,
+                    'elementId' => $entry->getElementId(),
+                    'elementType' => $entry->getElementType(),
+                    'operation' => $entry->getOperation(),
+                    'indexName' => $entry->getElementIndexName(),
+                ]);
                 $this->handleEntryByOperation($entry->getOperation(), $entry);
             }
 
@@ -128,6 +141,12 @@ final class IndexQueueService implements IndexQueueServiceInterface
             $this->indexQueueRepository->deleteQueueEntries($entries);
 
         } catch (Exception $e) {
+            $this->logger->error('Processing index queue batch failed', [
+                'dispatchId' => $dispatchId,
+                'entries' => count($entries),
+                'exception' => $e,
+            ]);
+
             throw new HandleIndexQueueEntriesException('handleIndexQueueEntry failed! Error: ' . $e->getMessage(), 0, $e);
         }
     }

--- a/src/Service/SearchIndex/IndexQueueService.php
+++ b/src/Service/SearchIndex/IndexQueueService.php
@@ -94,13 +94,13 @@ final class IndexQueueService implements IndexQueueServiceInterface
 
             $this->pathService->rewriteChildrenIndexPaths($element);
         } catch (Exception $e) {
-            $this->logger->error(
-                sprintf(
-                    'Update indexQueue in database-table %s failed! Error: %s',
-                    IndexQueue::TABLE,
-                    $e->getMessage()
-                )
-            );
+            $this->logger->error('Updating the index queue failed', [
+                'table' => IndexQueue::TABLE,
+                'elementId' => $element->getId(),
+                'elementType' => $element->getType(),
+                'operation' => $operation,
+                'exception' => $e,
+            ]);
         }
 
         return $this;

--- a/src/Service/SearchIndex/IndexService/IndexService.php
+++ b/src/Service/SearchIndex/IndexService/IndexService.php
@@ -58,7 +58,13 @@ final class IndexService implements IndexServiceInterface
             $originalChecksum =
                 $indexDocument['_source'][FieldCategory::SYSTEM_FIELDS->value][SystemField::CHECKSUM->value] ?? -1;
         } catch (Exception $e) {
-            $this->logger->error($e->getMessage());
+            // Could not read the existing document to compare checksums; fall back to always
+            // writing. Log with context + the exception so the cause is not lost.
+            $this->logger->error('Failed to read existing index document for checksum comparison', [
+                'indexName' => $indexName,
+                'elementId' => $element->getId(),
+                'exception' => $e,
+            ]);
             $originalChecksum = -1;
         }
 

--- a/src/Traits/LoggerAwareTrait.php
+++ b/src/Traits/LoggerAwareTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Traits;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Service\Attribute\Required;
 
 trait LoggerAwareTrait
@@ -21,10 +22,13 @@ trait LoggerAwareTrait
     protected LoggerInterface|null $logger;
 
     #[Required]
-    public function setLogger(LoggerInterface $pimcoreGenericDataIndexLogger): void
-    {
-        // Bind to the dedicated "pimcore_generic_data_index" Monolog channel (declared in the
-        // bundle extension). Autowiring resolves the argument name to that channel's logger.
-        $this->logger = $pimcoreGenericDataIndexLogger;
+    public function setLogger(
+        // The dedicated "pimcore_generic_data_index" Monolog channel is selected explicitly by
+        // service id, NOT by argument name - so the public parameter keeps its original name and
+        // named-argument callers are not broken.
+        #[Autowire(service: 'monolog.logger.pimcore_generic_data_index')]
+        LoggerInterface $pimcoreLogger,
+    ): void {
+        $this->logger = $pimcoreLogger;
     }
 }

--- a/src/Traits/LoggerAwareTrait.php
+++ b/src/Traits/LoggerAwareTrait.php
@@ -21,8 +21,10 @@ trait LoggerAwareTrait
     protected LoggerInterface|null $logger;
 
     #[Required]
-    public function setLogger(LoggerInterface $pimcoreLogger): void
+    public function setLogger(LoggerInterface $pimcoreGenericDataIndexLogger): void
     {
-        $this->logger = $pimcoreLogger;
+        // Bind to the dedicated "pimcore_generic_data_index" Monolog channel (declared in the
+        // bundle extension). Autowiring resolves the argument name to that channel's logger.
+        $this->logger = $pimcoreGenericDataIndexLogger;
     }
 }

--- a/tests/Unit/Command/IndexUpdateCommandTest.php
+++ b/tests/Unit/Command/IndexUpdateCommandTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Command;
 
 use Codeception\Test\Unit;
+use LogicException;
 use Pimcore\Bundle\GenericDataIndexBundle\Command\Update\IndexUpdateCommand;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\GlobalIndexAliasServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexQueue\EnqueueServiceInterface;
@@ -30,9 +31,16 @@ final class IndexUpdateCommandTest extends Unit
      */
     public function testReturnsFailureWhenAnUpdateSectionThrows(): void
     {
+        // The section throws an exception that WRAPS an underlying cause, so the test can assert the
+        // whole chain is rendered - not just the outer message. Without a nested cause the cause-chain
+        // loop in writeSectionError() could be deleted and this test would stay green.
         $indexUpdateService = $this->makeEmpty(IndexUpdateServiceInterface::class, [
             'updateAll' => function (): void {
-                throw new RuntimeException('mapping update failed (simulated)');
+                throw new RuntimeException(
+                    'mapping update failed (simulated)',
+                    0,
+                    new LogicException('root cause: invalid mapping definition')
+                );
             },
         ]);
 
@@ -41,9 +49,13 @@ final class IndexUpdateCommandTest extends Unit
 
         $this->assertSame(Command::FAILURE, $commandTester->getStatusCode());
         $display = $commandTester->getDisplay();
-        // the exception type and message must both be visible (cause preservation)
+        // the outer exception type and message must be visible
         $this->assertStringContainsString('RuntimeException', $display);
         $this->assertStringContainsString('mapping update failed (simulated)', $display);
+        // ...and so must the preserved cause chain (type + message of the previous exception)
+        $this->assertStringContainsString('caused by', $display);
+        $this->assertStringContainsString('LogicException', $display);
+        $this->assertStringContainsString('root cause: invalid mapping definition', $display);
     }
 
     /**

--- a/tests/Unit/Command/IndexUpdateCommandTest.php
+++ b/tests/Unit/Command/IndexUpdateCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Command;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\Command\Update\IndexUpdateCommand;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\GlobalIndexAliasServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexQueue\EnqueueServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\IndexUpdateServiceInterface;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class IndexUpdateCommandTest extends Unit
+{
+    /**
+     * A failing section must surface as a non-zero exit code so deployment pipelines see it,
+     * instead of the command reporting success on a broken index (PEES-1206 / #853).
+     */
+    public function testReturnsFailureWhenAnUpdateSectionThrows(): void
+    {
+        $indexUpdateService = $this->makeEmpty(IndexUpdateServiceInterface::class, [
+            'updateAll' => function (): void {
+                throw new RuntimeException('mapping update failed (simulated)');
+            },
+        ]);
+
+        $commandTester = new CommandTester($this->createCommand($indexUpdateService));
+        $commandTester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        $display = $commandTester->getDisplay();
+        // the exception type and message must both be visible (cause preservation)
+        $this->assertStringContainsString('RuntimeException', $display);
+        $this->assertStringContainsString('mapping update failed (simulated)', $display);
+    }
+
+    /**
+     * All sections are still attempted, and the queue is still dispatched, even when one fails.
+     */
+    public function testDispatchesQueueEvenWhenASectionFails(): void
+    {
+        $dispatched = false;
+        $indexUpdateService = $this->makeEmpty(IndexUpdateServiceInterface::class, [
+            'updateAll' => function (): void {
+                throw new RuntimeException('boom');
+            },
+        ]);
+        $enqueueService = $this->makeEmpty(EnqueueServiceInterface::class, [
+            'dispatchQueueMessages' => function () use (&$dispatched): void {
+                $dispatched = true;
+            },
+        ]);
+
+        $commandTester = new CommandTester($this->createCommand($indexUpdateService, $enqueueService));
+        $commandTester->execute([]);
+
+        $this->assertTrue($dispatched, 'queue dispatch must still run so already-updated work is processed');
+        $this->assertSame(Command::FAILURE, $commandTester->getStatusCode());
+    }
+
+    /**
+     * The happy path still returns success.
+     */
+    public function testReturnsSuccessWhenAllSectionsSucceed(): void
+    {
+        $commandTester = new CommandTester($this->createCommand());
+        $commandTester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+    }
+
+    private function createCommand(
+        ?IndexUpdateServiceInterface $indexUpdateService = null,
+        ?EnqueueServiceInterface $enqueueService = null,
+    ): IndexUpdateCommand {
+        $command = new IndexUpdateCommand();
+        $command->setIndexUpdateService($indexUpdateService ?? $this->makeEmpty(IndexUpdateServiceInterface::class));
+        $command->setEnqueueService($enqueueService ?? $this->makeEmpty(EnqueueServiceInterface::class));
+        $command->setGlobalIndexAliasService($this->makeEmpty(GlobalIndexAliasServiceInterface::class));
+
+        return $command;
+    }
+}

--- a/tests/Unit/Command/IndexUpdateCommandTest.php
+++ b/tests/Unit/Command/IndexUpdateCommandTest.php
@@ -83,6 +83,35 @@ final class IndexUpdateCommandTest extends Unit
     }
 
     /**
+     * An exception message containing console-style markup must not make the error reporting throw
+     * from OutputFormatter - that would abort the remaining sections and the queue dispatch, the
+     * opposite of what this command promises. The dynamic values are escaped, so the run completes.
+     */
+    public function testExceptionMessageWithConsoleMarkupDoesNotAbortTheRun(): void
+    {
+        $dispatched = false;
+        $indexUpdateService = $this->makeEmpty(IndexUpdateServiceInterface::class, [
+            'updateAll' => function (): void {
+                // `<fg=bogus>` is invalid console markup: OutputFormatter throws on it unless escaped.
+                throw new RuntimeException('invalid mapping <fg=bogus>value</>');
+            },
+        ]);
+        $enqueueService = $this->makeEmpty(EnqueueServiceInterface::class, [
+            'dispatchQueueMessages' => function () use (&$dispatched): void {
+                $dispatched = true;
+            },
+        ]);
+
+        $commandTester = new CommandTester($this->createCommand($indexUpdateService, $enqueueService));
+        $commandTester->execute([]); // must not throw
+
+        $this->assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        $this->assertTrue($dispatched, 'queue dispatch must still run even when the error message contains markup');
+        // the markup is rendered literally rather than interpreted as a (broken) style tag
+        $this->assertStringContainsString('invalid mapping <fg=bogus>value</>', $commandTester->getDisplay());
+    }
+
+    /**
      * The happy path still returns success.
      */
     public function testReturnsSuccessWhenAllSectionsSucceed(): void

--- a/tests/Unit/Command/StatusCommandTest.php
+++ b/tests/Unit/Command/StatusCommandTest.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericDataIndexBundle\Tests\Unit\Command;
+
+use Codeception\Test\Unit;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Command\StatusCommand;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Stats\IndexStats;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Stats\IndexStatsIndex;
+use Pimcore\Bundle\GenericDataIndexBundle\Repository\IndexQueueRepository;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\IndexStatsServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\TimeServiceInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class StatusCommandTest extends Unit
+{
+    /**
+     * The status overview lists each index with its document count and reports the queue depth.
+     */
+    public function testRendersIndicesAndQueueDepth(): void
+    {
+        $stats = new IndexStats(7, [
+            new IndexStatsIndex('dataobject_car-even', 1234, 512.0),
+            new IndexStatsIndex('asset-even', 42, 8.5),
+        ]);
+
+        $commandTester = new CommandTester($this->createCommand($stats));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+        $this->assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        $this->assertStringContainsString('dataobject_car-even', $display);
+        $this->assertStringContainsString('1234', $display);
+        $this->assertStringContainsString('asset-even', $display);
+        // queue depth from the stats
+        $this->assertStringContainsString('7', $display);
+        // empty (makeEmpty) queue repository reports nothing pending dispatch
+        $this->assertStringContainsString('no', $display);
+    }
+
+    /**
+     * An index that exists in BOTH the -even and -odd version at once is the fingerprint of an
+     * interrupted reindex and must be surfaced as a warning.
+     */
+    public function testWarnsOnInterruptedReindexLeftover(): void
+    {
+        $stats = new IndexStats(0, [
+            new IndexStatsIndex('dataobject_car-even', 10, 1.0),
+            new IndexStatsIndex('dataobject_car-odd', 10, 1.0),
+            new IndexStatsIndex('asset-even', 5, 1.0),
+        ]);
+
+        $commandTester = new CommandTester($this->createCommand($stats));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+        $this->assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        $this->assertStringContainsString('interrupted reindex', $display);
+        $this->assertStringContainsString('dataobject_car', $display);
+        // the healthy single-version index must NOT be flagged as a leftover
+        $this->assertStringNotContainsString("\n  asset\n", $display);
+    }
+
+    /**
+     * With no indices at all the command hints at building the index rather than printing an empty
+     * table, and still exits cleanly (read-only diagnostic).
+     */
+    public function testWarnsWhenNoIndicesExist(): void
+    {
+        $commandTester = new CommandTester($this->createCommand(new IndexStats(0, [])));
+        $commandTester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        $this->assertStringContainsString('No indices found', $commandTester->getDisplay());
+    }
+
+    private function createCommand(IndexStats $stats): StatusCommand
+    {
+        $statsService = $this->makeEmpty(IndexStatsServiceInterface::class, [
+            'getStats' => $stats,
+        ]);
+
+        return new StatusCommand($statsService, $this->getEmptyQueueRepository());
+    }
+
+    /**
+     * A real (final) repository wired with empty collaborators: every query resolves to nothing,
+     * so dispatchableItemExists() deterministically returns false without a database.
+     */
+    private function getEmptyQueueRepository(): IndexQueueRepository
+    {
+        return new IndexQueueRepository(
+            $this->makeEmpty(EntityManagerInterface::class),
+            $this->makeEmpty(TimeServiceInterface::class),
+            $this->makeEmpty(Connection::class),
+            $this->makeEmpty(DenormalizerInterface::class)
+        );
+    }
+}


### PR DESCRIPTION
## Why

When a Generic Data Index problem surfaces in the field (a class not reindexed, a queue that silently stops, a value that doesn't match), we currently have very little to go on. This PR adds traceability so future GDI errors are reproducible and identifiable — **without any BC break**, so it can ship in a bugfix release.

## What

Six focused, additive commits:

1. **`update:index` exits non-zero when a section fails.** Previously a failing mapping/asset/class update was logged but the command still returned `0`, so deployment pipelines saw a false success on a broken index. It now attempts *all* sections (and still dispatches the queue), then returns a non-zero exit code if any failed. `writeSectionError()` preserves the exception class and its cause chain instead of a bare message.
2. **Dedicated `pimcore_generic_data_index` Monolog channel.** GDI logs can now be filtered, raised to debug, or routed separately. Additive — the channel is still handled by the application's existing handlers.
3. **Structured log context + original exception** on the failure paths (index checksum read, queue enqueue, dispatch handler) instead of message-only logs.
4. **Dispatch-id correlation across the queue lifecycle.** A claimed batch's dispatch id is now logged at dispatch and at processing, so a whole batch's fate can be traced with a single grep.
5. **New read-only `generic-data-index:status` command.** Prints queue depth (and whether items are pending dispatch), every live index with its document count and size, and warns on any index present in both the `-even` and `-odd` version at once (the fingerprint of an interrupted reindex).
6. **Logs the mapping-checksum reindex decision per class** (skip vs reindex, with stored vs current checksum), so needless full reindexes — and checksum over-triggering — become diagnosable.

## ⚠️ Release note — behavior change (commit 1)

`generic-data-index:update:index` now returns a **non-zero exit code** when one or more update sections fail. A pipeline that previously treated the command as successful on a partial failure will now correctly see a failure. This is a bugfix (the old behavior hid broken indices), but it is an observable change in exit status and should be mentioned in the changelog.

No other behavior changes. All additions are logging, a new read-only command, and the exit-code correction.

## Testing

- Full Codeception suite green locally (Docker harness, cold container cache): **465 tests, 1851 assertions, OK**.
- PHPStan clean; php-cs-fixer clean.
- New unit tests: `IndexUpdateCommandTest` (exit-code + cause preservation + queue-still-dispatched) and `StatusCommandTest` (indices/queue rendering, interrupted-reindex warning, empty-index hint).

## Propagation

After merge: forward-merge `2.5 → 2026.1 → 2026.2 → 2026.x`. No ee-LTS line (the bundle has none).