### PR TITLE
Fix: drop redundant array_values() in generic-data-index:status

### DIFF
--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -111,6 +111,8 @@ final class StatusCommand extends AbstractCommand
             }
         }
 
-        return array_values(array_keys(array_intersect_key($seenEven, $seenOdd)));
+        // array_keys() already returns a 0-indexed list, so no array_values() wrapper is needed
+        // (newer PHPStan flags the redundant call).
+        return array_keys(array_intersect_key($seenEven, $seenOdd));
     }
 }


### PR DESCRIPTION
## Why

The `generic-data-index:status` command (added in #494) has a redundant `array_values()` call:

```php
return array_values(array_keys(array_intersect_key($seenEven, $seenOdd)));
```

`array_keys()` already returns a 0-indexed `list<string>`, so the `array_values()` wrapper is a no-op. 2.5's PHPStan doesn't flag it, but the **PHP 8.5 / 2026.1+** PHPStan run does (`Parameter #1 $array (list<string>) of array_values is already a list, call has no effect.`), which turned the static-analysis leg red when #494 was forward-merged to `2026.1`.

## What

Remove the redundant `array_values()`. Behaviour is identical — `StatusCommandTest::testWarnsOnInterruptedReindexLeftover` already covers `detectBlueGreenLeftovers()`.

Lands on `2.5` (where the code originated) so it stays identical across all lines; forward-merges up to `2026.1 → 2026.2 → 2026.x` with the #494 traceability work.